### PR TITLE
[wip] fix windows issues 

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -9,6 +9,6 @@ platforms:
   macos:
     test_targets:
     - "//:all_tests"
-   windows:
+  windows:
     test_targets:
     - "//:all_tests"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -9,3 +9,6 @@ platforms:
   macos:
     test_targets:
     - "//:all_tests"
+   windows:
+    test_targets:
+    - "//:all_tests"

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 build --strategy=KotlinCompile=worker
 build --test_output=errors
 build --verbose_failures
+build --sandbox_debug
 

--- a/kotlin/builder/BUILD
+++ b/kotlin/builder/BUILD
@@ -120,5 +120,8 @@ java_test(
     size = "small",
     srcs = glob(["unittests/**/*.java"]),
     test_class = "io.bazel.kotlin.builder.mode.jvm.utils.JdepsParserTest",
-    deps = [":builder_for_tests"],
+    deps = [
+        ":builder_for_tests",
+        "//third_party/jvm/com/google/truth"
+    ],
 )

--- a/kotlin/builder/src/io/bazel/kotlin/builder/BuildCommandBuilder.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/builder/BuildCommandBuilder.kt
@@ -23,6 +23,7 @@ import io.bazel.kotlin.builder.utils.ArgMap
 import io.bazel.kotlin.builder.utils.DefaultKotlinCompilerPluginArgsEncoder
 import io.bazel.kotlin.model.KotlinModel
 import io.bazel.kotlin.model.KotlinModel.BuilderCommand
+import java.io.File
 
 
 @ImplementedBy(DefaultBuildCommandBuilder::class)
@@ -107,8 +108,7 @@ private class DefaultBuildCommandBuilder @Inject constructor(
                     addAllSourceJars(it)
                 }
 
