### PR TITLE
Add missing javax.annotation dependency

### DIFF
--- a/examples/plugin/src/serialization/BUILD
+++ b/examples/plugin/src/serialization/BUILD
@@ -3,7 +3,7 @@ load("//kotlin:kotlin.bzl", "kt_compiler_plugin", "kt_jvm_library", "kt_jvm_test
 kt_compiler_plugin(
     name = "serialization_plugin",
     deps = [
-       "@com_github_jetbrains_kotlin//:kotlinx-serialization-compiler-plugin",
+        "@com_github_jetbrains_kotlin//:kotlinx-serialization-compiler-plugin",
     ],
 )
 
@@ -24,8 +24,8 @@ kt_jvm_test(
     test_class = "plugin.serialization.SerializationTest",
     deps = [
         ":data",
-        "@kotlin_rules_maven//:org_jetbrains_kotlinx_kotlinx_serialization_runtime",
         "@com_github_jetbrains_kotlin//:kotlin-reflect",
         "@kotlin_rules_maven//:junit_junit",
+        "@kotlin_rules_maven//:org_jetbrains_kotlinx_kotlinx_serialization_runtime",
     ],
 )

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -330,6 +330,7 @@ def _run_kt_builder_action(ctx, rule_kind, toolchains, dirs, srcs, friend, compi
         inputs = depset(
             ctx.files.srcs,
             transitive = [compile_deps.compile_jars, transitive_runtime_jars]),
+        ),
         tools = tools,
         input_manifests = input_manifests,
         outputs = [f for f in outputs.values()],

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -329,7 +329,7 @@ def _run_kt_builder_action(ctx, rule_kind, toolchains, dirs, srcs, friend, compi
         mnemonic = "KotlinCompile",
         inputs = depset(
             ctx.files.srcs,
-            transitive = [compile_deps.compile_jars, transitive_runtime_jars]),
+            transitive = [compile_deps.compile_jars, transitive_runtime_jars],
         ),
         tools = tools,
         input_manifests = input_manifests,

--- a/kotlin/internal/repositories/setup.bzl
+++ b/kotlin/internal/repositories/setup.bzl
@@ -39,6 +39,7 @@ def kt_configure():
             "com.google.dagger:dagger:2.26",
             "com.google.dagger:dagger-compiler:2.26",
             "com.google.dagger:dagger-producers:2.26",
+            "javax.annotation:javax.annotation-api:1.3.2",
             "javax.inject:javax.inject:1",
             "org.pantsbuild:jarjar:1.7.2",
         ],

--- a/src/main/kotlin/io/bazel/kotlin/builder/BUILD
+++ b/src/main/kotlin/io/bazel/kotlin/builder/BUILD
@@ -31,6 +31,7 @@ java_library(
         "//third_party:dagger",
         "@com_github_jetbrains_kotlin//:annotations",
         "@com_github_jetbrains_kotlin//:kotlin-stdlib",
+        "@kotlin_rules_maven//:javax_annotation_javax_annotation_api",
         "@kotlin_rules_maven//:javax_inject_javax_inject",
     ],
 )

--- a/src/test/kotlin/io/bazel/kotlin/builder/BUILD
+++ b/src/test/kotlin/io/bazel/kotlin/builder/BUILD
@@ -34,9 +34,9 @@ java_library(
         "Deps.java",
         "DirectoryType.java",
         "KotlinAbstractTestBuilder.java",
+        "KotlinBuilderTestComponent.java",
         "KotlinJsTestBuilder.java",
         "KotlinJvmTestBuilder.java",
-        "KotlinBuilderTestComponent.java"
     ],
     data = [
         "//src/main/kotlin/io/bazel/kotlin/compiler",
@@ -52,7 +52,8 @@ java_library(
     deps = _COMMON_DEPS + [
         "//third_party:autovalue",
         "//third_party:dagger",
-        "//src/main/kotlin/io/bazel/kotlin/builder/tasks"
+        "@kotlin_rules_maven//:javax_annotation_javax_annotation_api",
+        "//src/main/kotlin/io/bazel/kotlin/builder/tasks",
     ],
 )
 


### PR DESCRIPTION
Bazel/Dagger integration requires javax.annotation to be on the
classpath to generate @generated annotation.

Recent ErrorProne releases (started from 2.3.3) added new bug pattern:
RefersToDaggerCodegen that is flagging the code as invalid, as it
doesn't realize that the code is generated.

Due to this problem, a previous attemt to bump EP version in Bazel was
reverted. Fixing it would allow us to make another attempt to update
EP version in Bazel.

Test Plan:

A. Involved approach:

1. Bump EP version to 2.3.4
2. Conduct custom java tools release with new EP version
3. Consume custom java tools release in WORKSPACE
4. Try to bulid rule_kotlin would fail with RefersToDaggerCodegen error

B. Simple approach

1. Apply this patch
2. Build rules_kotlin
3. Confirm that this class:
   KotlinBuilderComponent_Module_ProvidePluginArgEncoderFactory
   is annotated with @generated annotation:

@Generated(
    value = "dagger.internal.codegen.ComponentProcessor",
    comments = "https://dagger.dev"
)
@SuppressWarnings({
    "unchecked",
    "rawtypes"
})
public final class KotlinBuilderComponent_Module_ProvidePluginArgEncoderFactory
[...]