### PR TITLE
Allow resources to be in a kotlin directory

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -52,6 +52,7 @@ def _fold_jars_action(ctx, rule_kind, output_jar, input_jars):
 _CONVENTIONAL_RESOURCE_PATHS = [
     "src/main/resources",
     "src/test/resources",
+    "kotlin",
 ]
 
 def _adjust_resources_path_by_strip_prefix(path, resource_strip_prefix):

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -168,7 +168,7 @@ _common_attr = utils.add_dicts(
         ),
         "resource_strip_prefix": attr.string(
             doc = """The path prefix to strip from Java resources, files residing under common prefix such as
-        `src/main/resources` or `src/test/resources` will have stripping applied by convention.""",
+        `src/main/resources` or `src/test/resources` or `kotlin` will have stripping applied by convention.""",
             default = "",
         ),
         "resource_jars": attr.label_list(


### PR DESCRIPTION
We just put everything in a `kotlin` directory (which the test rules allow for) so it'd be nice if resources also didn't need this prefix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bazelbuild/rules_kotlin/268)
<!-- Reviewable:end -->
