### PR TITLE
Move implicits to toolchain and some other stuff

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -17,6 +17,7 @@ directories:
   .
 
 targets:
+  -//docs/...
   //kotlin/builder:for_ide
   //:all_tests
   //examples/...

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [Skydoc documentation](https://bazelbuild.github.io/rules_kotlin)
 
 # Announcements
+* <b>Jun 29, 2018.</b> The commits from this data forward are compatible with bazel `>=0.14`. JDK9 host issues were 
+  fixed support was added as well as fixing other misc deprecations. I recommend skipping `0.15.0` if you are on a mac.  
 * <b>May 25, 2018.</b> Test "friend" support. A single friend dep can be provided to `kt_jvm_test` which allows the test
   to access internal members of the module under test.
 * <b>February 15, 2018.</b> Toolchains for the JVM rules. Currently this allow tweaking: 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [Skydoc documentation](https://bazelbuild.github.io/rules_kotlin)
 
 # Announcements
-* <b>Jun 29, 2018.</b> The commits from this data forward are compatible with bazel `>=0.14`. JDK9 host issues were 
-  fixed support was added as well as fixing other misc deprecations. I recommend skipping `0.15.0` if you are on a mac.  
+* <b>Jun 29, 2018.</b> The commits from this date forward are compatible with bazel `>=0.14`. JDK9 host issues were 
+  fixed as well some other deprecations. I recommend skipping `0.15.0` if you   are on a Mac. 
 * <b>May 25, 2018.</b> Test "friend" support. A single friend dep can be provided to `kt_jvm_test` which allows the test
   to access internal members of the module under test.
 * <b>February 15, 2018.</b> Toolchains for the JVM rules. Currently this allow tweaking: 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -14,11 +14,11 @@
 workspace(name="io_bazel_rules_kotlin")
 load("//kotlin/internal:bootstrap.bzl",github_archive="github_archive")
 
-github_archive(
-    name = "com_google_protobuf",
-    repo = "google/protobuf",
-    commit = "106ffc04be1abf3ff3399f54ccf149815b287dd9",
-)
+#github_archive(
+#    name = "com_google_protobuf",
+#    repo = "google/protobuf",
+#    commit = "106ffc04be1abf3ff3399f54ccf149815b287dd9",
+#)
 
 github_archive(
     name = "build_bazel_rules_nodejs",

--- a/kotlin/builder/BUILD
+++ b/kotlin/builder/BUILD
@@ -23,7 +23,9 @@ _COMPILER_DEPS = [
 
 # Common depset for the builder.
 _COMMON_DEPS = [
-    "//kotlin/builder/proto",
+    "//kotlin/builder/proto:deps",
+    "//kotlin/builder/proto:kotlin_model",
+    "//kotlin/builder/proto:worker",
     "@com_github_jetbrains_kotlin//:preloader",
     "@io_bazel_rules_kotlin_com_google_protobuf_protobuf_java//jar",
     "@io_bazel_rules_kotlin_com_google_protobuf_protobuf_java_util//jar",

--- a/kotlin/builder/proto/BUILD
+++ b/kotlin/builder/proto/BUILD
@@ -12,45 +12,45 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-proto_library(
-    name = "kotlin_model_proto",
-    srcs = [":kotlin_model.proto"],
-    visibility=["//visibility:public"]
-)
-
-java_proto_library(
-    name = "kotlin_model_java_proto",
-    deps = [":kotlin_model_proto"]
-)
-
-_PROTO_LIBS=["deps", "worker_protocol"]
-
-[proto_library(
-    name="%s_proto" % lib,
-    srcs=["%s.proto" % lib]
-    ) for lib in _PROTO_LIBS]
-
-[java_proto_library(
-    name="%s_java_proto" % lib,
-    deps=["%s_proto" % lib],
-    ) for lib in _PROTO_LIBS]
+# commented out till 0.16 is released. We aren't  prebuilding the libraries at the moment so it's fine.
+#proto_library(
+#    name = "kotlin_model_proto",
+#    srcs = [":kotlin_model.proto"],
+#    visibility=["//visibility:public"]
+#)
+#
+#java_proto_library(
+#    name = "kotlin_model_java_proto",
+#    deps = [":kotlin_model_proto"]
+#)
+#
+#_PROTO_LIBS=["deps", "worker_protocol"]
+#
+#[proto_library(
+#    name="%s_proto" % lib,
+#    srcs=["%s.proto" % lib]
+#    ) for lib in _PROTO_LIBS]
+#
+#[java_proto_library(
+#    name="%s_java_proto" % lib,
+#    deps=["%s_proto" % lib],
+#    ) for lib in _PROTO_LIBS]
+#
 
 java_import(
-    name = "proto",
-    jars = [
-        "jars/libdeps_proto-speed.jar",
-        "jars/libworker_protocol_proto-speed.jar",
-        "jars/libkotlin_model_proto-speed.jar"
-    ],
+    name = "deps",
+    jars = ["jars/libdeps_proto-speed.jar"],
     visibility = ["//kotlin/builder:__subpackages__"]
 )
 
-filegroup(
-    name = "files",
-    srcs = [
-        "jars/libdeps_proto-speed.jar",
-        "jars/libworker_protocol_proto-speed.jar"
-    ],
+java_import(
+    name = "worker",
+    jars = ["jars/libworker_protocol_proto-speed.jar"],
+    visibility = ["//kotlin/builder:__subpackages__"]
+)
+
+java_import(
+    name = "kotlin_model",
+    jars = ["jars/libkotlin_model_proto-speed.jar"],
     visibility = ["//kotlin/builder:__subpackages__"]
 )

--- a/kotlin/kotlin.bzl
+++ b/kotlin/kotlin.bzl
@@ -119,51 +119,16 @@ load(
 )
 load("//third_party/jvm:workspace.bzl", _maven_dependencies="maven_dependencies")
 
-# _kt.defs.KT_COMPILER_REPO can't be used till skydoc is removed
-KT_COMPILER_REPO="com_github_jetbrains_kotlin"
-
-
 ########################################################################################################################
 # Rule Attributes
 ########################################################################################################################
 _implicit_deps = {
-    "_kotlin_compiler_classpath": attr.label_list(
-        allow_files = True,
-        default = [
-            Label("@" + KT_COMPILER_REPO + "//:compiler"),
-            Label("@" + KT_COMPILER_REPO + "//:reflect"),
-            Label("@" + KT_COMPILER_REPO + "//:script-runtime"),
-        ],
-    ),
-    "_kotlin_home": attr.label(
-        default = Label("@" + KT_COMPILER_REPO + "//:home"),
-        allow_files = True,
-        cfg = "host",
-    ),
-    "_kotlinw": attr.label(
-        default = Label("//kotlin/builder"),
-        executable = True,
-        cfg = "host",
-    ),
-    "_kotlin_runtime": attr.label(
-        single_file = True,
-        default = Label("@" + KT_COMPILER_REPO + "//:runtime"),
-    ),
-    "_kotlin_std": attr.label_list(default = [
-        Label("@" + KT_COMPILER_REPO + "//:stdlib"),
-        Label("@" + KT_COMPILER_REPO + "//:stdlib-jdk7"),
-        Label("@" + KT_COMPILER_REPO + "//:stdlib-jdk8"),
-    ]),
     "_kotlin_toolchain": attr.label_list(
         default = [
             Label("@io_bazel_rules_kotlin//kotlin:kt_toolchain_ide_info"),
         ],
+        cfg="host",
         allow_files = False,
-    ),
-    "_kotlin_reflect": attr.label(
-        single_file = True,
-        default =
-            Label("@" + KT_COMPILER_REPO + "//:reflect"),
     ),
     "_singlejar": attr.label(
         executable = True,
@@ -183,12 +148,10 @@ _implicit_deps = {
         default = Label("@bazel_tools//tools/jdk:java"),
         allow_files = True,
     ),
-    "_jdk": attr.label(
-        default = Label("@bazel_tools//tools/jdk"),
+    "_java_stub_template": attr.label(
         cfg = "host",
-        allow_files = True,
+        default = Label("@kt_java_stub_template//file"),
     ),
-    "_java_stub_template": attr.label(default = Label("@kt_java_stub_template//file")),
 }
 
 _common_attr = dict(_implicit_deps.items() + {

--- a/kotlin/toolchains.bzl
+++ b/kotlin/toolchains.bzl
@@ -43,8 +43,21 @@ register_toolchains("//:custom_toolchain")
 ```
 """
 
+_KT_COMPILER_REPO="com_github_jetbrains_kotlin"
+
 # The toolchain rules are not made private, at least the jvm ones so that they may be introspected in Intelij.
 _common_attrs = {
+    "kotlin_home": attr.label(
+        default = Label("@" + _KT_COMPILER_REPO + "//:home"),
+        allow_files = True,
+        cfg = "host"
+    ),
+    "kotlinbuilder": attr.label(
+        default = Label("//kotlin/builder"),
+        executable = True,
+        allow_files = True,
+        cfg = "host",
+    ),
     "language_version": attr.string(
         default = "1.2",
         values = [
@@ -70,6 +83,17 @@ _common_attrs = {
 }
 
 _kt_jvm_attrs = dict(_common_attrs.items() + {
+    "jvm_runtime": attr.label(
+        single_file = True,
+        default = Label("@" + _KT_COMPILER_REPO + "//:runtime"),
+    ),
+    "jvm_stdlibs": attr.label_list(
+        default = [
+            Label("@" + _KT_COMPILER_REPO + "//:stdlib"),
+            Label("@" + _KT_COMPILER_REPO + "//:stdlib-jdk7"),
+            Label("@" + _KT_COMPILER_REPO + "//:stdlib-jdk8"),
+        ]
+    ),
     "jvm_target": attr.string(
         default = "1.8",
         values = [
@@ -84,8 +108,16 @@ def _kotlin_toolchain_impl(ctx):
         label = _utils.restore_label(ctx.label),
         language_version = ctx.attr.language_version,
         api_version = ctx.attr.api_version,
+        coroutines = ctx.attr.coroutines,
+
         jvm_target = ctx.attr.jvm_target,
-        coroutines = ctx.attr.coroutines
+
+
+        kotlinbuilder = ctx.attr.kotlinbuilder,
+        kotlin_home = ctx.files.kotlin_home,
+
+        jvm_runtime = ctx.files.jvm_runtime,
+        jvm_stdlibs = ctx.files.jvm_stdlibs
     )
     return struct(providers=[toolchain])
 


### PR DESCRIPTION
* move implicits to kotlin toolchain, 
* tidy up srcs partitioning and fix bug,
* temporarily remove protobuf from the workspace till 0.16.. 