### PR TITLE
 Pass transitive deps to kotlinc

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -158,7 +158,7 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
     # TODO extract and move this into common. Need to make it generic first.
     friends = getattr(ctx.attr, "friends", [])
     deps = [d[JavaInfo] for d in friends + ctx.attr.deps] + [toolchain.jvm_stdlibs]
-    compile_jars = java_common.merge(deps).compile_jars
+    compile_jars = java_common.merge(deps).transitive_compile_time_jars
 
     if len(friends) == 0:
         module_name = _utils.derive_module_name(ctx)

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -19,6 +19,10 @@ load(
     "//kotlin/internal:defs.bzl",
     _KtJvmInfo = "KtJvmInfo",
 )
+load(
+    "//kotlin/internal/utils:utils.bzl",
+    _utils = "utils",
+)
 
 def _make_providers(ctx, providers, transitive_files = depset(order = "default")):
     return struct(
@@ -116,7 +120,7 @@ def kt_jvm_import_impl(ctx):
         source_jar = source_jars[0]
 
     kt_info = _KtJvmInfo(
-        module_name = "",
+        module_name = _utils.derive_module_name(ctx),
         outputs = struct(
             jars = artifacts,
         ),
@@ -130,6 +134,7 @@ def kt_jvm_import_impl(ctx):
                 compile_jar = jars[0],
                 source_jar = source_jar,
                 runtime_deps = ctx.attr.runtime_deps,
+                exports = [d[JavaInfo] for d in getattr(ctx.attr, "exports", [])],
                 neverlink = getattr(ctx.attr, "neverlink", False),
             ),
             kt_info,

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -339,6 +339,14 @@ kt_jvm_import = rule(
             mandatory = False,
             providers = [JavaInfo],
         ),
+        "exports": attr.label_list(
+            doc = """Exported libraries.
+
+            Deps listed here will be made available to other rules, as if the parents explicitly depended on
+            these deps. This is not true for regular (non-exported) deps.""",
+            default = [],
+            providers = [JavaInfo],
+        ),
         "neverlink": attr.bool(
             doc = """If true only use this library for compilation and not at runtime.""",
             default = False,


### PR DESCRIPTION
When the java compiler is run by `java_binary` and `java_library` the compile classpath includes `exports` of `deps`: transitive dependencies. This currently doesn't happen with `kt_jvm_binary` or `kt_jvm_library`. This change makes the kotlin rules consistent (I believe/hope).

IIUC using `exports` in this way is not ideal. It's preferable to declare all compile `deps` explicitly. In practice having transitive dependencies is a valuable stepping stone for a large scale maven -> bazel migration.

Ideally this behaviour would be complemented by a `strict_java_deps` like flag? That's a much bigger job.