### PR TITLE
Have the no-srcs android_library in android.bzl use exports= instead of deps=

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 **/bazel-*
 **/.project
+**/.ijwb
+**/.aswb

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -28,7 +28,7 @@ def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
     native.android_library(
         name = base_name,
         visibility = ["//visibility:private"],
-        deps = base_deps,
+        exports = base_deps,
         **kwargs
     )
     _kt_jvm_library(


### PR DESCRIPTION
Make the no-srcs android_library to use `exports=` instead of the now-deprecated usage of `deps=`

Addresses #152