### PR TITLE
Fix mixed UTF-8 Java and Kotlin builds

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -231,6 +231,9 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
         arguments = [args],
         progress_message = progress_message,
         input_manifests = input_manifests,
+        env = {
+            "LC_CTYPE": "en_US.UTF-8" # For Java source files
+        },
     )
 
     return struct(


### PR DESCRIPTION
When building .java files using the native Java rules, the environment
variable LC_LANG=en_US.UTF-8 is explicitely set for the actual build
action, see: https://git.io/fhhc7

When building a mixed Kotlin + Java module on Linux, the .java sources
are not handled by the native Java rules, and as a result are treated as
encoded using US-ASCII due to sandboxing which strips the environment
from all locale information, causing the compiler to default to the
'C' locale.

This patch adds this environment variable when building Kotlin + Java
modules and has no side effects on Kotlin-only modules as UTF-8 is the
only valid encoding for .kt source files.