### PR TITLE
Fix some incompatible native android_* rules references

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -13,6 +13,15 @@
 # limitations under the License.
 workspace(name = "io_bazel_rules_kotlin")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
+load("//kotlin/internal/repositories:repositories.bzl", "github_archive")
+
+RULES_ANDROID_TAG = "0.1.1"
+RULES_ANDROID_SHA = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806"
+
+RULES_JVM_EXTERNAL_TAG = "3.0"
+RULES_JVM_EXTERNAL_SHA = "62133c125bf4109dfd9d2af64830208356ce4ef8b165a6ef15bbff7460b35c3a"
+
 RULES_NODEJS_VERSION = "0.36.1"
 RULES_NODEJS_SHA = "3356c6b767403392bab018ce91625f6d15ff8f11c6d772dc84bc9cada01c669a"
 
@@ -29,12 +38,14 @@ BAZEL_DEPS_VERSION = "0.1.0"
 BAZEL_DEPS_SHA = "05498224710808be9687f5b9a906d11dd29ad592020246d4cd1a26eeaed0735e"
 
 
-local_repository(
-    name = "node_example",
-    path = "examples/node",
-)
+local_repository(name = "node_example", path = "examples/node")
 
-load("//kotlin/internal/repositories:repositories.bzl", "github_archive")
+http_archive(
+    name = "build_bazel_rules_android",
+    sha256 = RULES_ANDROID_SHA,
+    strip_prefix = "rules_android-0.1.1",
+    url = "https://github.com/bazelbuild/rules_android/archive/v%s.zip" % RULES_ANDROID_TAG,
+)
 
 github_archive(
     name = "com_google_protobuf",
@@ -44,10 +55,7 @@ github_archive(
 )
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
 protobuf_deps()
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_jar")
 
 http_archive(
     name = "bazel_skylib",
@@ -72,39 +80,27 @@ http_archive(
     ],
 )
 
-load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
-
 # Creates toolchain configuration for remote execution with BuildKite CI
 # for rbe_ubuntu1604
-rbe_autoconfig(
-    name = "buildkite_config",
-)
+load("@bazel_toolchains//rules:rbe_repo.bzl", "rbe_autoconfig")
+rbe_autoconfig(name = "buildkite_config")
 
 load("//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
-
 kotlin_repositories()
-
 kt_register_toolchains()
 
 # The following are to support building and running nodejs examples from src/test
-
 http_archive(
     name = "build_bazel_rules_nodejs",
     sha256 = RULES_NODEJS_SHA,
     url = "https://github.com/bazelbuild/rules_nodejs/releases/download/{0}/rules_nodejs-{0}.tar.gz".format(RULES_NODEJS_VERSION),
 )
-
 load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
-
 yarn_install(
     name = "node_ws",
     package_json = "@node_example//:package.json",
     yarn_lock = "@node_example//:yarn.lock",
 )
-
-RULES_JVM_EXTERNAL_TAG = "2.7"
-
-RULES_JVM_EXTERNAL_SHA = "f04b1466a00a2845106801e0c5cec96841f49ea4e7d1df88dc8e4bf31523df74"
 
 http_archive(
     name = "rules_jvm_external",
@@ -112,9 +108,7 @@ http_archive(
     strip_prefix = "rules_jvm_external-%s" % RULES_JVM_EXTERNAL_TAG,
     url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % RULES_JVM_EXTERNAL_TAG,
 )
-
 load("@rules_jvm_external//:defs.bzl", "maven_install")
-
 maven_install(
     artifacts = [
         "org.jetbrains.kotlinx:atomicfu-js:0.13.1",
@@ -125,4 +119,3 @@ maven_install(
         "https://repo1.maven.org/maven2",
     ],
 )
-

--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -1,8 +1,22 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+RULES_ANDROID_TAG = "0.1.1"
+RULES_ANDROID_SHA = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806"
 RULES_JVM_EXTERNAL_TAG = "2.8"
-
 RULES_JVM_EXTERNAL_SHA = "79c9850690d7614ecdb72d68394f994fef7534b292c4867ce5e7dec0aa7bdfad"
+SKYLIB_TAG = "1.0.2"
+SKYLIB_SHA = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44"
+
+http_archive(
+    name = "build_bazel_rules_android",
+    sha256 = RULES_ANDROID_SHA,
+    strip_prefix = "rules_android-0.1.1",
+    url = "https://github.com/bazelbuild/rules_android/archive/v%s.zip" % RULES_ANDROID_TAG,
+)
+
+load("@build_bazel_rules_android//android:rules.bzl", "android_ndk_repository", "android_sdk_repository")
+android_sdk_repository(name = "androidsdk")
+android_ndk_repository(name = "androidndk")  # Required. Name *must* be "androidndk".
 
 http_archive(
     name = "rules_jvm_external",
@@ -27,42 +41,15 @@ maven_install(
     ],
 )
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-
-http_archive(
-    name = "build_bazel_rules_android",
-    sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-    strip_prefix = "rules_android-0.1.1",
-    urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
-)
-
-load(
-    "@build_bazel_rules_android//android:rules.bzl",
-    "android_ndk_repository",
-    "android_sdk_repository",
-)
-
-android_sdk_repository(name = "androidsdk")
-
-android_ndk_repository(name = "androidndk")  # Required. Name *must* be "androidndk".
-
 # Directly load the kotlin rules from the parent repo.
-local_repository(
-    name = "io_bazel_rules_kotlin",
-    path = "../..",
-)
-
+local_repository(name = "io_bazel_rules_kotlin", path = "../..")
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
-
 kotlin_repositories()
-
 kt_register_toolchains()
 
-# Skylib, for build_test, so don't bother initializing the unit test infrastructure.
+# Skylib, only to get build_test(), so don't bother initializing the unit test infrastructure.
 http_archive(
     name = "bazel_skylib",
-    sha256 = "97e70364e9249702246c0e9444bccdc4b847bed1eb03c5a3ece4f83dfe6abc44",
-    urls = [
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.0.2/bazel-skylib-1.0.2.tar.gz",
-    ],
+    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel-skylib-{0}.tar.gz".format(SKYLIB_TAG),
+    sha256 = SKYLIB_SHA,
 )

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -15,6 +15,7 @@ load(
     "//kotlin/internal/jvm:jvm.bzl",
     _kt_jvm_library = "kt_jvm_library",
 )
+load("@build_bazel_rules_android//android:rules.bzl", "android_library")
 
 def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
     """Delegates Android related build attributes to the native rules but uses the Kotlin builder to compile Java and
@@ -25,7 +26,7 @@ def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
 
     base_deps = deps + ["@io_bazel_rules_kotlin//kotlin/internal/jvm:android_sdk"]
 
-    native.android_library(
+    android_library(
         name = base_name,
         visibility = ["//visibility:private"],
         exports = base_deps,
@@ -36,7 +37,7 @@ def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
         srcs = srcs,
         deps = base_deps + [base_name],
         plugins = plugins,
-        testonly = kwargs.get("testonly", default=0),
+        testonly = kwargs.get("testonly", default = 0),
         visibility = ["//visibility:private"],
     )
     return [base_name, kt_name]
@@ -45,10 +46,10 @@ def kt_android_library(name, exports = [], visibility = None, **kwargs):
     """Creates an Android sandwich library. `srcs`, `deps`, `plugins` are routed to `kt_jvm_library` the other android
     related attributes are handled by the native `android_library` rule.
     """
-    native.android_library(
+    android_library(
         name = name,
         exports = exports + _kt_android_artifact(name, **kwargs),
         visibility = visibility,
-        tags = kwargs.get("tags", default=None),
-        testonly = kwargs.get("testonly", default=0),
+        tags = kwargs.get("tags", default = None),
+        testonly = kwargs.get("testonly", default = 0),
     )


### PR DESCRIPTION
This only fixes these references within the library, and does not address third-party violations from things like @build_tools.  Also, updates and reorganizes the android sample's WORKSPACE file. Minor buildifier formatting also.

Partly addresses #251