-
-                joinedClasspath = classpathList.joinToString(":")
+                joinedClasspath = classpathList.joinToString(File.pathSeparator)
             }
 
             with(root.infoBuilder) {

--- a/kotlin/builder/src/io/bazel/kotlin/builder/KotlinToolchain.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/builder/KotlinToolchain.kt
@@ -18,6 +18,7 @@ package io.bazel.kotlin.builder
 import com.google.common.collect.ImmutableSet
 import com.google.inject.*
 import com.google.inject.util.Modules
+import io.bazel.kotlin.builder.utils.BazelRunFiles
 import io.bazel.kotlin.builder.utils.resolveVerified
 import org.jetbrains.kotlin.preloading.ClassPreloadingUtils
 import org.jetbrains.kotlin.preloading.Preloader
@@ -42,13 +43,12 @@ class KotlinToolchain private constructor(
         internal val NO_ARGS = arrayOf<Any>()
 
         private val isJdk9OrNewer = !System.getProperty("java.version").startsWith("1.")
-        private val javaRunfiles get() = Paths.get(System.getenv("JAVA_RUNFILES"))
 
         private fun createClassLoader(javaHome: Path, kotlinHome: Path): ClassLoader {
             val preloadJars = mutableListOf<File>().also {
                 it += kotlinHome.resolveVerified("lib", "kotlin-compiler.jar")
-                it +=  javaRunfiles.resolveVerified("io_bazel_rules_kotlin", "kotlin", "builder", "compiler_lib.jar")
-                if(!isJdk9OrNewer) {
+                it += BazelRunFiles.resolveVerified("io_bazel_rules_kotlin", "kotlin", "builder", "compiler_lib.jar")
+                if (!isJdk9OrNewer) {
                     it += javaHome.resolveVerified("lib", "tools.jar")
                 }
             }

--- a/kotlin/builder/src/io/bazel/kotlin/builder/KotlinToolchainModule.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/builder/KotlinToolchainModule.kt
@@ -18,6 +18,7 @@ package io.bazel.kotlin.builder
 import com.google.inject.AbstractModule
 import com.google.inject.Provides
 import io.bazel.kotlin.builder.KotlinToolchain.Companion.NO_ARGS
+import io.bazel.kotlin.builder.utils.BazelRunFiles
 import io.bazel.kotlin.builder.utils.executeAndAwait
 import io.bazel.kotlin.builder.utils.resolveVerified
 import io.bazel.kotlin.builder.utils.resolveVerifiedToAbsoluteString
@@ -30,7 +31,8 @@ internal object KotlinToolchainModule : AbstractModule() {
     fun jarToolInvoker(toolchain: KotlinToolchain): KotlinToolchain.JarToolInvoker =
         object : KotlinToolchain.JarToolInvoker {
             override fun invoke(args: List<String>, directory: File?) {
-                val jarTool = toolchain.javaHome.resolveVerifiedToAbsoluteString("bin", "jar")
+                val jarTool = toolchain.javaHome.resolveVerifiedToAbsoluteString(
+                    "bin", if (BazelRunFiles.isWindows) "jar.exe" else "jar")
                 val command = mutableListOf(jarTool).also { it.addAll(args) }
                 executeAndAwait(10, directory, command).takeIf { it != 0 }?.also {
                     throw CompilationStatusException("error running jar command ${command.joinToString(" ")}", it)

--- a/kotlin/builder/src/io/bazel/kotlin/builder/mode/jvm/actions/JavaCompiler.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/builder/mode/jvm/actions/JavaCompiler.kt
@@ -21,6 +21,7 @@ import io.bazel.kotlin.builder.CompilationStatusException
 import io.bazel.kotlin.builder.KotlinToolchain
 import io.bazel.kotlin.builder.utils.addAll
 import io.bazel.kotlin.model.KotlinModel.BuilderCommand
+import java.io.File
 
 @ImplementedBy(DefaultJavaCompiler::class)
 interface JavaCompiler {
@@ -35,7 +36,7 @@ private class DefaultJavaCompiler @Inject constructor(
         val outputs = command.outputs
         if (inputs.javaSourcesList.isNotEmpty() || inputs.generatedJavaSourcesList.isNotEmpty()) {
             val args = mutableListOf(
-                "-cp", "${outputs.classDirectory}/:${outputs.tempDirectory}/:${inputs.joinedClasspath}",
+                "-cp", "${outputs.classDirectory}${File.separatorChar}${File.pathSeparator}${outputs.tempDirectory}${File.separatorChar}${File.pathSeparatorChar}${inputs.joinedClasspath}",
                 "-d", outputs.classDirectory
             ).let {
                 it.addAll(

--- a/kotlin/builder/src/io/bazel/kotlin/builder/mode/jvm/actions/KotlinCompiler.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/builder/mode/jvm/actions/KotlinCompiler.kt
@@ -23,6 +23,7 @@ import io.bazel.kotlin.builder.utils.addAll
 import io.bazel.kotlin.model.KotlinModel
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.File
 import java.io.PrintStream
 
 @ImplementedBy(DefaultKotlinCompiler::class)
@@ -66,7 +67,7 @@ private class DefaultKotlinCompiler @Inject constructor(
             "-language-version", command.info.toolchainInfo.common.languageVersion,
             "-jvm-target", command.info.toolchainInfo.jvm.jvmTarget,
             // https://github.com/bazelbuild/rules_kotlin/issues/69: remove once jetbrains adds a flag for it.
-            "--friend-paths", command.info.friendPathsList.joinToString(":")
+            "--friend-paths", command.info.friendPathsList.joinToString(File.pathSeparator)
         )
 
         args

--- a/kotlin/builder/src/io/bazel/kotlin/builder/mode/jvm/utils/JdepsParser.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/builder/mode/jvm/utils/JdepsParser.kt
@@ -22,7 +22,10 @@ import java.nio.file.Paths
 import java.util.*
 import java.util.function.Predicate
 
-class JdepsParser private constructor(private val filename: String, private val isImplicit: Predicate<String>) {
+class JdepsParser private constructor(
+    private val filename: String,
+    private val isImplicit: Predicate<String>
+) {
     private val packageSuffix: String = " ($filename)"
 
     private val depMap = HashMap<String, Deps.Dependency.Builder>()

--- a/kotlin/builder/src/io/bazel/kotlin/builder/mode/jvm/utils/JdepsParser.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/builder/mode/jvm/utils/JdepsParser.kt
@@ -16,11 +16,11 @@
 package io.bazel.kotlin.builder.mode.jvm.utils
 
 import com.google.devtools.build.lib.view.proto.Deps
+import java.io.File
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.*
 import java.util.function.Predicate
-import java.util.stream.Stream
 
 class JdepsParser private constructor(private val filename: String, private val isImplicit: Predicate<String>) {
     private val packageSuffix: String = " ($filename)"
@@ -120,7 +120,7 @@ class JdepsParser private constructor(private val filename: String, private val 
         ): Deps.Dependencies {
             val filename = Paths.get(classJar).fileName.toString()
             val jdepsParser = JdepsParser(filename, isImplicit)
-            Stream.of(*classPath.split(":".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray())
+            classPath.split(File.pathSeparator)
                 .forEach { x -> jdepsParser.consumeJarLine(x, Deps.Dependency.Kind.UNUSED) }
             jdepLines.forEach { jdepsParser.processLine(it) }
 

--- a/kotlin/builder/src/io/bazel/kotlin/builder/utils/BazelUtils.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/builder/utils/BazelUtils.kt
@@ -29,7 +29,7 @@ object BazelRunFiles {
      */
     private val manifestFile: String? =
         if (System.getProperty("os.name").toLowerCase().indexOf("win") >= 0) {
-            System.getenv("RUNFILES_MANIFEST_FILE")
+            checkNotNull(System.getenv("RUNFILES_MANIFEST_FILE"))
         } else null
 
     private val javaRunFiles = Paths.get(System.getenv("JAVA_RUNFILES"))
@@ -57,17 +57,17 @@ object BazelRunFiles {
      * Resolve a run file on windows or *nix.
      */
     fun resolveVerified(vararg path: String): File {
-        return if (manifestFile != null) {
+        return manifestFile?.let { mf ->
             path.joinToString("/").let { rfPath ->
                 File(
                     checkNotNull(runfiles[rfPath]) {
-                        "windows runfile manifest ${manifestFile} did not contain path $rfPath"
+                        "windows runfile manifest ${mf} did not contain path $rfPath"
                     }
                 )
             }.also {
                 check(it.exists()) { "runfile file $it did not exist" }
             }
-        } else javaRunFiles.resolveVerified(*path)
+        } ?: javaRunFiles.resolveVerified(*path)
     }
 }
 

--- a/kotlin/builder/src/io/bazel/kotlin/builder/utils/BazelUtils.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/builder/utils/BazelUtils.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.bazel.kotlin.builder.utils
+
+import com.google.common.collect.ImmutableMap
+import java.io.File
+import java.io.FileInputStream
+import java.nio.charset.Charset
+import java.nio.file.Paths
+
+
+/** Utility class for getting runfiles in tests on Windows.  */
+object BazelRunFiles {
+    /**
+     * Populated on windows. The RUNFILES_MANIFEST_FILE is set on platforms other then windows but it can be empty,]
+     */
+    private val manifestFile: String? =
+        if (System.getProperty("os.name").toLowerCase().indexOf("win") >= 0) {
+            System.getenv("RUNFILES_MANIFEST_FILE")
+        } else null
+
+    private val javaRunFiles = Paths.get(System.getenv("JAVA_RUNFILES"))
+
+    private val runfiles by lazy {
+        with(ImmutableMap.builder<String, String>()) {
+            FileInputStream(manifestFile)
+                .bufferedReader(Charset.forName("UTF-8"))
+                .lines()
+                .forEach { it ->
+                    val line = it.trim { it <= ' ' }
+                    if (!line.isEmpty()) {
+                        // TODO(bazel-team): This is buggy when the path contains spaces, we should fix the manifest format.
+                        line.split(" ").also {
+                            check(it.size == 2) { "RunFiles manifest entry contains more than one space" }
+                            put(it[0], it[1])
+                        }
+                    }
+                }
+            build()
+        }
+    }
+
+    /**
+     * Resolve a run file on windows or *nix.
+     */
+    fun resolveVerified(vararg path: String): File {
+        return if (manifestFile != null) {
+            path.joinToString("/").let { rfPath ->
+                File(
+                    checkNotNull(runfiles[rfPath]) {
+                        "windows runfile manifest ${manifestFile} did not contain path $rfPath"
+                    }
+                )
+            }.also {
+                check(it.exists()) { "runfile file $it did not exist" }
+            }
+        } else javaRunFiles.resolveVerified(*path)
+    }
+}
+

--- a/kotlin/builder/src/io/bazel/kotlin/builder/utils/BazelUtils.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/builder/utils/BazelUtils.kt
@@ -24,11 +24,12 @@ import java.nio.file.Paths
 
 /** Utility class for getting runfiles in tests on Windows.  */
 object BazelRunFiles {
+    val isWindows = System.getProperty("os.name").toLowerCase().indexOf("win") >= 0
     /**
      * Populated on windows. The RUNFILES_MANIFEST_FILE is set on platforms other then windows but it can be empty,]
      */
     private val manifestFile: String? =
-        if (System.getProperty("os.name").toLowerCase().indexOf("win") >= 0) {
+        if (isWindows) {
             checkNotNull(System.getenv("RUNFILES_MANIFEST_FILE"))
         } else null
 

--- a/kotlin/builder/src/io/bazel/kotlin/compiler/BazelK2JVMCompiler.kt
+++ b/kotlin/builder/src/io/bazel/kotlin/compiler/BazelK2JVMCompiler.kt
@@ -21,6 +21,7 @@ import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 import org.jetbrains.kotlin.config.Services
+import java.io.File
 
 @Suppress("unused")
 class BazelK2JVMCompiler(private val delegate: K2JVMCompiler = K2JVMCompiler()) {
@@ -34,7 +35,7 @@ class BazelK2JVMCompiler(private val delegate: K2JVMCompiler = K2JVMCompiler()) 
             // https://github.com/bazelbuild/rules_kotlin/issues/69: remove once jetbrains adds a flag for it.
                 args[i].startsWith("--friend-paths") -> {
                     i++
-                    friendsPaths = args[i].split(":").toTypedArray()
+                    friendsPaths = args[i].split(File.pathSeparator).toTypedArray()
                 }
                 else -> tally += args[i]
             }

--- a/kotlin/builder/unittests/io/bazel/kotlin/workers/mode/jvm/utils/JdepsParserTest.java
+++ b/kotlin/builder/unittests/io/bazel/kotlin/workers/mode/jvm/utils/JdepsParserTest.java
@@ -15,6 +15,8 @@
  */
 package io.bazel.kotlin.builder.mode.jvm.utils;
 
+import com.google.common.collect.ImmutableSet;
+import com.google.common.truth.Truth;
 import com.google.devtools.build.lib.view.proto.Deps;
 import org.junit.Assert;
 import org.junit.Test;
@@ -74,8 +76,8 @@ public class JdepsParserTest {
           + "   com.axsy.testing.alt.sub                           -> java.lang                                          java.base\n"
           + "   com.axsy.testing.alt.sub                           -> kotlin                                             kotlin-stdlib.jar\n";
 
-  private static final List<String> CLASSPATH =
-      Arrays.asList(
+  private static final ImmutableSet<String> CLASSPATH =
+      ImmutableSet.of(
           "bazel-bin/cloud/qa/integrationtests/pkg/extensions/postgres/unused.jar",
           "bazel-server-cloud/external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk8.jar",
           "bazel-server-cloud/external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk7.jar",
@@ -115,6 +117,13 @@ public class JdepsParserTest {
     Assert.assertEquals(LABEL, result.getRuleLabel());
 
     Assert.assertEquals(7, result.getDependencyCount());
+    Truth.assertThat(
+            result
+                .getDependencyList()
+                .stream()
+                .map(Deps.Dependency::getPath)
+                .collect(Collectors.toSet()))
+        .containsExactlyElementsIn(CLASSPATH);
     Assert.assertEquals(1, depKinds(result, Deps.Dependency.Kind.UNUSED).size());
     Assert.assertEquals(3, depKinds(result, Deps.Dependency.Kind.IMPLICIT).size());
     Assert.assertEquals(3, depKinds(result, Deps.Dependency.Kind.EXPLICIT).size());

--- a/kotlin/builder/unittests/io/bazel/kotlin/workers/mode/jvm/utils/JdepsParserTest.java
+++ b/kotlin/builder/unittests/io/bazel/kotlin/workers/mode/jvm/utils/JdepsParserTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.Arrays;
@@ -108,7 +109,7 @@ public class JdepsParserTest {
         JdepsParser.Companion.parse(
             LABEL,
             CLASS_JAR,
-            CLASSPATH.stream().collect(Collectors.joining(":")),
+            CLASSPATH.stream().collect(Collectors.joining(File.pathSeparator)),
             Arrays.asList(fixture.split("\n")),
             IS_KOTLIN_IMPLICIT);
     Assert.assertEquals(LABEL, result.getRuleLabel());

--- a/kotlin/internal/utils.bzl
+++ b/kotlin/internal/utils.bzl
@@ -184,7 +184,7 @@ def _write_launcher_action(ctx, rjars, main_class, jvm_flags, args="", wrapper_p
         jvm_flags: The flags that should be passed to the jvm.
         args: Args that should be passed to the Binary.
     """
-    classpath = ":".join(["${RUNPATH}%s" % (j.short_path) for j in rjars.to_list()])
+    classpath = ctx.configuration.host_path_separator.join(["${RUNPATH}%s" % (j.short_path) for j in rjars.to_list()])
     jvm_flags = " ".join([ctx.expand_location(f, ctx.attr.data) for f in jvm_flags])
     template = ctx.attr._java_stub_template.files.to_list()[0]
 


### PR DESCRIPTION
I don’t have a windows machine (vbox is painfull to work with) if anyone wants to work on this feel free.

Still TODO

- [ ]  consider switching out the runfile abstraction I put in the builder for the one provided by bazel.
- [ ] fix the cp generation in `java_stub_template` used by `kt_jvm_test` and `kt_jvm_ binary`.  Current the cp isn’t being constructed from the runfiles manifest on windows.
- [ ] update the tests for windows.