### PR TITLE
Set shebang correctly as initial line

### DIFF
--- a/scripts/bazel_from_source
+++ b/scripts/bazel_from_source
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,7 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#!/usr/bin/env bash
+
 # Note: Written on a mac please make it compatible with linux if needed.
 set -o errexit
 

--- a/scripts/gen_proto_jars
+++ b/scripts/gen_proto_jars
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#!/usr/bin/env bash
+
 # Note: Written on a mac please make it compatible with linux if needed.
-#!/usr/bin/env bash
 
 # The script precompiles the ptoto deps. If this isn't used the client workspaces would have a dependency on protoc.
 # If (when) Bazel distributes a host protoc this file can be removed.

--- a/scripts/reflow_skylark
+++ b/scripts/reflow_skylark
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#!/usr/bin/env bash
+
 # Note: Written on a mac please make it compatible with linux if needed.
-#!/usr/bin/env bash
 
 buildifier -showlog -mode=fix -v $(find src kotlin -type f \
     -iname "*.bzl" -or \

--- a/scripts/regen_deps
+++ b/scripts/regen_deps
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#!/usr/bin/env bash
+
 # Note: Written on a mac please make it compatible with linux if needed.
-#!/usr/bin/env bash
 
 set -e
 


### PR DESCRIPTION
Commit 24d69a6ffceb275e6 introduced some changes to headers of scripts, but failed to preserve the position of the shebang, which should be on the very first line.