### PR TITLE
fix bug in builder command object -- regular sources being merged into generated sources.

### DIFF
--- a/kotlin/builder/src/io/bazel/kotlin/builder/BuildCommandBuilder.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/builder/BuildCommandBuilder.kt
@@ -146,8 +146,8 @@ private class DefaultBuildCommandBuilder @Inject constructor(
     override fun withSources(command: BuilderCommand, sources: Iterator<String>): BuilderCommand =
         command.updateBuilder { builder ->
             sources.partitionSources(
-                { builder.inputsBuilder.addGeneratedKotlinSources(it) },
-                { builder.inputsBuilder.addGeneratedJavaSources(it) })
+                { builder.inputsBuilder.addKotlinSources(it) },
+                { builder.inputsBuilder.addJavaSources(it) })
         }
 
 


### PR DESCRIPTION
withSource method was extending the builder command with generated sources instead of regular sources.