### PR TITLE
Optional outputs

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -33,7 +33,11 @@ def _make_providers(ctx, providers, transitive_files = depset(order = "default")
             DefaultInfo(
                 files = depset([ctx.outputs.jar]),
                 runfiles = ctx.runfiles(
+                    # explicitly include data files, otherwise they appear to be missing
+                    files = ctx.files.data,
                     transitive_files = transitive_files,
+                    # continue to use collect_default until proper transitive data collecting is
+                    # implmented.
                     collect_default = True,
                 ),
             ),

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationArgs.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationArgs.kt
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package io.bazel.kotlin.builder.tasks.jvm
+
+import java.nio.file.FileSystem
+import java.nio.file.FileSystems
+import java.nio.file.Path
+
+/**
+ * CompilationArgs collects the arguments for executing the Kotlin compiler.
+ */
+internal class CompilationArgs(
+  val args: MutableList<String> = mutableListOf(),
+  private val dfs: FileSystem = FileSystems.getDefault()
+) {
+
+  fun givenNotEmpty(value: String, map: (String) -> Collection<String>): CompilationArgs {
+    if (value.isNotEmpty()) {
+      return values(map(value))
+    }
+    return this
+  }
+
+  fun absolutePaths(
+    paths: Collection<String>,
+    toArgs: (Sequence<Path>) -> String
+  ): CompilationArgs {
+    return value(toArgs(paths.asSequence().map { dfs.getPath(it) }.map(Path::toAbsolutePath)))
+  }
+
+  fun value(value: String): CompilationArgs {
+    args.add(value)
+    return this
+  }
+
+  fun flag(value: String): CompilationArgs {
+    args.add(value)
+    return this
+  }
+
+  fun flag(flag: String, value: String): CompilationArgs {
+    args.add(flag)
+    args.add(value)
+    return this
+  }
+
+  fun values(values: Collection<String>): CompilationArgs {
+    args.addAll(values)
+    return this
+  }
+
+  fun list(): List<String> = args.toList()
+}

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -17,7 +17,6 @@
 // Provides extensions for the JvmCompilationTask protocol buffer.
 package io.bazel.kotlin.builder.tasks.jvm
 
-import io.bazel.kotlin.builder.toolchain.CompilationStatusException
 import io.bazel.kotlin.builder.toolchain.CompilationTaskContext
 import io.bazel.kotlin.builder.toolchain.KotlinCompilerPluginArgsEncoder
 import io.bazel.kotlin.builder.toolchain.KotlinToolchain
@@ -27,38 +26,31 @@ import io.bazel.kotlin.builder.utils.ensureDirectories
 import io.bazel.kotlin.builder.utils.jars.JarCreator
 import io.bazel.kotlin.builder.utils.jars.SourceJarCreator
 import io.bazel.kotlin.builder.utils.jars.SourceJarExtractor
-import io.bazel.kotlin.builder.utils.joinedClasspath
 import io.bazel.kotlin.builder.utils.partitionJvmSources
 import io.bazel.kotlin.model.JvmCompilationTask
 import java.io.File
 import java.nio.file.Files
+import java.nio.file.Path
 import java.nio.file.Paths
 
 /**
  * Return a list with the common arguments.
  */
-internal fun JvmCompilationTask.getCommonArgs(): MutableList<String> {
-  val friendPaths = info.friendPathsList.map { Paths.get(it).toAbsolutePath() }
-  val args = mutableListOf<String>()
-  args.addAll(baseArgs() + listOf(
-      "-Xfriend-paths=${friendPaths.joinToString(X_FRIENDS_PATH_SEPARATOR)}",
-      "-d", directories.classes))
-  info.passthroughFlags?.takeIf { it.isNotBlank() }?.let { args.addAll(it.split(" ")) }
-  return args
-}
+internal fun JvmCompilationTask.commonArgs(): CompilationArgs = baseArgs()
+    .absolutePaths(info.friendPathsList) {
+      "-Xfriend-paths=${it.joinToString(X_FRIENDS_PATH_SEPARATOR)}"
+    }
+    .flag("-d", directories.classes)
+    .givenNotEmpty(info.passthroughFlags) { it.split(" ") }
 
-internal fun JvmCompilationTask.baseArgs(): List<String> {
-  return listOf(
-      "-cp", inputs.joinedClasspath
-      .split(File.pathSeparator)
-      .map { Paths.get(it).toAbsolutePath() }
-      .joinToString(File.pathSeparator),
-      "-api-version", info.toolchainInfo.common.apiVersion,
-      "-language-version", info.toolchainInfo.common.languageVersion,
-      "-jvm-target", info.toolchainInfo.jvm.jvmTarget,
-      "-module-name", info.moduleName
-  )
-}
+internal fun JvmCompilationTask.baseArgs(): CompilationArgs = CompilationArgs()
+    .flag("-cp").absolutePaths(inputs.classpathList) {
+      it.map(Path::toString).joinToString(File.pathSeparator)
+    }
+    .flag("-api-version", info.toolchainInfo.common.apiVersion)
+    .flag("-language-version", info.toolchainInfo.common.languageVersion)
+    .flag("-jvm-target", info.toolchainInfo.jvm.jvmTarget)
+    .flag("-module-name", info.moduleName)
 
 internal fun JvmCompilationTask.preProcessingSteps(context: CompilationTaskContext): JvmCompilationTask {
   ensureDirectories(
@@ -103,23 +95,22 @@ internal fun JvmCompilationTask.runAnnotationProcessors(
   } else {
     return context.execute("kapt (${inputs.processorsList.joinToString(", ")})")
     {
-      getCommonArgs().let { args ->
-        args.addAll(pluginArgsEncoder.encode(context,
-            this))
-        args.addAll(inputs.kotlinSourcesList)
-        args.addAll(inputs.javaSourcesList)
-        context.executeCompilerTask(
-            args,
-            compiler::compile,
-            printOnSuccess = context.whenTracing { false } ?: true)
-      }.let { outputLines ->
-        // if tracing is enabled the output should be formatted in a special way, if we aren't tracing then any
-        // compiler output would make it's way to the console as is.
-        context.whenTracing {
-          printLines("kapt output", outputLines)
-        }
-        expandWithGeneratedSources()
-      }
+      commonArgs()
+          .values(pluginArgsEncoder.encode(context, this))
+          .values(inputs.kotlinSourcesList)
+          .values(inputs.javaSourcesList).list().let { args ->
+            context.executeCompilerTask(
+                args,
+                compiler::compile,
+                printOnSuccess = context.whenTracing { false } ?: true)
+          }.let { outputLines ->
+            // if tracing is enabled the output should be formatted in a special way, if we aren't
+            // tracing then any compiler output would make it's way to the console as is.
+            context.whenTracing {
+              printLines("kapt output", outputLines)
+            }
+            return@let expandWithGeneratedSources()
+          }
     }
   }
 }
@@ -147,11 +138,12 @@ internal fun JvmCompilationTask.compileKotlin(
   compiler: KotlinToolchain.KotlincInvoker,
   printOnFail: Boolean = true
 ) =
-    getCommonArgs().let { args ->
-      args.addAll(inputs.javaSourcesList)
-      args.addAll(inputs.kotlinSourcesList)
-      context.executeCompilerTask(args, compiler::compile, printOnFail = printOnFail)
-    }
+    commonArgs()
+        .values(inputs.javaSourcesList)
+        .values(inputs.kotlinSourcesList)
+        .list().let { args ->
+          return@let context.executeCompilerTask(args, compiler::compile, printOnFail = printOnFail)
+        }
 
 /**
  * If any srcjars were provided expand the jars sources and create a new [JvmCompilationTask] with the

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -22,7 +22,6 @@ import io.bazel.kotlin.builder.toolchain.CompilationTaskContext
 import io.bazel.kotlin.builder.toolchain.KotlinCompilerPluginArgsEncoder
 import io.bazel.kotlin.builder.toolchain.KotlinToolchain
 import io.bazel.kotlin.builder.utils.IS_JVM_SOURCE_FILE
-import io.bazel.kotlin.builder.utils.addAll
 import io.bazel.kotlin.builder.utils.bazelRuleKind
 import io.bazel.kotlin.builder.utils.ensureDirectories
 import io.bazel.kotlin.builder.utils.jars.JarCreator
@@ -39,41 +38,36 @@ import java.nio.file.Paths
  * Return a list with the common arguments.
  */
 internal fun JvmCompilationTask.getCommonArgs(): MutableList<String> {
-  val args = mutableListOf<String>()
   val friendPaths = info.friendPathsList.map { Paths.get(it).toAbsolutePath() }
-  val cp = inputs.joinedClasspath
-      .split(File.pathSeparator)
-      .map { Paths.get(it).toAbsolutePath() }
-      .joinToString(File.pathSeparator)
-  args.addAll(
-      "-cp", cp,
-      "-api-version", info.toolchainInfo.common.apiVersion,
-      "-language-version", info.toolchainInfo.common.languageVersion,
-      "-jvm-target", info.toolchainInfo.jvm.jvmTarget,
-      "-Xfriend-paths=${friendPaths.joinToString(X_FRIENDS_PATH_SEPARATOR)}"
-  )
-  args
-      .addAll("-module-name", info.moduleName)
-      .addAll("-d", directories.classes)
-
-  info.passthroughFlags?.takeIf { it.isNotBlank() }?.also { args.addAll(it.split(" ")) }
+  val args = mutableListOf<String>()
+  args.addAll(baseArgs() + listOf(
+      "-Xfriend-paths=${friendPaths.joinToString(X_FRIENDS_PATH_SEPARATOR)}",
+      "-d", directories.classes))
+  info.passthroughFlags?.takeIf { it.isNotBlank() }?.let { args.addAll(it.split(" ")) }
   return args
 }
 
-internal fun JvmCompilationTask.preProcessingSteps(
-  context: CompilationTaskContext,
-  pluginArgsEncoder: KotlinCompilerPluginArgsEncoder,
-  compiler: KotlinToolchain.KotlincInvoker
-): JvmCompilationTask {
+internal fun JvmCompilationTask.baseArgs(): List<String> {
+  return listOf(
+      "-cp", inputs.joinedClasspath
+      .split(File.pathSeparator)
+      .map { Paths.get(it).toAbsolutePath() }
+      .joinToString(File.pathSeparator),
+      "-api-version", info.toolchainInfo.common.apiVersion,
+      "-language-version", info.toolchainInfo.common.languageVersion,
+      "-jvm-target", info.toolchainInfo.jvm.jvmTarget,
+      "-module-name", info.moduleName
+  )
+}
+
+internal fun JvmCompilationTask.preProcessingSteps(context: CompilationTaskContext): JvmCompilationTask {
   ensureDirectories(
       directories.temp,
       directories.generatedSources,
-      directories.generatedClasses
+      directories.generatedClasses,
+      directories.classes
   )
-  val taskWithAdditionalSources = context.execute("expand sources") { expandWithSourceJarSources() }
-  return context.execute({
-    "kapt (${inputs.processorsList.joinToString(", ")})"
-  }) { taskWithAdditionalSources.runAnnotationProcessors(context, pluginArgsEncoder, compiler) }
+  return context.execute("expand sources") { expandWithSourceJarSources() }
 }
 
 internal fun JvmCompilationTask.produceSourceJar() {
@@ -99,34 +93,26 @@ internal fun JvmCompilationTask.produceSourceJar() {
   }
 }
 
-internal fun JvmCompilationTask.runAnnotationProcessor(
-  context: CompilationTaskContext,
-  pluginArgsEncoder: KotlinCompilerPluginArgsEncoder,
-  compiler: KotlinToolchain.KotlincInvoker,
-  printOnSuccess: Boolean = true
-): List<String> {
-  check(inputs.processorsList.isNotEmpty()) { "method called without annotation processors" }
-  return getCommonArgs().let { args ->
-    args.addAll(pluginArgsEncoder.encode(context, this))
-    args.addAll(inputs.kotlinSourcesList)
-    args.addAll(inputs.javaSourcesList)
-    context.executeCompilerTask(args, compiler::compile, printOnSuccess = printOnSuccess)
-  }
-}
-
 internal fun JvmCompilationTask.runAnnotationProcessors(
   context: CompilationTaskContext,
   pluginArgsEncoder: KotlinCompilerPluginArgsEncoder,
   compiler: KotlinToolchain.KotlincInvoker
-): JvmCompilationTask =
-    if (inputs.processorsList.isEmpty()) {
-      this
-    } else {
-      runAnnotationProcessor(
-          context,
-          pluginArgsEncoder,
-          compiler,
-          printOnSuccess = context.whenTracing { false } ?: true).let { outputLines ->
+): JvmCompilationTask {
+  if (inputs.processorsList.isEmpty()) {
+    return this
+  } else {
+    return context.execute("kapt (${inputs.processorsList.joinToString(", ")})")
+    {
+      getCommonArgs().let { args ->
+        args.addAll(pluginArgsEncoder.encode(context,
+            this))
+        args.addAll(inputs.kotlinSourcesList)
+        args.addAll(inputs.javaSourcesList)
+        context.executeCompilerTask(
+            args,
+            compiler::compile,
+            printOnSuccess = context.whenTracing { false } ?: true)
+      }.let { outputLines ->
         // if tracing is enabled the output should be formatted in a special way, if we aren't tracing then any
         // compiler output would make it's way to the console as is.
         context.whenTracing {
@@ -135,6 +121,8 @@ internal fun JvmCompilationTask.runAnnotationProcessors(
         expandWithGeneratedSources()
       }
     }
+  }
+}
 
 /**
  * Produce the primary output jar.
@@ -150,32 +138,6 @@ internal fun JvmCompilationTask.createOutputJar() =
       it.setJarOwner(info.label, info.bazelRuleKind)
       it.execute()
     }
-
-internal fun JvmCompilationTask.compileAll(
-  context: CompilationTaskContext,
-  compiler: KotlinToolchain.KotlincInvoker,
-  javaCompiler: JavaCompiler
-) {
-  ensureDirectories(
-      directories.classes
-  )
-  var kotlinError: CompilationStatusException? = null
-  var result: List<String>? = null
-  context.execute("kotlinc") {
-    result = try {
-      compileKotlin(context, compiler, printOnFail = false)
-    } catch (ex: CompilationStatusException) {
-      kotlinError = ex
-      ex.lines
-    }
-  }
-  try {
-    context.execute("javac") { javaCompiler.compile(context, this) }
-  } finally {
-    checkNotNull(result).also(context::printCompilerOutput)
-    kotlinError?.also { throw it }
-  }
-}
 
 /**
  * Compiles Kotlin sources to classes. Does not compile Java sources.
@@ -220,14 +182,14 @@ internal fun JvmCompilationTask.expandWithGeneratedSources(): JvmCompilationTask
             .iterator()
     )
 
-internal fun JvmCompilationTask.expandWithSources(sources: Iterator<String>): JvmCompilationTask =
+private fun JvmCompilationTask.expandWithSources(sources: Iterator<String>): JvmCompilationTask =
     updateBuilder { builder ->
       sources.partitionJvmSources(
           { builder.inputsBuilder.addKotlinSources(it) },
           { builder.inputsBuilder.addJavaSources(it) })
     }
 
-internal fun JvmCompilationTask.updateBuilder(
+private fun JvmCompilationTask.updateBuilder(
   block: (JvmCompilationTask.Builder) -> Unit
 ): JvmCompilationTask =
     toBuilder().let {

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/ArgMap.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/ArgMap.kt
@@ -25,8 +25,13 @@ class ArgMap(private val map: Map<String, List<String>>) {
   private fun mandatorySingle(key: String): String =
       optionalSingle(key) ?: throw IllegalArgumentException("$key is not optional")
 
-  private fun labelDepMap(key: String) = optional(key)?.asSequence()?.windowed(2,
-      2)?.map { it[0] to it[1] }?.toMap() ?: emptyMap()
+  private fun labelDepMap(key: String) =
+      optional(key)
+          ?.asSequence()
+          ?.windowed(2, 2)
+          ?.map { it[0] to it[1] }
+          ?.toMap()
+          ?: emptyMap()
 
   private fun optionalSingle(key: String): String? =
       optional(key)?.let {
@@ -46,11 +51,11 @@ class ArgMap(private val map: Map<String, List<String>>) {
   }
 
   private fun hasAll(keys: Array<String>): Boolean {
-    return keys.all { optional(it)?.isNotEmpty()?:false }
+    return keys.all { optional(it)?.isNotEmpty() ?: false }
   }
 
   private fun hasAny(keys: Array<String>): Boolean {
-    return keys.any { optional(it)?.isNotEmpty()?:false }
+    return keys.any { optional(it)?.isNotEmpty() ?: false }
   }
 
   private fun mandatory(key: String): List<String> = optional(key)

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/ArgMap.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/ArgMap.kt
@@ -19,61 +19,92 @@ package io.bazel.kotlin.builder.utils
 import java.io.File
 
 class ArgMap(private val map: Map<String, List<String>>) {
-    /**
-     * Get the mandatory single value from a key
-     */
-    fun mandatorySingle(key: String): String =
-        optionalSingle(key) ?: throw IllegalArgumentException("$key is not optional")
+  /**
+   * Get the mandatory single value from a key
+   */
+  private fun mandatorySingle(key: String): String =
+      optionalSingle(key) ?: throw IllegalArgumentException("$key is not optional")
 
-    fun labelDepMap(key: String) = optional(key)?.asSequence()?.windowed(2, 2)?.map { it[0] to it[1] }?.toMap() ?: emptyMap()
+  private fun labelDepMap(key: String) = optional(key)?.asSequence()?.windowed(2,
+      2)?.map { it[0] to it[1] }?.toMap() ?: emptyMap()
 
-    fun optionalSingle(key: String): String? =
-        optional(key)?.let {
-            when (it.size) {
-                0 -> throw IllegalArgumentException("$key did not have a value")
-                1 -> it[0]
-                else -> throw IllegalArgumentException("$key should have a single value")
-            }
+  private fun optionalSingle(key: String): String? =
+      optional(key)?.let {
+        when (it.size) {
+          0 -> throw IllegalArgumentException("$key did not have a value")
+          1 -> it[0]
+          else -> throw IllegalArgumentException("$key should have a single value")
         }
+      }
 
-    fun mandatory(key: String): List<String> = optional(key) ?: throw IllegalArgumentException("$key is not optional")
-    fun optional(key: String): List<String>? = map[key]
+  private fun optionalSingleIf(key: String, condition: () -> Boolean): String? {
+    return if (condition()) {
+      optionalSingle(key)
+    } else {
+      mandatorySingle(key)
+    }
+  }
+
+  private fun hasAll(keys: Array<String>): Boolean {
+    return keys.all { optional(it)?.isNotEmpty()?:false }
+  }
+
+  private fun hasAny(keys: Array<String>): Boolean {
+    return keys.any { optional(it)?.isNotEmpty()?:false }
+  }
+
+  private fun mandatory(key: String): List<String> = optional(key)
+      ?: throw IllegalArgumentException(
+          "$key is not optional")
+
+  private fun optional(key: String): List<String>? = map[key]
+
+  fun mandatorySingle(key: Flag) = mandatorySingle(key.flag)
+  fun optionalSingle(key: Flag) = optionalSingle(key.flag)
+  fun optionalSingleIf(key: Flag, condition: () -> Boolean) =
+      optionalSingleIf(key.flag, condition)
+
+  fun hasAll(vararg keys: Flag) = hasAll(keys.map(Flag::flag).toTypedArray())
+  fun hasAny(vararg keys: Flag) = hasAny(keys.map(Flag::flag).toTypedArray())
+  fun mandatory(key: Flag) = mandatory(key.flag)
+  fun optional(key: Flag) = optional(key.flag)
+  fun labelDepMap(key: Flag) = labelDepMap(key.flag)
+
 }
 
 interface Flag {
-    val flag: String
+  val flag: String
 }
 
-fun ArgMap.mandatorySingle(key: Flag) = mandatorySingle(key.flag)
-fun ArgMap.optionalSingle(key: Flag) = optionalSingle(key.flag)
-fun ArgMap.mandatory(key: Flag) = mandatory(key.flag)
-fun ArgMap.optional(key: Flag) = optional(key.flag)
-fun ArgMap.labelDepMap(key: Flag) = labelDepMap(key.flag)
-
 object ArgMaps {
-    @JvmStatic
-    fun from(args: List<String>): ArgMap =
-        mutableMapOf<String, MutableList<String>>()
-            .also { argsToMap(args, it) }
-            .let(::ArgMap)
+  @JvmStatic
+  fun from(args: List<String>): ArgMap =
+      mutableMapOf<String, MutableList<String>>()
+          .also { argsToMap(args, it) }
+          .let(::ArgMap)
 
-    @JvmStatic
-    fun from(file: File): ArgMap = from(file.reader().readLines())
+  @JvmStatic
+  fun from(file: File): ArgMap = from(file.reader().readLines())
 
-    private fun argsToMap(args: List<String>, argMap: MutableMap<String, MutableList<String>>, isFlag: (String) -> Boolean = { it.startsWith("--") }) {
-        var currentKey: String = args.first().also { require(isFlag(it)) { "first arg must be a flag" } }
-        val currentValue = mutableListOf<String>()
-        val mergeCurrent = {
-            argMap.computeIfAbsent(currentKey) { mutableListOf() }.addAll(currentValue)
-            currentValue.clear()
-        }
-        args.drop(1).forEach {
-            if (it.startsWith("--")) {
-                mergeCurrent()
-                currentKey = it
-            } else {
-                currentValue.add(it)
-            }
-        }.also { mergeCurrent() }
+  private fun argsToMap(
+    args: List<String>,
+    argMap: MutableMap<String, MutableList<String>>,
+    isFlag: (String) -> Boolean = { it.startsWith("--") }
+  ) {
+    var currentKey: String =
+        args.first().also { require(isFlag(it)) { "first arg must be a flag" } }
+    val currentValue = mutableListOf<String>()
+    val mergeCurrent = {
+      argMap.computeIfAbsent(currentKey) { mutableListOf() }.addAll(currentValue)
+      currentValue.clear()
     }
+    args.drop(1).forEach {
+      if (it.startsWith("--")) {
+        mergeCurrent()
+        currentKey = it
+      } else {
+        currentValue.add(it)
+      }
+    }.also { mergeCurrent() }
+  }
 }

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinAbstractTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinAbstractTestBuilder.java
@@ -17,9 +17,19 @@ package io.bazel.kotlin.builder;
 
 import io.bazel.kotlin.builder.toolchain.CompilationStatusException;
 import io.bazel.kotlin.builder.toolchain.CompilationTaskContext;
-import io.bazel.kotlin.model.*;
-
-import java.io.*;
+import io.bazel.kotlin.model.CompilationTaskInfo;
+import io.bazel.kotlin.model.KotlinToolchainInfo;
+import io.bazel.kotlin.model.Platform;
+import io.bazel.kotlin.model.RuleKind;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.io.UncheckedIOException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -38,7 +48,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 abstract class KotlinAbstractTestBuilder<T> {
   private static final Path BAZEL_TEST_DIR =
-      Paths.get(Objects.requireNonNull(System.getenv("TEST_TMPDIR")));
+      FileSystems.getDefault().getPath(System.getenv("TEST_TMPDIR"));
 
   private static final AtomicInteger counter = new AtomicInteger(0);
   private final CompilationTaskInfo.Builder infoBuilder = CompilationTaskInfo.newBuilder();
@@ -80,7 +90,7 @@ abstract class KotlinAbstractTestBuilder<T> {
                         .setLanguageVersion("1.2"))
                 .setJvm(KotlinToolchainInfo.Jvm.newBuilder().setJvmTarget("1.8")));
     try {
-      this.instanceRoot = Files.createDirectory(BAZEL_TEST_DIR.resolve(Paths.get(label)));
+      this.instanceRoot = Files.createTempDirectory(BAZEL_TEST_DIR, label);
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -19,23 +19,25 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import io.bazel.kotlin.builder.Deps.AnnotationProcessor;
 import io.bazel.kotlin.builder.Deps.Dep;
+import io.bazel.kotlin.builder.toolchain.CompilationTaskContext;
 import io.bazel.kotlin.builder.toolchain.KotlinToolchain;
 import io.bazel.kotlin.model.CompilationTaskInfo;
 import io.bazel.kotlin.model.JvmCompilationTask;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCompilationTask> {
+
   @SuppressWarnings({"unused", "WeakerAccess"})
   public static Dep
       KOTLIN_ANNOTATIONS = Dep.fromLabel("@com_github_jetbrains_kotlin//:annotations"),
       KOTLIN_STDLIB = Dep.fromLabel("@com_github_jetbrains_kotlin//:kotlin-stdlib"),
       KOTLIN_STDLIB_JDK7 = Dep.fromLabel("@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk7"),
-      KOTLIN_STDLIB_JDK8 = Dep.fromLabel("@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8"),
-      JVM_ABI_GEN = Dep.fromLabel("//src/main/kotlin:jvm-abi-gen");
+      KOTLIN_STDLIB_JDK8 = Dep.fromLabel("@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8");
 
   private static final JvmCompilationTask.Builder taskBuilder = JvmCompilationTask.newBuilder();
   private static final EnumSet<DirectoryType> ALL_DIRECTORY_TYPES =
@@ -59,17 +61,52 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
         .setTemp(directory(DirectoryType.TEMP).toAbsolutePath().toString())
         .setGeneratedClasses(
             directory(DirectoryType.GENERATED_CLASSES).toAbsolutePath().toString());
-
-    taskBuilder
-        .getOutputsBuilder()
-        .setJar(instanceRoot().resolve("jar_file.jar").toAbsolutePath().toString())
-        .setJdeps(instanceRoot().resolve("jdeps_file.jdeps").toAbsolutePath().toString())
-        .setSrcjar(instanceRoot().resolve("jar_file-sources.jar").toAbsolutePath().toString());
   }
 
   @Override
   public JvmCompilationTask buildTask() {
     return taskBuilder.build();
+  }
+
+  private TaskBuilder taskBuilderInstance = new TaskBuilder();
+
+  @SafeVarargs
+  public final Dep runCompileTask(Consumer<TaskBuilder>... setup) {
+    return executeTask(component().jvmTaskExecutor()::execute, setup);
+  }
+
+  private KotlinBuilderComponent component() {
+    return DaggerKotlinBuilderComponent.builder()
+        .toolchain(KotlinToolchain.createToolchain())
+        .build();
+  }
+
+  private Dep executeTask(
+      BiConsumer<CompilationTaskContext, JvmCompilationTask> executor,
+      Consumer<TaskBuilder>[] setup) {
+    resetForNext();
+    Stream.of(setup).forEach(it -> it.accept(taskBuilderInstance));
+    return runCompileTask(
+        (taskContext, task) -> {
+          executor.accept(taskContext, task);
+
+          JvmCompilationTask.Outputs outputs = task.getOutputs();
+          assertFilesExist(
+              Stream.of(
+                  outputs.getJar(),
+                  outputs.getJdeps(),
+                  outputs.getSrcjar())
+                  .filter(p -> !p.isEmpty())
+                  .toArray(String[]::new)
+          );
+
+          return Dep.builder()
+              .label(taskBuilder.getInfo().getLabel())
+              .compileJars(ImmutableList.of(outputs.getJar()))
+              .runtimeDeps(ImmutableList.copyOf(taskBuilder.getInputs().getClasspathList()))
+              .sourceJar(taskBuilder.getOutputs().getSrcjar())
+              .build();
+        });
   }
 
   public class TaskBuilder {
@@ -109,24 +146,23 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
       Dep.classpathOf(dependencies)
           .forEach((dependency) -> taskBuilder.getInputsBuilder().addClasspath(dependency));
     }
-  }
 
-  private TaskBuilder taskBuilderInstance = new TaskBuilder();
+    public TaskBuilder outputSrcJar() {
+      taskBuilder.getOutputsBuilder()
+          .setSrcjar(instanceRoot().resolve("jar_file-sources.jar").toAbsolutePath().toString());
+      return this;
+    }
 
-  @SafeVarargs
-  public final Dep runCompileTask(Consumer<TaskBuilder>... setup) {
-    resetForNext();
-    Stream.of(setup).forEach(it -> it.accept(taskBuilderInstance));
-    return runCompileTask(
-        (taskContext, task) -> {
-          component.jvmTaskExecutor().execute(taskContext, task);
-          assertFilesExist(task.getOutputs().getJar(), task.getOutputs().getJdeps());
-          return Dep.builder()
-              .label(taskBuilder.getInfo().getLabel())
-              .compileJars(ImmutableList.of(taskBuilder.getOutputs().getJar()))
-              .runtimeDeps(ImmutableList.copyOf(taskBuilder.getInputs().getClasspathList()))
-              .sourceJar(taskBuilder.getOutputs().getSrcjar())
-              .build();
-        });
+    public TaskBuilder outputJar() {
+      taskBuilder.getOutputsBuilder()
+          .setJar(instanceRoot().resolve("jar_file.jar").toAbsolutePath().toString());
+      return this;
+    }
+
+    public TaskBuilder outputJdeps() {
+      taskBuilder.getOutputsBuilder()
+          .setJdeps(instanceRoot().resolve("jdeps_file.jdeps").toAbsolutePath().toString());
+      return this;
+    }
   }
 }

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -22,7 +22,6 @@ import io.bazel.kotlin.builder.Deps.Dep;
 import io.bazel.kotlin.builder.toolchain.KotlinToolchain;
 import io.bazel.kotlin.model.CompilationTaskInfo;
 import io.bazel.kotlin.model.JvmCompilationTask;
-
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.function.Consumer;
@@ -32,26 +31,13 @@ import java.util.stream.Stream;
 public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCompilationTask> {
   @SuppressWarnings({"unused", "WeakerAccess"})
   public static Dep
-      KOTLIN_ANNOTATIONS =
-          Dep.importJar(
-              "kotlin-annotations",
-              "external/com_github_jetbrains_kotlin/lib/annotations-13.0.jar"),
-      KOTLIN_STDLIB =
-          Dep.importJar(
-              "kotlin-stdlib", "external/com_github_jetbrains_kotlin/lib/kotlin-stdlib.jar"),
-      KOTLIN_STDLIB_JDK7 =
-          Dep.importJar(
-              "kotlin-stdlib-jdk7",
-              "external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk7.jar"),
-      KOTLIN_STDLIB_JDK8 =
-          Dep.importJar(
-              "kotlin-stdlib-jdk8",
-              "external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk8.jar");
+      KOTLIN_ANNOTATIONS = Dep.fromLabel("@com_github_jetbrains_kotlin//:annotations"),
+      KOTLIN_STDLIB = Dep.fromLabel("@com_github_jetbrains_kotlin//:kotlin-stdlib"),
+      KOTLIN_STDLIB_JDK7 = Dep.fromLabel("@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk7"),
+      KOTLIN_STDLIB_JDK8 = Dep.fromLabel("@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8"),
+      JVM_ABI_GEN = Dep.fromLabel("//src/main/kotlin:jvm-abi-gen");
 
   private static final JvmCompilationTask.Builder taskBuilder = JvmCompilationTask.newBuilder();
-  private static final KotlinBuilderComponent component =
-      DaggerKotlinBuilderComponent.builder().toolchain(KotlinToolchain.createToolchain()).build();
-
   private static final EnumSet<DirectoryType> ALL_DIRECTORY_TYPES =
       EnumSet.of(
           DirectoryType.SOURCES,

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmKaptTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmKaptTest.java
@@ -19,35 +19,35 @@ import io.bazel.kotlin.builder.Deps.AnnotationProcessor;
 import io.bazel.kotlin.builder.Deps.Dep;
 import io.bazel.kotlin.builder.DirectoryType;
 import io.bazel.kotlin.builder.KotlinJvmTestBuilder;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
 import java.io.File;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 
 import static io.bazel.kotlin.builder.KotlinJvmTestBuilder.KOTLIN_ANNOTATIONS;
 import static io.bazel.kotlin.builder.KotlinJvmTestBuilder.KOTLIN_STDLIB;
 
 @RunWith(JUnit4.class)
 public class KotlinBuilderJvmKaptTest {
-    private static final Dep AUTO_VALUE_ANNOTATIONS =
-            Dep.importJar(
-                    "autovalue_annotations",
-                    System.getProperty("auto_value_annotations")
-                            .replaceFirst("external" + File.separator, ""));
-    private static final Dep AUTO_VALUE =
-            Dep.importJar(
-                    "autovalue",
-                    System.getProperty("auto_value")
-                            .replaceFirst("external" + File.separator, ""));
-    private static final AnnotationProcessor AUTO_VALUE_ANNOTATION_PROCESSOR =
-            AnnotationProcessor.builder()
-                    .processClass("com.google.auto.value.processor.AutoValueProcessor")
-                    .processorPath(
-                            Dep.classpathOf(AUTO_VALUE_ANNOTATIONS, AUTO_VALUE, KOTLIN_ANNOTATIONS).collect(Collectors.toSet()))
-                    .build();
+  private static final Dep AUTO_VALUE_ANNOTATIONS =
+      Dep.importJar(
+          "autovalue_annotations",
+          System.getProperty("auto_value_annotations")
+              .replaceFirst("external" + File.separator, ""));
+  private static final Dep AUTO_VALUE =
+      Dep.importJar(
+          "autovalue",
+          System.getProperty("auto_value")
+              .replaceFirst("external" + File.separator, ""));
+  private static final AnnotationProcessor AUTO_VALUE_ANNOTATION_PROCESSOR =
+      AnnotationProcessor.builder()
+          .processClass("com.google.auto.value.processor.AutoValueProcessor")
+          .processorPath(
+              Dep.classpathOf(AUTO_VALUE_ANNOTATIONS, AUTO_VALUE, KOTLIN_ANNOTATIONS)
+                  .collect(Collectors.toSet()))
+          .build();
 
   private static final KotlinJvmTestBuilder ctx = new KotlinJvmTestBuilder();
 
@@ -61,24 +61,27 @@ public class KotlinBuilderJvmKaptTest {
   public void testKaptKt() {
     ctx.runCompileTask(
         ADD_AUTO_VALUE_PLUGIN,
-        c ->
-            c.addSource(
-                "TestKtValue.kt",
-                "package autovalue\n"
-                    + "\n"
-                    + "import com.google.auto.value.AutoValue\n"
-                    + "\n"
-                    + "@AutoValue\n"
-                    + "abstract class TestKtValue {\n"
-                    + "    abstract fun name(): String\n"
-                    + "    fun builder(): Builder = AutoValue_TestKtValue.Builder()\n"
-                    + "\n"
-                    + "    @AutoValue.Builder\n"
-                    + "    abstract class Builder {\n"
-                    + "        abstract fun setName(name: String): Builder\n"
-                    + "        abstract fun build(): TestKtValue\n"
-                    + "    }\n"
-                    + "}"));
+        c -> {
+          c.addSource(
+              "TestKtValue.kt",
+              "package autovalue\n"
+                  + "\n"
+                  + "import com.google.auto.value.AutoValue\n"
+                  + "\n"
+                  + "@AutoValue\n"
+                  + "abstract class TestKtValue {\n"
+                  + "    abstract fun name(): String\n"
+                  + "    fun builder(): Builder = AutoValue_TestKtValue.Builder()\n"
+                  + "\n"
+                  + "    @AutoValue.Builder\n"
+                  + "    abstract class Builder {\n"
+                  + "        abstract fun setName(name: String): Builder\n"
+                  + "        abstract fun build(): TestKtValue\n"
+                  + "    }\n"
+                  + "}");
+          c.outputJar().outputSrcJar();
+        }
+    );
 
     ctx.assertFilesExist(
         DirectoryType.CLASSES,
@@ -91,8 +94,8 @@ public class KotlinBuilderJvmKaptTest {
   public void testMixedKaptBiReferences() {
     ctx.runCompileTask(
         ADD_AUTO_VALUE_PLUGIN,
-        it -> {
-          it.addSource(
+        ctx -> {
+          ctx.addSource(
               "TestKtValue.kt",
               "package autovalue.a\n"
                   + "\n"
@@ -111,7 +114,7 @@ public class KotlinBuilderJvmKaptTest {
                   + "    }\n"
                   + "}");
 
-          it.addSource(
+          ctx.addSource(
               "TestAutoValue.java",
               "package autovalue.b;\n"
                   + "\n"
@@ -134,6 +137,7 @@ public class KotlinBuilderJvmKaptTest {
                   + "    }\n"
                   + "\n"
                   + "}");
+          ctx.outputJar().outputSrcJar();
         });
     ctx.assertFilesExist(
         DirectoryType.SOURCE_GEN,

--- a/src/test/kotlin/io/bazel/kotlin/defs.bzl
+++ b/src/test/kotlin/io/bazel/kotlin/defs.bzl
@@ -30,7 +30,6 @@ def kt_rules_test(name, **kwargs):
     args.setdefault("jvm_flags", [])
     args["deps"] = args.setdefault("deps", []) + ["//src/test/kotlin/io/bazel/kotlin/builder:test_lib"]
     for dep in [
-        "//src/main/kotlin:jvm-abi-gen",
         "//src/main/kotlin/io/bazel/kotlin/compiler",
         "@com_github_jetbrains_kotlin//:annotations",
         "@com_github_jetbrains_kotlin//:kotlin-stdlib",

--- a/src/test/kotlin/io/bazel/kotlin/defs.bzl
+++ b/src/test/kotlin/io/bazel/kotlin/defs.bzl
@@ -24,14 +24,29 @@ def _get_class_name(kwargs):
         return kwargs["test_classes"]
 
 def kt_rules_test(name, **kwargs):
-    kwargs.setdefault("size", "small")
-    kwargs["deps"] = kwargs.setdefault("deps", []) + ["//src/test/kotlin/io/bazel/kotlin/builder:test_lib"]
-    kwargs.setdefault("test_class", _get_class_name(kwargs))
-    for f in kwargs.get("srcs"):
+    args = dict(kwargs.items())
+    args.setdefault("size", "small")
+    args.setdefault("data", [])
+    args.setdefault("jvm_flags", [])
+    args["deps"] = args.setdefault("deps", []) + ["//src/test/kotlin/io/bazel/kotlin/builder:test_lib"]
+    for dep in [
+        "//src/main/kotlin:jvm-abi-gen",
+        "//src/main/kotlin/io/bazel/kotlin/compiler",
+        "@com_github_jetbrains_kotlin//:annotations",
+        "@com_github_jetbrains_kotlin//:kotlin-stdlib",
+        "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk7",
+        "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8",
+    ] + args["data"]:
+        if dep not in args["data"]:
+            args["data"] += [dep]
+        args["jvm_flags"] += ["-D%s=$(rootpath %s)" %(dep.replace("/",".").replace(":","."), dep)]
+
+    args.setdefault("test_class", _get_class_name(kwargs))
+    for f in args.get("srcs"):
         if f.endswith(".kt"):
-            kt_jvm_test(name = name, **kwargs)
+            kt_jvm_test(name = name, **args)
             return
-    java_test(name = name, **kwargs)
+    java_test(name = name, **args)
 
 def kt_rules_e2e_test(name, **kwargs):
     kwargs.setdefault("size", "small")


### PR DESCRIPTION
Changes the builder to be more intelligent about work execution: If an output is not requested, it is not created

Jdeps output is now optional, as it is not currently consumed.

Fix for java_test runfiles and kt_jvm_import. native rules consume runfiles in a separate private provider, to ensure that *all* starlark runfiles are picked up, each starlark rule should create runfiles.

Depends on: /bazelbuild/rules_kotlin/pull/290