### PR TITLE
Use a comma to separate friends-paths.

### DIFF
--- a/kotlin/internal/repositories/repositories.bzl
+++ b/kotlin/internal/repositories/repositories.bzl
@@ -32,9 +32,9 @@ _BAZEL_JAVA_LAUNCHER_VERSION = "0.28.1"
 
 _KOTLIN_CURRENT_COMPILER_RELEASE = {
     "urls": [
-        "https://github.com/JetBrains/kotlin/releases/download/v1.3.21/kotlin-compiler-1.3.21.zip",
+        "https://github.com/JetBrains/kotlin/releases/download/v1.3.50/kotlin-compiler-1.3.50.zip",
     ],
-    "sha256": "dbc7fbed67e0fa9a2f2ef6efd89fc1ef8d92daa38bb23c1f23914869084deb56",
+    "sha256": "69424091a6b7f52d93eed8bba2ace921b02b113dbb71388d704f8180a6bdc6ec",
 }
 
 def github_archive(name, repo, commit, build_file_content = None, sha256 = None):

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -28,6 +28,12 @@ import java.nio.file.Paths
 import javax.inject.Inject
 import javax.inject.Singleton
 
+/**
+ * Due to an inconsistency in the handling of -Xfriends-path, jvm uses a comma (property list
+ * separator), js uses the system path separator.
+ */
+const val X_FRIENDS_PATH_SEPARATOR = ","
+
 @Singleton
 class KotlinJvmTaskExecutor @Inject internal constructor(
     private val compiler: KotlinToolchain.KotlincInvoker,
@@ -57,7 +63,6 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
 
     private fun JvmCompilationTask.produceSourceJar() {
         Paths.get(outputs.srcjar).also { sourceJarPath ->
-            Files.deleteIfExists(sourceJarPath)
             Files.createFile(sourceJarPath)
             SourceJarCreator(
                 sourceJarPath
@@ -98,14 +103,17 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
     private fun JvmCompilationTask.getCommonArgs(): MutableList<String> {
         val args = mutableListOf<String>()
         val friendPaths = info.friendPathsList.map { Paths.get(it).toAbsolutePath() }
+        val cp = inputs.joinedClasspath
+            .split(File.pathSeparator)
+            .map { Paths.get(it).toAbsolutePath() }
+            .joinToString(File.pathSeparator)
         args.addAll(
-            "-cp", inputs.joinedClasspath,
+            "-cp", cp,
             "-api-version", info.toolchainInfo.common.apiVersion,
             "-language-version", info.toolchainInfo.common.languageVersion,
             "-jvm-target", info.toolchainInfo.jvm.jvmTarget,
-            "-Xfriend-paths=${friendPaths.joinToString(File.pathSeparator)}"
+            "-Xfriend-paths=${friendPaths.joinToString(X_FRIENDS_PATH_SEPARATOR)}"
         )
-
         args
             .addAll("-module-name", info.moduleName)
             .addAll("-d", directories.classes)


### PR DESCRIPTION
Use a comma to separate friends-paths, as kotlinc extracts friends path elements using that separator, not the usual system path separator.

> Note: This differs between the js and jvm backends [KT34277]

Fixes #210

[KT34277]: https://youtrack.jetbrains.com/issue/KT-34277