### PR TITLE
Set default file modification date in jars to 2010-1-1

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/JarHelper.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/JarHelper.kt
@@ -80,7 +80,7 @@ open class JarHelper internal constructor (
     }
 
     /**
-     * Returns the time for a new Jar file entry in milliseconds since the epoch. Uses JarCreator.DEFAULT_TIMESTAMP]
+     * Returns the time for a new Jar file entry in milliseconds since the epoch. Uses [JarCreator.DEFAULT_TIMESTAMP]
      * for normalized entries, [System.currentTimeMillis] otherwise.
      *
      * @param filename The name of the file for which we are entering the time
@@ -236,12 +236,12 @@ open class JarHelper internal constructor (
         const val MANIFEST_NAME = JarFile.MANIFEST_NAME
         const val SERVICES_DIR = "META-INF/services/"
         internal val EMPTY_BYTEARRAY = ByteArray(0)
+
         /** Normalize timestamps.  */
-        val DEFAULT_TIMESTAMP = LocalDateTime.of(1980, 1, 1, 0, 0, 0)
+        val DEFAULT_TIMESTAMP = LocalDateTime.of(2010, 1, 1, 0, 0, 0)
             .atZone(ZoneId.systemDefault())
             .toInstant()
             .toEpochMilli()
-
         // These attributes are used by JavaBuilder, Turbine, and ijar.
         // They must all be kept in sync.
         val TARGET_LABEL = Attributes.Name("Target-Label")

--- a/src/test/kotlin/io/bazel/kotlin/KotlinAssertionTestCase.kt
+++ b/src/test/kotlin/io/bazel/kotlin/KotlinAssertionTestCase.kt
@@ -79,7 +79,7 @@ abstract class KotlinAssertionTestCase(root: String) : BasicAssertionTestCase() 
             val modifiedTimestamp = LocalDateTime.ofInstant(
                 Instant.ofEpochMilli(it.lastModifiedTime.toMillis()), ZoneId.systemDefault()
             )
-            assertTrue("normalized modification time stamps should have year 1980") { modifiedTimestamp.year == 1980 }
+            assertTrue("normalized modification time stamps should have year 2010") { modifiedTimestamp.year == 2010 }
         }
     }
 

--- a/src/test/kotlin/io/bazel/kotlin/KotlinNormalizationAssertionTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/KotlinNormalizationAssertionTest.kt
@@ -31,7 +31,7 @@ class KotlinNormalizationAssertionTest : KotlinAssertionTestCase("src/test/data/
             name = "test_module_name_lib.jar",
             description = "Builder jars should be normalized with and include stamp data"
         ) {
-            validateFileSha256("1d26035bda6f384b9cc6bbe5a5bf0727b4da0aeec59545c421de32775149d4cf")
+            validateFileSha256("a6eca5f9db22d5fb2914efa821cb553c213cdc05df5d0b7cbe1e58e6d308b513")
             assertManifestStamped()
             assertEntryCompressedAndNormalizedTimestampYear("helloworld/Main.class")
         }
@@ -39,7 +39,7 @@ class KotlinNormalizationAssertionTest : KotlinAssertionTestCase("src/test/data/
             name = "test_embed_resources.jar",
             description = "Merging resources into the main output jar should still result in a normalized jar"
         ) {
-            validateFileSha256("ff35e9779be25c5803ab74cd5cee46bfd35da9412fe78395d1ebc2fb2e20880a")
+            validateFileSha256("e3fff23417b6624a5a6445e367456f8fea6a47ed4a529626b8723a36475ba58a")
             assertManifestStamped()
             assertEntryCompressedAndNormalizedTimestampYear("testresources/AClass.class")
             assertEntryCompressedAndNormalizedTimestampYear(


### PR DESCRIPTION
This change sets the default modification data files in jars created with rules_kotlin to 2010-1-1.

I've patched JarHelper.kt with the latest version of the [bazelbuild/bazel Jarhelper](https://github.com/bazelbuild/bazel/blob/master/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper/JarHelper.java)

Reasoning: I noticed testJarNormalization failed to pass because the modification date for files in `test_embed_resources.jar` was set to 2010-1-1 instead of 1980-1-1.
In commit [bcefd9833cb5620fef8a27c37c2808a66b57c7e6 in bazelbuild/bazel](https://github.com/bazelbuild/bazel/commit/bcefd9833cb5620fef8a27c37c2808a66b57c7e6#diff-81c20aa091487ff7400c193d10ea25f2) the default date when normalizing Jars is set to 2010-1-1.