### PR TITLE
Allowing no-source kt-lib

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -150,8 +150,8 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
     toolchain = ctx.toolchains[_TOOLCHAIN_TYPE]
 
     srcs = _partition_srcs(ctx.files.srcs)
-    if not srcs.kt and not srcs.java and not srcs.src_jars:
-        fail("no sources provided")
+    if not srcs.kt and not srcs.java and not srcs.src_jars and ctx.attr.deps:
+        fail("no sources provided, but deps were declared. Did you mean runtime_deps?")
 
     # TODO extract and move this into common. Need to make it generic first.
     friends = getattr(ctx.attr, "friends", [])


### PR DESCRIPTION
This may be useful when wanting to combine several libs together. Similar functionality
is available in java_library.
Ensuring that if  were specified we fail (should be converted to runtime_deps).