### PR TITLE
Basic Android support

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [Skydoc documentation](https://bazelbuild.github.io/rules_kotlin)
 
 # Announcements
+* <b>August 14, 2018.</b> Android support. No documentation but it's a simple integration. see 
+  `kotlin/internal/jvm/android.bzl`.
 * <b>Jun 29, 2018.</b> The commits from this date forward are compatible with bazel `>=0.14`. JDK9 host issues were 
   fixed as well some other deprecations. I recommend skipping `0.15.0` if you   are on a Mac. 
 * <b>May 25, 2018.</b> Test "friend" support. A single friend dep can be provided to `kt_jvm_test` which allows the test

--- a/kotlin/internal/jvm/BUILD
+++ b/kotlin/internal/jvm/BUILD
@@ -11,3 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+java_import(
+    name = "android_sdk",
+    jars = ["@bazel_tools//tools/android:android_jar"],
+    neverlink = 1,
+    visibility = ["//visibility:public"],
+)

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -37,6 +37,9 @@ def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
     return [base_name, kt_name]
 
 def kt_android_library(name, exports = [], visibility = None, **kwargs):
+    """Creates a Android sandwich library. `srcs`, `deps`, `plugins` are routed to `kt_jvm_library` the other android
+    related attributes are handled by the native `android_library` rule.
+    """
     native.android_library(
         name = name,
         exports = exports + _kt_android_artifact(name, **kwargs),

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -1,0 +1,44 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+load(
+    ":jvm.bzl",
+    _kt_jvm_library = "kt_jvm_library",
+)
+
+def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
+    """Delegates Android related build attributes to the native rules but uses the Kotlin builder to compile Java and
+    Kotlin srcs. Returns a sequence of labels that a wrapping macro should export."""
+    base_name = name + "_base"
+    kt_name = name + "_kt"
+
+    native.android_library(
+        name = base_name,
+        visibility = ["//visibility:private"],
+        **kwargs
+    )
+    _kt_jvm_library(
+        name = kt_name,
+        srcs = srcs,
+        deps = deps + ["@io_bazel_rules_kotlin//kotlin/internal/jvm:android_sdk", base_name],
+        plugins = plugins,
+        visibility = ["//visibility:private"],
+    )
+    return [base_name, kt_name]
+
+def kt_android_library(name, exports = [], visibility = None, **kwargs):
+    native.android_library(
+        name = name,
+        exports = exports + _kt_android_artifact(name, **kwargs),
+        visibility = visibility,
+    )

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -96,6 +96,10 @@ load(
     _kt_jvm_plugin_aspect = "kt_jvm_plugin_aspect",
 )
 load(
+    "//kotlin/internal:defs.bzl",
+    _KT_COMPILER_REPO = "KT_COMPILER_REPO",
+)
+load(
     "//kotlin/internal/jvm:impl.bzl",
     _kt_jvm_binary_impl = "kt_jvm_binary_impl",
     _kt_jvm_import_impl = "kt_jvm_import_impl",
@@ -125,6 +129,12 @@ _implicit_deps = {
     "_java_stub_template": attr.label(
         cfg = "host",
         default = Label("@kt_java_stub_template//file"),
+    ),
+    "_toolchain": attr.label(
+        doc = """The Kotlin JVM Runtime. it's only purpose is to enable the Android native rules to discover the Kotlin
+        runtime for dexing""",
+        default = Label("@" + _KT_COMPILER_REPO + "//:kotlin-runtime"),
+        cfg = "target",
     ),
 }
 

--- a/kotlin/kotlin.bzl
+++ b/kotlin/kotlin.bzl
@@ -20,3 +20,7 @@ load(
     "kt_jvm_library",
     "kt_jvm_test",
 )
+load(
+    "//kotlin/internal/jvm:android.bzl",
+    "kt_android_library",
+)


### PR DESCRIPTION
@jin Everything seems to be working. There is a single thin macro in `android.bzl`. Could you verify the macros are correct. 

Some notes / RFCs:

* This approach should work for mix java / kotlin compiles -- so a project can be gradually converted to Kotlin !
* AS 3.0.1 is working fine with the Kotlin. No new rules were added (might need to add a internal `kt_android_library` rule later on to pick up the android  toolchainWDYT ?). 
* I didn't look into the kotlin aidl compiler plugin. I don't think there is a need WDYT ? . 
* The example is not very nice.  It would be really useful to get a comprehensive idiomatic example. @jin could the android team contribute such a sample ?