### PR TITLE
Cleanup for Bazel incompatible changes

### DIFF
--- a/kotlin/internal/js/impl.bzl
+++ b/kotlin/internal/js/impl.bzl
@@ -120,9 +120,10 @@ def kt_js_import_impl(ctx):
     args.add("--out", ctx.outputs.js)
     args.add("--aux", ctx.outputs.js_map)
 
-    inputs, _, input_manifest = ctx.resolve_command(tools = [ctx.attr._importer])
+    tools, _, input_manifest = ctx.resolve_command(tools = [ctx.attr._importer])
     ctx.actions.run(
-        inputs = inputs + [jar_file],
+        inputs = [jar_file],
+        tools = tools,
         executable = ctx.executable._importer,
         outputs = [
             ctx.outputs.js,

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -100,7 +100,8 @@ def _build_resourcejar_action(ctx):
     zipper_args = _resourcejar_args_action(ctx)
     ctx.actions.run_shell(
         mnemonic = "KotlinZipResourceJar",
-        inputs = ctx.files.resources + [ctx.executable._zipper, zipper_args],
+        inputs = ctx.files.resources + [zipper_args],
+        tools = [ctx.executable._zipper],
         outputs = [resources_jar_output],
         command = "{zipper} c {resources_jar_output} @{path}".format(
             path = zipper_args.path,
@@ -129,13 +130,10 @@ def _partition_srcs(srcs):
         elif f.path.endswith(".srcjar"):
             src_jars.append(f)
 
-    kt = depset(kt_srcs)
-    java = depset(java_srcs)
-
     return struct(
-        kt = kt,
-        java = java,
-        all_srcs = kt + java,
+        kt = depset(kt_srcs),
+        java = depset(java_srcs),
+        all_srcs = depset(kt_srcs + java_srcs),
         src_jars = depset(src_jars),
     )
 
@@ -152,7 +150,7 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
     toolchain = ctx.toolchains[_TOOLCHAIN_TYPE]
 
     srcs = _partition_srcs(ctx.files.srcs)
-    if (len(srcs.kt) + len(srcs.java) == 0) and len(srcs.src_jars) == 0:
+    if not srcs.kt and not srcs.java and not srcs.src_jars:
         fail("no sources provided")
 
     # TODO extract and move this into common. Need to make it generic first.
@@ -169,7 +167,7 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
         elif ctx.attr.module_name:
             fail("if friends has been set then module_name cannot be provided")
         else:
-            friend_paths = depset([j.path for j in friends[0][JavaInfo].compile_jars])
+            friend_paths = depset([j.path for j in friends[0][JavaInfo].compile_jars.to_list()])
             module_name = friends[0][_KtJvmInfo].module_name
     else:
         fail("only one friend is possible")
@@ -181,10 +179,10 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
 
     args = _utils.init_args(ctx, rule_kind, module_name)
 
-    args.add("--classdir", classes_directory)
-    args.add("--sourcegendir", sourcegen_directory)
-    args.add("--tempdir", temp_directory)
-    args.add("--kotlin_generated_classdir", generated_classes_directory)
+    args.add("--classdir", classes_directory.path)
+    args.add("--sourcegendir", sourcegen_directory.path)
+    args.add("--tempdir", temp_directory.path)
+    args.add("--kotlin_generated_classdir", generated_classes_directory.path)
 
     args.add("--output", output_jar)
     args.add("--kotlin_output_jdeps", ctx.outputs.jdeps)
@@ -192,32 +190,33 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
 
     args.add("--kotlin_friend_paths", "\n".join(friend_paths.to_list()))
 
-    args.add("--classpath", compile_jars)
+    args.add_all("--classpath", compile_jars)
     args.add_all("--sources", srcs.all_srcs, omit_if_empty = True)
     args.add_all("--source_jars", srcs.src_jars, omit_if_empty = True)
 
     # Collect and prepare plugin descriptor for the worker.
     plugin_info = _merge_plugin_infos(ctx.attr.plugins + ctx.attr.deps)
     if len(plugin_info.annotation_processors) > 0:
-        processors = depset()
-        processorpath = depset()
+        processors = []
+        processorpath = []
         for p in plugin_info.annotation_processors:
             processors += [p.processor_class]
             processorpath += p.classpath
-        args.add("--processors", processors)
-        args.add("--processorpath", processorpath)
+        args.add_all("--processors", processors)
+        args.add_all("--processorpath", processorpath)
 
     progress_message = "Compiling Kotlin to JVM %s { kt: %d, java: %d, srcjars: %d }" % (
         ctx.label,
-        len(srcs.kt),
-        len(srcs.java),
-        len(srcs.src_jars),
+        len(srcs.kt.to_list()),
+        len(srcs.java.to_list()),
+        len(srcs.src_jars.to_list()),
     )
 
-    inputs, _, input_manifests = ctx.resolve_command(tools = [toolchain.kotlinbuilder, toolchain.kotlin_home])
+    tools, _, input_manifests = ctx.resolve_command(tools = [toolchain.kotlinbuilder, toolchain.kotlin_home])
     ctx.actions.run(
         mnemonic = "KotlinCompile",
-        inputs = depset(inputs) + ctx.files.srcs + compile_jars,
+        inputs = depset(ctx.files.srcs, transitive = [compile_jars]),
+        tools = tools,
         outputs = [
             output_jar,
             ctx.outputs.jdeps,

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -162,7 +162,7 @@ def kt_jvm_binary_impl(ctx):
 
 def kt_jvm_junit_test_impl(ctx):
     providers = _kt_jvm_produce_jar_actions(ctx, "kt_jvm_test")
-    runtime_jars = providers.java.transitive_runtime_jars + ctx.files._bazel_test_runner
+    runtime_jars = depset(ctx.files._bazel_test_runner, transitive = [providers.java.transitive_runtime_jars])
     _write_launcher_action(
         ctx,
         runtime_jars,

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -107,6 +107,7 @@ load(
     _kt_jvm_junit_test_impl = "kt_jvm_junit_test_impl",
     _kt_jvm_library_impl = "kt_jvm_library_impl",
 )
+load("//kotlin/internal/utils:utils.bzl", "utils")
 
 _implicit_deps = {
     "_singlejar": attr.label(
@@ -136,61 +137,64 @@ _implicit_deps = {
     ),
 }
 
-_common_attr = _implicit_deps + {
-    "srcs": attr.label_list(
-        doc = """The list of source files that are processed to create the target, this can contain both Java and Kotlin
+_common_attr = utils.add_dicts(
+    _implicit_deps,
+    {
+        "srcs": attr.label_list(
+            doc = """The list of source files that are processed to create the target, this can contain both Java and Kotlin
         files. Java analysis occurs first so Kotlin classes may depend on Java classes in the same compilation unit.""",
-        default = [],
-        allow_files = [".srcjar", ".kt", ".java"],
-    ),
-    "deps": attr.label_list(
-        doc = """A list of dependencies of this rule.See general comments about `deps` at
+            default = [],
+            allow_files = [".srcjar", ".kt", ".java"],
+        ),
+        "deps": attr.label_list(
+            doc = """A list of dependencies of this rule.See general comments about `deps` at
         [Attributes common to all build rules](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).""",
-        aspects = [_kt_jvm_plugin_aspect],
-        providers = [
-            [JavaInfo],
-        ],
-        allow_files = False,
-    ),
-    "runtime_deps": attr.label_list(
-        doc = """Libraries to make available to the final binary or test at runtime only. Like ordinary deps, these will
+            aspects = [_kt_jvm_plugin_aspect],
+            providers = [
+                [JavaInfo],
+            ],
+            allow_files = False,
+        ),
+        "runtime_deps": attr.label_list(
+            doc = """Libraries to make available to the final binary or test at runtime only. Like ordinary deps, these will
         appear on the runtime classpath, but unlike them, not on the compile-time classpath.""",
-        default = [],
-        allow_files = False,
-    ),
-    "resources": attr.label_list(
-        doc = """A list of files that should be include in a Java jar.""",
-        default = [],
-        allow_files = True,
-    ),
-    "resource_strip_prefix": attr.string(
-        doc = """The path prefix to strip from Java resources, files residing under common prefix such as
+            default = [],
+            allow_files = False,
+        ),
+        "resources": attr.label_list(
+            doc = """A list of files that should be include in a Java jar.""",
+            default = [],
+            allow_files = True,
+        ),
+        "resource_strip_prefix": attr.string(
+            doc = """The path prefix to strip from Java resources, files residing under common prefix such as
         `src/main/resources` or `src/test/resources` will have stripping applied by convention.""",
-        default = "",
-    ),
-    "resource_jars": attr.label_list(
-        doc = """Set of archives containing Java resources. If specified, the contents of these jars are merged into
+            default = "",
+        ),
+        "resource_jars": attr.label_list(
+            doc = """Set of archives containing Java resources. If specified, the contents of these jars are merged into
         the output jar.""",
-        default = [],
-    ),
-    "data": attr.label_list(
-        doc = """The list of files needed by this rule at runtime. See general comments about `data` at
+            default = [],
+        ),
+        "data": attr.label_list(
+            doc = """The list of files needed by this rule at runtime. See general comments about `data` at
         [Attributes common to all build rules](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).""",
-        allow_files = True,
-    ),
-    "plugins": attr.label_list(
-        default = [],
-        aspects = [_kt_jvm_plugin_aspect],
-    ),
-    "module_name": attr.string(
-        doc = """The name of the module, if not provided the module name is derived from the label. --e.g.,
+            allow_files = True,
+        ),
+        "plugins": attr.label_list(
+            default = [],
+            aspects = [_kt_jvm_plugin_aspect],
+        ),
+        "module_name": attr.string(
+            doc = """The name of the module, if not provided the module name is derived from the label. --e.g.,
         `//some/package/path:label_name` is translated to
         `some_package_path-label_name`.""",
-        mandatory = False,
-    ),
-}
+            mandatory = False,
+        ),
+    },
+)
 
-_lib_common_attr = _common_attr + {
+_lib_common_attr = utils.add_dicts(_common_attr, {
     "exports": attr.label_list(
         doc = """Exported libraries.
 
@@ -203,15 +207,15 @@ _lib_common_attr = _common_attr + {
         doc = """If true only use this library for compilation and not at runtime.""",
         default = False,
     ),
-}
+})
 
-_runnable_common_attr = _common_attr + {
+_runnable_common_attr = utils.add_dicts(_common_attr, {
     "jvm_flags": attr.string_list(
         doc = """A list of flags to embed in the wrapper script generated for running this binary. Note: does not yet
         support make variable substitution.""",
         default = [],
     ),
-}
+})
 
 _common_outputs = dict(
     jar = "%{name}.jar",
@@ -257,7 +261,7 @@ kt_jvm_test = rule(
     * The kotlin test library is not added implicitly, it is available with the label
     `@com_github_jetbrains_kotlin//:kotlin-test`.
     """,
-    attrs = _runnable_common_attr + {
+    attrs = utils.add_dicts(_runnable_common_attr, {
         "_bazel_test_runner": attr.label(
             default = Label("@bazel_tools//tools/jdk:TestRunner_deploy.jar"),
             allow_files = True,
@@ -273,7 +277,7 @@ kt_jvm_test = rule(
             default = "",
         ),
         "main_class": attr.string(default = "com.google.testing.junit.runner.BazelTestRunner"),
-    },
+    }),
     executable = True,
     outputs = _common_outputs,
     test = True,

--- a/kotlin/internal/jvm/plugins.bzl
+++ b/kotlin/internal/jvm/plugins.bzl
@@ -49,7 +49,7 @@ def _kt_jvm_plugin_aspect_impl(target, ctx):
                 struct(
                     label = _utils.restore_label(ctx.label),
                     processor_class = processor.processor_class,
-                    classpath = [cp.path for cp in merged_deps.transitive_runtime_jars],
+                    classpath = [cp.path for cp in merged_deps.transitive_runtime_jars.to_list()],
                     generates_api = processor.generates_api,
                 ),
             ],

--- a/kotlin/internal/utils/utils.bzl
+++ b/kotlin/internal/utils/utils.bzl
@@ -42,11 +42,32 @@ def _init_builder_args(ctx, rule_kind, module_name):
             debug = debug + [tag]
         if tag == "timings":
             debug = debug + [tag]
-    args.add("--kotlin_debug_tags", debug)
+    args.add_all("--kotlin_debug_tags", debug, omit_if_empty = False)
 
     return args
 
+# Copied from https://github.com/bazelbuild/bazel-skylib/blob/master/lib/dicts.bzl
+# Remove it if we add a dependency on skylib.
+def _add_dicts(*dictionaries):
+    """Returns a new `dict` that has all the entries of the given dictionaries.
+    If the same key is present in more than one of the input dictionaries, the
+    last of them in the argument list overrides any earlier ones.
+    This function is designed to take zero or one arguments as well as multiple
+    dictionaries, so that it follows arithmetic identities and callers can avoid
+    special cases for their inputs: the sum of zero dictionaries is the empty
+    dictionary, and the sum of a single dictionary is a copy of itself.
+    Args:
+      *dictionaries: Zero or more dictionaries to be added.
+    Returns:
+      A new `dict` that has all the entries of the given dictionaries.
+    """
+    result = {}
+    for d in dictionaries:
+        result.update(d)
+    return result
+
 utils = struct(
+    add_dicts = _add_dicts,
     init_args = _init_builder_args,
     restore_label = _restore_label,
     derive_module_name = _derive_module_name,


### PR DESCRIPTION
- Avoid depset concatenation and implicit iteration
- Avoid '+' operator on dictionaries
- Migrate to the Args methods
- Separate tools from other inputs

Tested:
  bazel0.20 test :all --all_incompatible_changes --incompatible_disallow_legacy_javainfo=false