### PR TITLE
Support more recent java versions in the kotlin toolchain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain")
 define_kt_toolchain(
     name = "kotlin_toolchain",
     api_version = KOTLIN_LANGUAGE_LEVEL,  # "1.1", "1.2", or "1.3"
-    jvm_target = JAVA_LANGUAGE_LEVEL, # "1.6" or "1.8"
+    jvm_target = JAVA_LANGUAGE_LEVEL, # "1.6", "1.8", "9", "10", "11", or "12",
     language_version = KOTLIN_LANGUAGE_LEVEL,  # "1.1", "1.2", or "1.3"
 )
 ```

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -141,6 +141,10 @@ _kt_toolchain = rule(
             values = [
                 "1.6",
                 "1.8",
+                "9",
+                "10",
+                "11",
+                "12",
             ],
         ),
         "js_target": attr.string(


### PR DESCRIPTION
Fixes #229 