### PR TITLE
Tweak the inference of the test class's package a bit

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -156,7 +156,9 @@ def kt_jvm_binary_impl(ctx):
 
 _SPLIT_STRINGS = [
     "src/test/java/",
+    "src/test/kotlin/",
     "javatests/",
+    "kotlin/",
     "java/",
     "test/",
 ]


### PR DESCRIPTION
Tweak the inference of the test class's package a bit, to support src/test/kotlin/ and kotlin/, since while it's common for kotlin files to live in a /java/ root, it's not UNcommon for them to live in a *kotlin/ root.