### PR TITLE
Fix regression introduced in #271 for legacy use of "jars" in kt_jvm_import

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -73,7 +73,10 @@ def _unify_jars(ctx):
     else:
         # Legacy handling.
         jars = []
-        source_jars = [ctx.file.srcjar] if ctx.file.srcjar else []
+        if (ctx.file.srcjar and not "%s" % ctx.file.srcjar.path == "third_party/empty.jar"):
+            source_jars = [ctx.file.srcjar]
+        else:
+            source_jars = []
 
         # TODO after a while remove the for block, the checks after it,and simplify the source-jar to jar allignment.
         # There must be a single jar jar and it can either be a filegroup or a JavaInfo.
@@ -98,9 +101,7 @@ def _unify_jars(ctx):
             fail("got more than one jar, this is an error create an issue: %s" % jars)
         if len(source_jars) > 1:
             fail("got more than one source jar. " +
-                 "Did you include both srcjar and a sources jar in the jars attribute?: " +
-                 jars)
-            print(source_jars)
+                 "Did you include both srcjar and a sources jar in the jars attribute?: %s" % source_jars)
         return struct(class_jar = jars[0], source_jar = source_jars[0] if len(source_jars) == 1 else None, ijar = None)
 
 def kt_jvm_import_impl(ctx):


### PR DESCRIPTION
Only propagate srcjar if it isn't the default empty jar added in ae70089a2f672182d55ef8cd1bd97ec6d2370d6a to fix bazelbuild/intellij#1616

This fixes a regression introduced in #271, which fixes a bug in intellij by adding a default srcjar if there isn't one. This broke legacy handling of the `jars=` attribute in kt_jvm_import, when the imported `jars=` attribute had a `-sources.jar` in the resulting files.  By not using srcjar you get the default, plus you get the extra -sources.jar, which blows up the "only one source jar" assertion. This just only propagates `srcjar` into the legacy handling IF it isn't the default value. 

Also remove a print statement that leaked in, and fix a bad type issue in the fail() of the above-mentioned assertion code, which was surfaced when this mode came into existence.

This only occurs when using `kt_jvm_import(jars=)`, which is already legacy and slated for removal.  We may just rip out the facility, but for now, we support it. 