### PR TITLE
Add kotlin-reflect to jvm_runtime and jvm_stdlibs

### DIFF
--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -117,7 +117,8 @@ _kt_toolchain = rule(
         "jvm_runtime": attr.label_list(
             doc = "The implicit jvm runtime libraries. This is internal.",
             default = [
-                Label("@" + _KT_COMPILER_REPO + "//:kotlin-stdlib")
+                Label("@" + _KT_COMPILER_REPO + "//:kotlin-stdlib"),
+                Label("@" + _KT_COMPILER_REPO + "//:kotlin-reflect"),
             ],
             providers = [JavaInfo],
             cfg = "target",
@@ -126,6 +127,7 @@ _kt_toolchain = rule(
             doc = "The jvm stdlibs. This is internal.",
             default = [
                 Label("@" + _KT_COMPILER_REPO + "//:annotations"),
+                Label("@" + _KT_COMPILER_REPO + "//:kotlin-reflect"),
                 Label("@" + _KT_COMPILER_REPO + "//:kotlin-stdlib"),
                 Label("@" + _KT_COMPILER_REPO + "//:kotlin-stdlib-jdk7"),
                 # JDK8 is being added blindly but I think we will probably not support bytecode levels 1.6 when the


### PR DESCRIPTION
kotlin-reflect should be part of the standard libraries for Kotlin compiles