### PR TITLE
Fix package names with underscores

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreator.kt
@@ -35,7 +35,7 @@ class SourceJarCreator(
     private const val BL = """\p{Blank}*"""
     private const val COM_BL = """$BL(?:/\*[^\n]*\*/$BL)*"""
     private val PKG_PATTERN: Pattern =
-      Pattern.compile("""^${COM_BL}package$COM_BL([a-zA-Z1-9.]+)$COM_BL(?:;?.*)$""")
+      Pattern.compile("""^${COM_BL}package$COM_BL([a-zA-Z1-9._]+)$COM_BL(?:;?.*)$""")
 
     @JvmStatic
     fun extractPackage(line: String): String? =


### PR DESCRIPTION
Currently `kt_jvm_library` messes up the package path when it contains an underscore (unusual but allowed by Java rules). This adds the underscore to the list of accepted characters for a package.