### PR TITLE
Expose toolchain dict directly in common attributes

### DIFF
--- a/kotlin/BUILD
+++ b/kotlin/BUILD
@@ -14,7 +14,6 @@
 package(default_visibility = ["//visibility:public"])
 
 load("//kotlin:toolchains.bzl", "define_kt_toolchain")
-load("//kotlin/internal:bootstrap.bzl", "kt_toolchain_ide_info")
 
 toolchain_type(
     name = "kt_toolchain_type",
@@ -22,7 +21,5 @@ toolchain_type(
 )
 
 define_kt_toolchain(name = "default_toolchain")
-
-kt_toolchain_ide_info(name="kt_toolchain_ide_info")
 
 exports_files(["toolchains.bzl", "kotlin.bzl"], visibility=["//docs:__subpackages__"])

--- a/kotlin/internal/bootstrap.bzl
+++ b/kotlin/internal/bootstrap.bzl
@@ -33,28 +33,6 @@ kotlin_stdlib = rule(
 
 """Import Kotlin libraries that are part of the compiler release."""
 
-def _kt_toolchain_ide_info_impl(ctx):
-    tc=ctx.toolchains[kt.defs.TOOLCHAIN_TYPE]
-    info = struct(
-        label = tc.label,
-        common = struct(
-            language_version = tc.language_version,
-            api_version = tc.api_version,
-            coroutines = tc.coroutines
-        ),
-        jvm = struct(
-            jvm_target = tc.jvm_target,
-        )
-    )
-    ctx.actions.write(ctx.outputs.ide_info, info.to_json())
-    return [DefaultInfo(files=depset([ctx.outputs.ide_info]))]
-
-kt_toolchain_ide_info = rule(
-    outputs = {"ide_info": "kt_toolchain_ide_info.json"},
-    toolchains = [kt.defs.TOOLCHAIN_TYPE],
-    implementation = _kt_toolchain_ide_info_impl,
-)
-
 def github_archive(name, repo, commit, build_file_content = None):
     if build_file_content:
         native.new_http_archive(

--- a/kotlin/kotlin.bzl
+++ b/kotlin/kotlin.bzl
@@ -168,10 +168,8 @@ _implicit_deps = {
         Label("@" + KT_COMPILER_REPO + "//:stdlib-jdk7"),
         Label("@" + KT_COMPILER_REPO + "//:stdlib-jdk8"),
     ]),
-    "_kotlin_toolchain": attr.label_list(
-        default = [
-            Label("@io_bazel_rules_kotlin//kotlin:kt_toolchain_ide_info"),
-        ],
+    "_toolchain": attr.label(
+        default = Label("@io_bazel_rules_kotlin//kotlin:default_toolchain_impl"),
         allow_files = False,
     ),
     "_kotlin_reflect": attr.label(

--- a/kotlin/toolchains.bzl
+++ b/kotlin/toolchains.bzl
@@ -89,7 +89,7 @@ def _kotlin_toolchain_impl(ctx):
     )
     return struct(providers=[toolchain])
 
-kt_toolchain = rule(
+kt_jvm_toolchain = rule(
     attrs = _kt_jvm_attrs,
     implementation = _kotlin_toolchain_impl,
 )
@@ -105,7 +105,7 @@ Args:
 def define_kt_toolchain(name, language_version=None, api_version=None, jvm_target=None, coroutines=None):
     """Define a Kotlin JVM Toolchain, the name is used in the `toolchain` rule so can be used to register the toolchain in the WORKSPACE file."""
     impl_name = name + "_impl"
-    kt_toolchain(
+    kt_jvm_toolchain(
         name = impl_name,
         language_version = language_version,
         api_version = api_version,

--- a/kotlin/toolchains.bzl
+++ b/kotlin/toolchains.bzl
@@ -45,14 +45,14 @@ register_toolchains("//:custom_toolchain")
 
 # The toolchain rules are not made private, at least the jvm ones so that they may be introspected in Intelij.
 _common_attrs = {
-    "language_version": attr.string(
+    "kotlin_language_version": attr.string(
         default = "1.2",
         values = [
             "1.1",
             "1.2",
         ],
     ),
-    "api_version": attr.string(
+    "kotlin_api_version": attr.string(
         default = "1.2",
         values = [
             "1.1",
@@ -82,8 +82,8 @@ _kt_jvm_attrs = dict(_common_attrs.items() + {
 def _kotlin_toolchain_impl(ctx):
     toolchain = platform_common.ToolchainInfo(
         label = _utils.restore_label(ctx.label),
-        language_version = ctx.attr.language_version,
-        api_version = ctx.attr.api_version,
+        kotlin_language_version = ctx.attr.kotlin_language_version,
+        kotlin_api_version = ctx.attr.kotlin_api_version,
         jvm_target = ctx.attr.jvm_target,
         coroutines = ctx.attr.coroutines
     )
@@ -96,7 +96,7 @@ kt_jvm_toolchain = rule(
 
 """The kotlin jvm toolchain
 Args:
-  language_version: the -languag_version flag [see](https://kotlinlang.org/docs/reference/compatibility.html).
+  language_version: the -language_version flag [see](https://kotlinlang.org/docs/reference/compatibility.html).
   api_version: the -api_version flag [see](https://kotlinlang.org/docs/reference/compatibility.html).
   jvm_target: the -jvm_target flag.
   coroutines: the -Xcoroutines flag, enabled by default as it's considered production ready 1.2.0 onward.
@@ -107,8 +107,8 @@ def define_kt_toolchain(name, language_version=None, api_version=None, jvm_targe
     impl_name = name + "_impl"
     kt_jvm_toolchain(
         name = impl_name,
-        language_version = language_version,
-        api_version = api_version,
+        kotlin_language_version = language_version,
+        kotlin_api_version = api_version,
         jvm_target = jvm_target,
         coroutines = coroutines,
         visibility = ["//visibility:public"]


### PR DESCRIPTION
Renames attributes for consistency with the internal rules, and removes toolchain ide info in favor of the platform_common.ToolchainInfo dict.

The renames are entirely optional -- happy to revert them. I'm assuming they're not yet referenced anywhere, and will only be used by the IntelliJ plugin in the short term.

If this change is OK, the next step would be exposing the standard library targets directly in the toolchain dict.