### PR TITLE
Add exports to kt_jvm_import

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -19,6 +19,10 @@ load(
     "//kotlin/internal:defs.bzl",
     _KtJvmInfo = "KtJvmInfo",
 )
+load(
+    "//kotlin/internal/utils:utils.bzl",
+    _utils = "utils",
+)
 
 def _make_providers(ctx, providers, transitive_files = depset(order = "default")):
     return struct(
@@ -116,7 +120,7 @@ def kt_jvm_import_impl(ctx):
         source_jar = source_jars[0]
 
     kt_info = _KtJvmInfo(
-        module_name = "",
+        module_name = _utils.derive_module_name(ctx),
         outputs = struct(
             jars = artifacts,
         ),
@@ -130,6 +134,7 @@ def kt_jvm_import_impl(ctx):
                 compile_jar = jars[0],
                 source_jar = source_jar,
                 runtime_deps = ctx.attr.runtime_deps,
+                exports = [d[JavaInfo] for d in getattr(ctx.attr, "exports", [])],
                 neverlink = getattr(ctx.attr, "neverlink", False),
             ),
             kt_info,

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -339,6 +339,14 @@ kt_jvm_import = rule(
             mandatory = False,
             providers = [JavaInfo],
         ),
+        "exports": attr.label_list(
+            doc = """Exported libraries.
+
+            Deps listed here will be made available to other rules, as if the parents explicitly depended on
+            these deps. This is not true for regular (non-exported) deps.""",
+            default = [],
+            providers = [JavaInfo],
+        ),
         "neverlink": attr.bool(
             doc = """If true only use this library for compilation and not at runtime.""",
             default = False,


### PR DESCRIPTION
Adds an `exports` attribute to `kt_jvm_import`. For kotlin support in bazel-deps: https://github.com/johnynek/bazel-deps/pull/212

Example https://github.com/wcurrie/bazel-kt-test

Having `exports` allows `bazel-deps` to generate a `kt_jvm_import` rule for each external dependency (jar), avoiding ijar generation, but maintaining transitive dependencies via `exports`.

As a reminder, trying to run the kotlin compiler with ijars instead of full jars will fail on methods marked as inline.

I see `kt_jvm_import` was/is meant to be temporary (https://github.com/bazelbuild/rules_kotlin/issues/4#issuecomment-402570312).

Maybe ijar will support kotlin in someday soon (https://github.com/bazelbuild/bazel/commit/c1f6455d38399853ff9f34e3eb5e8ca26e590290):
> We have a Kotlin compiler plugin that will annotate inlined methods with @KeepForCompile and ijar can use this to include code that is a part of the library's compiletime interface into the stripped jar.

I couldn't find any description of the plugin or `@KeepForCompile`.

Is there any harm in merging this, even if `kt_jvm_import` will later be deleted?