### PR TITLE
Make sure testonly is plumbed through the android rules.

### DIFF
--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -36,6 +36,7 @@ def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
         srcs = srcs,
         deps = base_deps + [base_name],
         plugins = plugins,
+        testonly = kwargs.get("testonly", default=0),
         visibility = ["//visibility:private"],
     )
     return [base_name, kt_name]
@@ -48,4 +49,5 @@ def kt_android_library(name, exports = [], visibility = None, **kwargs):
         name = name,
         exports = exports + _kt_android_artifact(name, **kwargs),
         visibility = visibility,
+        testonly = kwargs.get("testonly", default=0),
     )


### PR DESCRIPTION
Android rules break if they depend on testonly, even if you set testonly=1, as the testonly setting isn't passed on to the kt_android_library's native android_library wrapper, nor the underlying pass-through target (that suffixes with "_base").  This adds testonly to both. 