### PR TITLE
Support friend access to a target's internal members.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,9 +3,11 @@ platforms:
   ubuntu1604:
     test_targets:
     - "//:all_tests"
+    - "//examples/dagger/..."
   ubuntu1804:
     test_targets:
     - "//:all_tests"
+    - "//examples/dagger/..."
   rbe_ubuntu1604:
     test_targets:
     - "--"
@@ -14,6 +16,7 @@ platforms:
     # execution compatible, do not run them for now.
     - "//src/test/kotlin/io/bazel/kotlin:KotlinJvmFriendsVisibilityTest"
     - "//src/test/kotlin/io/bazel/kotlin:KotlinJvmBasicAssertionTest"
+    - "//examples/dagger/..."
     test_flags:
     # Override the default worker strategy for remote builds (worker strategy
     # cannot be used with remote builds)
@@ -21,3 +24,4 @@ platforms:
   macos:
     test_targets:
     - "//:all_tests"
+    - "//examples/dagger/..."

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,9 +35,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 
 http_archive(
     name = "bazel_skylib",
-    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz"],
-    strip_prefix = "bazel-skylib-0.8.0",
     sha256 = "2ea8a5ed2b448baf4a6855d3ce049c4c452a6470b1efd1504fdb7c1c134d220a",
+    strip_prefix = "bazel-skylib-0.8.0",
+    urls = ["https://github.com/bazelbuild/bazel-skylib/archive/0.8.0.tar.gz"],
 )
 
 http_jar(

--- a/examples/dagger/BUILD.bazel
+++ b/examples/dagger/BUILD.bazel
@@ -1,0 +1,21 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+package(default_visibility = ["//examples/dagger:__subpackages__"])
+
+java_binary(
+    name = "coffee_app",
+    main_class = "coffee.CoffeeApp",
+    visibility = ["//visibility:public"],
+    runtime_deps = ["//examples/dagger/src/coffee"],
+)

--- a/examples/dagger/src/coffee/BUILD.bazel
+++ b/examples/dagger/src/coffee/BUILD.bazel
@@ -11,30 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-package(default_visibility = ["//visibility:private"])
-
 load("//kotlin:kotlin.bzl", "kt_jvm_library")
-
-java_plugin(
-    name = "dagger_plugin",
-    processor_class = "dagger.internal.codegen.ComponentProcessor",
-    deps = [
-        "//third_party/jvm/com/google/dagger",
-        "//third_party/jvm/com/google/dagger:dagger_compiler",
-        "//third_party/jvm/com/google/dagger:dagger_producers",
-        "//third_party/jvm/javax/inject:javax_inject",
-        "@//third_party/jvm/com/google/guava",
-    ],
-)
-
-java_library(
-    name = "dagger_lib",
-    exported_plugins = ["dagger_plugin"],
-    exports = [
-        "//third_party/jvm/com/google/dagger",
-        "//third_party/jvm/javax/inject:javax_inject",
-    ],
-)
 
 # Generate a srcjar to validate intellij plugin correctly attaches it.
 genrule(
@@ -54,20 +31,18 @@ rm TeaPot.kt
 )
 
 kt_jvm_library(
-    name = "coffee_lib",
-    srcs = glob(["src/**"]) + [
+    name = "coffee",
+    srcs = glob(["*.kt"]) + [
         # Adding a file ending with .srcjar is how code generation patterns are implemented.
         ":tea_lib_src",
     ],
+    friend = "//examples/dagger/src/heating",
+    visibility = ["//examples/dagger:__subpackages__"],
     deps = [
-        ":dagger_lib",
+        "//examples/dagger/src/heating",
+        "//examples/dagger/src/pumping",
+        "//examples/dagger/src/time",
+        "//third_party:dagger",
         "//third_party/jvm/org/jetbrains/kotlinx:kotlinx_coroutines_core",
     ],
-)
-
-java_binary(
-    name = "coffee_app",
-    main_class = "coffee.CoffeeApp",
-    visibility = ["//visibility:public"],
-    runtime_deps = [":coffee_lib"],
 )

--- a/examples/dagger/src/coffee/CoffeeMaker.kt
+++ b/examples/dagger/src/coffee/CoffeeMaker.kt
@@ -16,9 +16,11 @@
 package coffee
 
 import dagger.Lazy
+import heating.Heater
+import javax.inject.Inject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import javax.inject.Inject
+import pumping.Pump
 
 class CoffeeMaker @Inject internal constructor(
     // Create a possibly costly heater only when we use it.
@@ -33,6 +35,9 @@ class CoffeeMaker @Inject internal constructor(
             pump.pump()
             println(" [_]P coffee! [_]P ")
             heater.get().off()
+        }
+        withContext(Dispatchers.Default) {
+            if (heater.get().isOn) throw IllegalStateException("Heater should be off")
         }
     }
 }

--- a/examples/dagger/src/heating/BUILD.bazel
+++ b/examples/dagger/src/heating/BUILD.bazel
@@ -1,0 +1,24 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+load("//kotlin:kotlin.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "heating",
+    srcs = glob(["*.kt"]),
+    visibility = ["//examples/dagger:__subpackages__"],
+    deps = [
+        "//examples/dagger/src/time",
+        "//third_party:dagger",
+    ],
+)

--- a/examples/dagger/src/heating/ElectricHeater.kt
+++ b/examples/dagger/src/heating/ElectricHeater.kt
@@ -13,32 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package coffee
+package heating
 
-import dagger.Binds
-import dagger.Module
-import dagger.Provides
-import heating.ElectricHeater
-import heating.Heater
-import javax.inject.Singleton
-import pumping.PumpModule
+import javax.inject.Inject
 import time.Delayer
 
-@Module(includes = arrayOf(PumpModule::class, Bindings::class))
-internal class DripCoffeeModule {
-    @Provides
-    @Singleton
-    fun provideDelayer(): Delayer {
-        return object : Delayer {
-            override fun delay() {
-                Thread.sleep(1000)
-            }
-        }
-    }
-}
+class ElectricHeater
+    @Inject constructor(private val delayer: Delayer) : Heater() {
 
-@Module
-internal abstract class Bindings {
-    @Binds @Singleton
-    internal abstract fun bindHeater(heater: ElectricHeater): Heater
+    override var isHot: Boolean = false
+    override var isOn: Boolean = false
+
+    override fun on() {
+        isOn = true
+        println("~ ~ ~ heating ~ ~ ~")
+        delayer.delay()
+        this.isHot = true
+    }
+
+    override fun off() {
+        this.isOn = false
+        println("~ ~ ~ cooling ~ ~ ~")
+        delayer.delay()
+        this.isHot = false
+    }
 }

--- a/examples/dagger/src/heating/Heater.kt
+++ b/examples/dagger/src/heating/Heater.kt
@@ -13,13 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package coffee
+package heating
 
-import dagger.Binds
-import dagger.Module
+abstract class Heater {
+    abstract val isHot: Boolean
 
-@Module
-internal abstract class PumpModule {
-    @Binds
-    internal abstract fun providePump(pump: Thermosiphon): Pump
+    internal abstract val isOn: Boolean
+
+    abstract fun on()
+    abstract fun off()
 }

--- a/examples/dagger/src/pumping/BUILD.bazel
+++ b/examples/dagger/src/pumping/BUILD.bazel
@@ -1,0 +1,25 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+load("//kotlin:kotlin.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "pumping",
+    srcs = glob(["*.kt"]),
+    visibility = ["//examples/dagger:__subpackages__"],
+    deps = [
+        "//examples/dagger/src/heating",
+        "//examples/dagger/src/time",
+        "//third_party:dagger",
+    ],
+)

--- a/examples/dagger/src/pumping/Pump.kt
+++ b/examples/dagger/src/pumping/Pump.kt
@@ -13,8 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package coffee
+package pumping
 
-internal interface Pump {
+interface Pump {
     fun pump()
 }

--- a/examples/dagger/src/pumping/PumpModule.kt
+++ b/examples/dagger/src/pumping/PumpModule.kt
@@ -13,16 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package coffee
+package pumping
 
-import javax.inject.Inject
+import dagger.Binds
+import dagger.Module
 
-internal class Thermosiphon @Inject
-constructor(private val heater: Heater) : Pump {
-
-    override fun pump() {
-        if (heater.isHot) {
-            println("=> => pumping => =>")
-        }
-    }
+@Module
+abstract class PumpModule {
+    @Binds
+    internal abstract fun providePump(pump: Thermosiphon): Pump
 }

--- a/examples/dagger/src/pumping/Thermosiphon.kt
+++ b/examples/dagger/src/pumping/Thermosiphon.kt
@@ -13,10 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package coffee
+package pumping
 
-internal interface Heater {
-    val isHot: Boolean
-    fun on()
-    fun off()
+import heating.Heater
+import javax.inject.Inject
+import time.Delayer
+
+internal class Thermosiphon
+    @Inject constructor(private val heater: Heater, private val delayer: Delayer) :
+    Pump {
+
+    override fun pump() {
+        if (heater.isHot) {
+            println("=> => pumping => =>")
+            delayer.delay()
+        }
+    }
 }

--- a/examples/dagger/src/time/BUILD.bazel
+++ b/examples/dagger/src/time/BUILD.bazel
@@ -1,0 +1,20 @@
+# Copyright 2019 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+load("//kotlin:kotlin.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "time",
+    srcs = glob(["*.kt"]),
+    visibility = ["//examples/dagger:__subpackages__"],
+)

--- a/examples/dagger/src/time/Delayer.kt
+++ b/examples/dagger/src/time/Delayer.kt
@@ -13,17 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package coffee
+package time
 
-internal class ElectricHeater : Heater {
-    override var isHot: Boolean = false
-
-    override fun on() {
-        println("~ ~ ~ heating ~ ~ ~")
-        this.isHot = true
-    }
-
-    override fun off() {
-        this.isHot = false
-    }
+/** Introduces a delay (which can be overridden in testing */
+interface Delayer {
+    fun delay(): Unit
 }

--- a/examples/dagger/test/coffee/BUILD.bazel
+++ b/examples/dagger/test/coffee/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//kotlin:kotlin.bzl", "kt_jvm_library", "kt_jvm_test")
+
+kt_jvm_library(
+    name = "testlib",
+    srcs = ["BasicTestUtil.kt"],
+    friend = "//examples/dagger/src/heating",
+    deps = [
+        "//examples/dagger/src/heating",
+    ],
+)
+
+kt_jvm_test(
+    name = "BasicTest",
+    srcs = ["BasicTest.kt"],
+    friends = [":testlib"],  # old syntax
+    deps = [
+        ":testlib",
+        "//examples/dagger/src/heating",
+        "//third_party/jvm/com/google/truth",
+        "//third_party/jvm/junit",
+    ],
+)

--- a/examples/dagger/test/coffee/BasicTest.kt
+++ b/examples/dagger/test/coffee/BasicTest.kt
@@ -1,0 +1,21 @@
+package coffee
+
+import com.google.common.truth.Truth.assertThat
+import heating.ElectricHeater
+import org.junit.Test
+import time.Delayer
+
+class BasicTest {
+    @Test fun `test that internal member is transitively visible`() {
+        val heater = ElectricHeater(object : Delayer {
+            override fun delay() {
+                println("fake delay")
+            }
+        })
+        assertThat(isHeaterOn(heater)).isFalse()
+        heater.on()
+        assertThat(isHeaterOn(heater)).isTrue()
+        heater.off()
+        assertThat(heater.isOn).isFalse()
+    }
+}

--- a/examples/dagger/test/coffee/BasicTestUtil.kt
+++ b/examples/dagger/test/coffee/BasicTestUtil.kt
@@ -1,0 +1,5 @@
+package coffee
+
+import heating.Heater
+
+internal fun isHeaterOn(heater: Heater): Boolean = heater.isOn

--- a/kotlin/internal/defs.bzl
+++ b/kotlin/internal/defs.bzl
@@ -21,6 +21,7 @@ KT_COMPILER_REPO = "com_github_jetbrains_kotlin"
 KtJvmInfo = provider(
     fields = {
         "module_name": "the module name",
+        "friend_paths": "The target(s) that this library can see the internals of.",
         "srcs": "the source files. [intelij-aspect]",
         "outputs": "output jars produced by this rule. [intelij-aspect]",
     },

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -16,7 +16,7 @@ load(
     _kt_jvm_library = "kt_jvm_library",
 )
 
-def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
+def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], friend = None, **kwargs):
     """Delegates Android related build attributes to the native rules but uses the Kotlin builder to compile Java and
     Kotlin srcs. Returns a sequence of labels that a wrapping macro should export.
     """
@@ -36,8 +36,11 @@ def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
         srcs = srcs,
         deps = base_deps + [base_name],
         plugins = plugins,
-        testonly = kwargs.get("testonly", default=0),
-        visibility = ["//visibility:private"],
+        testonly = kwargs.get("testonly", default = 0),
+        friend = friend,
+        # must be public to be referenced as friends.
+        # TODO: rework this into a proper android provider giving rule, so we can avoid all this.
+        visibility = ["//visibility:public"],
     )
     return [base_name, kt_name]
 
@@ -49,5 +52,5 @@ def kt_android_library(name, exports = [], visibility = None, **kwargs):
         name = name,
         exports = exports + _kt_android_artifact(name, **kwargs),
         visibility = visibility,
-        testonly = kwargs.get("testonly", default=0),
+        testonly = kwargs.get("testonly", default = 0),
     )

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -98,8 +98,8 @@ def _unify_jars(ctx):
             fail("got more than one jar, this is an error create an issue: %s" % jars)
         if len(source_jars) > 1:
             fail("got more than one source jar. " +
-                 "Did you include both srcjar and a sources jar in the jars attribute?: " +
-                 jars)
+                "Did you include both srcjar and a sources jar in the jars attribute?: " +
+                jars)
             print(source_jars)
         return struct(class_jar = jars[0], source_jar = source_jars[0] if len(source_jars) == 1 else None, ijar = None)
 

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -173,7 +173,7 @@ def kt_jvm_junit_test_impl(ctx):
         for file in ctx.files.srcs:
             if file.basename.split(".")[0] == ctx.attr.name:
                 for splitter in _SPLIT_STRINGS:
-                    elements = file.short_path.split(splitter, maxsplit = 1)
+                    elements = file.short_path.split(splitter, 1)
                     if len(elements) == 2:
                         test_class = elements[1].split(".")[0].replace("/", ".")
 

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -161,6 +161,11 @@ _common_attr = utils.add_dicts(
             default = [],
             allow_files = False,
         ),
+        "friend": attr.label(
+            doc = """A single Kotlin dep which allows this code to access internal members of the given dependency.
+             Currently uses the output jar of the module -- i.e., exported deps won't be included.""",
+            providers = [JavaInfo, _KtJvmInfo],
+        ),
         "resources": attr.label_list(
             doc = """A list of files that should be include in a Java jar.""",
             default = [],
@@ -267,8 +272,10 @@ kt_jvm_test = rule(
             allow_files = True,
         ),
         "friends": attr.label_list(
-            doc = """A single Kotlin dep which allows the test code access to internal members. Currently uses the output
-            jar of the module -- i.e., exported deps won't be included.""",
+            doc = """A single Kotlin dep which allows this code to access internal members of the given dependency.
+            Currently uses the output jar of the module -- i.e., exported deps won't be included.
+
+            DEPRECATED - PLEASE USE `friend=` instead.""",
             default = [],
             providers = [JavaInfo, _KtJvmInfo],
         ),

--- a/kotlin/internal/repositories/repositories.bzl
+++ b/kotlin/internal/repositories/repositories.bzl
@@ -32,9 +32,9 @@ _BAZEL_JAVA_LAUNCHER_VERSION = "0.28.1"
 
 _KOTLIN_CURRENT_COMPILER_RELEASE = {
     "urls": [
-        "https://github.com/JetBrains/kotlin/releases/download/v1.3.21/kotlin-compiler-1.3.21.zip",
+        "https://github.com/JetBrains/kotlin/releases/download/v1.3.50/kotlin-compiler-1.3.50.zip",
     ],
-    "sha256": "dbc7fbed67e0fa9a2f2ef6efd89fc1ef8d92daa38bb23c1f23914869084deb56",
+    "sha256": "69424091a6b7f52d93eed8bba2ace921b02b113dbb71388d704f8180a6bdc6ec",
 }
 
 def github_archive(name, repo, commit, build_file_content = None, sha256 = None):

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -28,6 +28,12 @@ import java.nio.file.Paths
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Due to an inconsistency in the handling of -Xfriends-path, jvm uses a comma (property list
+ * separator), js uses the system path separator.
+ */
+const val X_FRIENDS_PATH_SEPARATOR = ","
+
 @Singleton
 class KotlinJvmTaskExecutor @Inject internal constructor(
     private val compiler: KotlinToolchain.KotlincInvoker,
@@ -96,15 +102,18 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
      */
     private fun JvmCompilationTask.getCommonArgs(): MutableList<String> {
         val args = mutableListOf<String>()
-        val friendPaths= info.friendPathsList.map { Paths.get(it).toAbsolutePath() }
+        val friendPaths = info.friendPathsList.map { Paths.get(it).toAbsolutePath() }
+        val cp = inputs.joinedClasspath
+            .split(File.pathSeparator)
+            .map { Paths.get(it).toAbsolutePath() }
+            .joinToString(File.pathSeparator)
         args.addAll(
-            "-cp", inputs.joinedClasspath,
+            "-cp", cp,
             "-api-version", info.toolchainInfo.common.apiVersion,
             "-language-version", info.toolchainInfo.common.languageVersion,
             "-jvm-target", info.toolchainInfo.jvm.jvmTarget,
-            "-Xfriend-paths=${friendPaths.joinToString(File.pathSeparator)}"
+            "-Xfriend-paths=${friendPaths.joinToString(X_FRIENDS_PATH_SEPARATOR)}"
         )
-
         args
             .addAll("-module-name", info.moduleName)
             .addAll("-d", directories.classes)
@@ -220,5 +229,3 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
             it.build()
         }
 }
-
-

--- a/src/test/kotlin/io/bazel/kotlin/KotlinAssertionTestCase.kt
+++ b/src/test/kotlin/io/bazel/kotlin/KotlinAssertionTestCase.kt
@@ -120,7 +120,7 @@ abstract class BasicAssertionTestCase {
         ProcessBuilder().command("bash", "-c", Paths.get(executable).fileName.toString())
             .also { it.directory(executable.resolveDirectory()) }
             .start().let {
-                it.waitFor(5, TimeUnit.SECONDS)
+                it.waitFor(10, TimeUnit.SECONDS)
                 assert(it.exitValue() == 0) {
                     throw TestCaseFailedException(
                         description = description,


### PR DESCRIPTION
> Note: This PR is against a design currently under discussion in #211. It's here for illustration, though it is complete, and a version of it is being used by Square internally. It's not intended to be reviewed as the chosen implementation, as there are some un-answered questions in the aforementioned design discussion. 

### Support `friend` access to a target's `internal` members.

Allow the rules to support kotlin `internal` visibility (usually accessible only to the compilation unit)
by allowing a library or test to specify that it is friends with another library like so:

```
kt_jvm_library(
    name = "foo",
    srcs = glob(["*.kt"]),
    friend = "//some/other:target",
    # ...
)
```

> Note: declaring friends of a kt_android_library requires adding `_kt` to the target, e.g.
> `//some/other:target_kt`.  This is because the `kt_android_library` rule is a macro with a
> `kt_jvm_library` under the hood, and the surfaced rule is an android rule which doesn't have
> kotlin aware bazel providers. This will be fixed in the future.

This grants access to `internal` members of `//some/other:target`. A library can only be friends
with one other library, which must be a kotlin-aware target (returns a KtJvmInfo from the rule). It inherits the module name from that library. Only one friend can be declared, because of the assumptions made here about module membership.  Since friendship can be transitive (see below), this constrains the visibility so it does not become an arbitrarily growing lattice of trust, defeating the purpose.

Very common use-cases for this are:

  * tests and test-libraries depending on internals of the system under test.
  * clusters of targets that represent one logical unit, with public, private,
     fake, testing-utilities, configuration, or other targets that comprise the
     whole unit.

Friendship has limited transitivity. Consider projects `C`, `B`, and `A` with a dependency
relationship `C->B->A`.  If `C` declares friendship in `B`, and `B` declares friendship with `A`,
then they are all treated as logically one module for `internal` purposes. However it doesn't
skip. Once the line of friendship is broken, a separate module is presumed by kotlinc. 

Addresses #211 (and #210 along the way). 
