### PR TITLE
Update deps for 0.26.0.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,15 +13,32 @@
 # limitations under the License.
 workspace(name = "io_bazel_rules_kotlin")
 
+local_repository(
+    name = "node_example",
+    path = "examples/node",
+)
+
 load("//kotlin/internal/repositories:repositories.bzl", "github_archive")
 
 github_archive(
     name = "com_google_protobuf",
-    commit = "106ffc04be1abf3ff3399f54ccf149815b287dd9",
+    commit = "09745575a923640154bcf307fba8aedff47f240a",  # v3.8.0, as of 2019-05-28
     repo = "google/protobuf",
+    sha256 = "76ee4ba47dec6146872b6cd051ae5bd12897ef0b1523d5aeb56d81a5a4ca885a",
 )
 
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
+
+http_archive(
+    name = "bazel_skylib",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz"],
+    strip_prefix = "bazel-skylib-0.8.0",
+    sha256 = "2ea8a5ed2b448baf4a6855d3ce049c4c452a6470b1efd1504fdb7c1c134d220a",
+)
 
 http_jar(
     name = "bazel_deps",

--- a/kotlin/internal/repositories/repositories.bzl
+++ b/kotlin/internal/repositories/repositories.bzl
@@ -37,7 +37,7 @@ _KOTLIN_CURRENT_COMPILER_RELEASE = {
     "sha256": "a23a40a3505e78563100b9e6cfd7f535fbf6593b69a5c470800fbafbeccf8434",
 }
 
-def github_archive(name, repo, commit, build_file_content = None):
+def github_archive(name, repo, commit, build_file_content = None, sha256 = None):
     if build_file_content:
         _http_archive(
             name = name,
@@ -45,6 +45,7 @@ def github_archive(name, repo, commit, build_file_content = None):
             url = "https://github.com/%s/archive/%s.zip" % (repo, commit),
             type = "zip",
             build_file_content = build_file_content,
+            sha256 = sha256,
         )
     else:
         _http_archive(
@@ -52,6 +53,7 @@ def github_archive(name, repo, commit, build_file_content = None):
             strip_prefix = "%s-%s" % (repo.split("/")[1], commit),
             url = "https://github.com/%s/archive/%s.zip" % (repo, commit),
             type = "zip",
+            sha256 = sha256,
         )
 
 def kotlin_repositories(compiler_release = _KOTLIN_CURRENT_COMPILER_RELEASE):


### PR DESCRIPTION
The error I am still stuck with when running `bazel test //...`:

```
ERROR: /.../rules_kotlin/kotlin/internal/BUILD:31:1: in js_stdlibs attribute of _kt_toolchain rule //kotlin/internal:default_toolchain_impl: '@com_github_jetbrains_kotlin//:kotlin-stdlib-js' does not have mandatory providers: 'KtJsInfo'. Since this rule was created by the macro 'define_kt_toolchain', the error might have been caused by the macro implementation in /.../rules_kotlin/kotlin/internal/BUILD:31:1
ERROR: Analysis of target '//kotlin/internal:default_toolchain_impl' failed; build aborted: Analysis of target '//kotlin/internal:default_toolchain_impl' failed; build aborted
```

cc @jin 