### PR TITLE
Fix missing plugin inputs

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -225,6 +225,7 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
     friend = _compiler_friends(ctx, friends = getattr(ctx.attr, "friends", []))
     compile_deps = _compiler_deps(toolchains, friend, deps = ctx.attr.deps + ctx.attr.plugins)
     annotation_processors = _plugin_mappers.targets_to_annotation_processors(ctx.attr.plugins + ctx.attr.deps)
+    transitive_runtime_jars = _plugin_mappers.targets_to_transitive_runtime_jars(ctx.attr.plugins + ctx.attr.deps)
     plugins = ctx.attr.plugins
 
     _run_kt_builder_action(
@@ -236,6 +237,7 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
         friend = friend,
         compile_deps = compile_deps,
         annotation_processors = annotation_processors,
+        transitive_runtime_jars = transitive_runtime_jars,
         plugins = plugins,
         outputs = {
             "output": output_jar,
@@ -271,7 +273,7 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
         ),
     )
 
-def _run_kt_builder_action(ctx, rule_kind, toolchains, dirs, srcs, friend, compile_deps, annotation_processors, plugins, outputs):
+def _run_kt_builder_action(ctx, rule_kind, toolchains, dirs, srcs, friend, compile_deps, annotation_processors, transitive_runtime_jars, plugins, outputs):
     """Creates a KotlinBuilder action invocation."""
     args = _utils.init_args(ctx, rule_kind, friend.module_name)
 
@@ -327,7 +329,7 @@ def _run_kt_builder_action(ctx, rule_kind, toolchains, dirs, srcs, friend, compi
         mnemonic = "KotlinCompile",
         inputs = depset(
             ctx.files.srcs,
-            transitive = [compile_deps.compile_jars] + [ap.classpath for ap in annotation_processors.to_list()]),
+            transitive = [compile_deps.compile_jars, transitive_runtime_jars]),
         tools = tools,
         input_manifests = input_manifests,
         outputs = [f for f in outputs.values()],

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -327,7 +327,7 @@ def _run_kt_builder_action(ctx, rule_kind, toolchains, dirs, srcs, friend, compi
         mnemonic = "KotlinCompile",
         inputs = depset(
             ctx.files.srcs,
-            transitive = [compile_deps.compile_jars] + [ap.classpath for ap in annotation_processors]),
+            transitive = [compile_deps.compile_jars] + [ap.classpath for ap in annotation_processors.to_list()]),
         tools = tools,
         input_manifests = input_manifests,
         outputs = [f for f in outputs.values()],

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -325,7 +325,9 @@ def _run_kt_builder_action(ctx, rule_kind, toolchains, dirs, srcs, friend, compi
 
     ctx.actions.run(
         mnemonic = "KotlinCompile",
-        inputs = depset(ctx.files.srcs, transitive = [compile_deps.compile_jars]),
+        inputs = depset(
+            ctx.files.srcs,
+            transitive = [compile_deps.compile_jars] + [ap.classpath for ap in annotation_processors]),
         tools = tools,
         input_manifests = input_manifests,
         outputs = [f for f in outputs.values()],

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -187,6 +187,7 @@ _common_attr = utils.add_dicts(
             default = [],
             aspects = [_kt_jvm_plugin_aspect],
             providers = [JavaInfo],
+            cfg = "host",
         ),
         "module_name": attr.string(
             doc = """The name of the module, if not provided the module name is derived from the label. --e.g.,


### PR DESCRIPTION
java_plugin runtime jars were not being added to the KotlinCompile action's input list which meant that bazel was not properly ensuring that they were available.

This PR just adds the plugin jars we need to the action input and lets bazel handle the rest.

Before this, kotlin's plugin implementation was fundamentally broken and only worked by chance.