### PR TITLE
Passthrough tags to the container android_library

### DIFF
--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -49,5 +49,6 @@ def kt_android_library(name, exports = [], visibility = None, **kwargs):
         name = name,
         exports = exports + _kt_android_artifact(name, **kwargs),
         visibility = visibility,
+        tags = kwargs.get("tags", default=None),
         testonly = kwargs.get("testonly", default=0),
     )


### PR DESCRIPTION
Tags were being dropped which meant that tag filters targets wasn't working properly.