### PR TITLE
Fix the worker contract.

### DIFF
--- a/.bazelproject
+++ b/.bazelproject
@@ -30,6 +30,7 @@ targets:
   //src/main/kotlin/io/bazel/kotlin/builder/utils:utils_for_ide
   //src/main/kotlin/io/bazel/kotlin/builder/toolchain:toolchain_for_ide
   //src/main/kotlin/io/bazel/kotlin/compiler:compiler_for_ide
+  //kotlin:stardoc
 
 test_sources:
   src/test/*

--- a/kotlin/doc-templates/rule.vm
+++ b/kotlin/doc-templates/rule.vm
@@ -24,7 +24,7 @@ ${util.ruleSummary($ruleName, $ruleInfo)}
 ## print lines, removing common indent.
 #foreach ($ln in $ruleInfo.docString.split("\n"))
     #if ($ln.length() >= $chomp && $ln.substring(0, $chomp).trim().isEmpty())
-        ${ln.substring($chomp)}
+${ln.substring($chomp)}
     #else
         ${ln}
     #end

--- a/kotlin/internal/repositories/setup.bzl
+++ b/kotlin/internal/repositories/setup.bzl
@@ -42,6 +42,9 @@ def kt_configure():
             "com.google.dagger:dagger-producers:2.26",
             "javax.inject:javax.inject:1",
             "org.pantsbuild:jarjar:1.7.2",
+            "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.6",
+            "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.6",
+            "org.jetbrains.kotlinx:kotlinx-coroutines-debug:1.3.6",
         ],
         repositories = [
             "https://maven-central.storage.googleapis.com/repos/central/data/",

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/BazelWorker.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/BazelWorker.kt
@@ -16,23 +16,30 @@
  */
 package io.bazel.kotlin.builder.tasks
 
-import com.google.devtools.build.lib.worker.WorkerProtocol
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse
 import io.bazel.kotlin.builder.utils.WorkingDirectoryContext
 import io.bazel.kotlin.builder.utils.wasInterrupted
+import java.io.BufferedInputStream
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.Closeable
 import java.io.IOException
+import java.io.InputStream
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
+import java.util.logging.Level
+import java.util.logging.Logger
 
 /**
  * Interface for command line programs.
  *
  * This is the same thing as a main function, except not static.
  */
+@FunctionalInterface
 interface CommandLineProgram {
   /**
    * Runs blocking program start to finish.
@@ -56,107 +63,164 @@ interface CommandLineProgram {
  * @param <T> delegate program type
  */
 class BazelWorker(
-  private val delegate: CommandLineProgram,
+  private val commandLineProgram: CommandLineProgram,
   private val output: PrintStream,
   private val mnemonic: String
 ) {
-  companion object {
-    const val OK = 0
-    const val INTERRUPTED_STATUS = 1
-    const val ERROR_STATUS = 2
-  }
 
   fun apply(args: List<String>): Int {
-    return if (args.contains("--persistent_worker"))
-      runAsPersistentWorker()
-    else WorkingDirectoryContext.newContext().use { ctx ->
-      delegate.apply(ctx.dir, loadArguments(args, false))
+    if (args.contains("--persistent_worker")) {
+      return WorkerIO.open().use { io ->
+        PersistentWorker(io, commandLineProgram).run(args)
+      }
+    } else {
+      output.println(
+        "HINT: $mnemonic will compile faster if you run: echo \"build --strategy=$mnemonic=worker\" >>~/.bazelrc"
+      )
+      return WorkerIO.noop().use { io ->
+        InvocationWorker(io, commandLineProgram).run(args)
+      }
+    }
+  }
+}
+
+private fun maybeExpand(args: List<String>): List<String> {
+  if (args.isNotEmpty()) {
+    val lastArg = args[args.size - 1]
+    if (lastArg.startsWith("@")) {
+      val pathElement = lastArg.substring(1)
+      val flagFile = Paths.get(pathElement)
+      try {
+        return Files.readAllLines(flagFile, UTF_8)
+      } catch (e: IOException) {
+        throw RuntimeException(e)
+      }
+    }
+  }
+  return args
+}
+
+/** Defines the common worker interface. */
+interface Worker {
+  fun run(args: List<String>): Int
+}
+
+class WorkerIO(
+  val input: InputStream,
+  val output: PrintStream,
+  val execution: ByteArrayOutputStream,
+  private val restore: () -> Unit
+) : Closeable {
+  companion object {
+    fun open(): WorkerIO {
+      val stdErr = System.err
+      val stdIn = BufferedInputStream(System.`in`)
+      val stdOut = System.out
+      val inputBuffer = ByteArrayInputStream(ByteArray(0))
+      val execution = ByteArrayOutputStream()
+      val outputBuffer = PrintStream(execution)
+
+      // delegate the system defaults to capture execution information
+      System.setErr(outputBuffer)
+      System.setOut(outputBuffer)
+      System.setIn(inputBuffer)
+
+      return WorkerIO(stdIn, stdOut, execution) {
+        System.setOut(stdOut)
+        System.setIn(stdIn)
+        System.setErr(stdErr)
+      }
+    }
+
+    fun noop(): WorkerIO {
+      val inputBuffer = ByteArrayInputStream(ByteArray(0))
+      val execution = ByteArrayOutputStream()
+      val outputBuffer = PrintStream(execution)
+      return WorkerIO(inputBuffer, outputBuffer, execution) {}
     }
   }
 
-  private fun runAsPersistentWorker(): Int {
-    val realStdIn = System.`in`
-    val realStdOut = System.out
-    val realStdErr = System.err
-    try {
-      ByteArrayInputStream(ByteArray(0)).use { emptyIn ->
-        ByteArrayOutputStream().use { buffer ->
-          PrintStream(buffer).use { ps ->
-            System.setIn(emptyIn)
-            System.setOut(ps)
-            System.setErr(ps)
-            val invocationWorker = InvocationWorker(delegate, buffer)
-            while (true) {
-              val status =
-                  WorkerProtocol.WorkRequest.parseDelimitedFrom(realStdIn)?.let { request ->
-                    invocationWorker.invoke(loadArguments(request.argumentsList, true))
-                  }?.also { (status, log) ->
-                    with(WorkerProtocol.WorkResponse.newBuilder()) {
-                      exitCode = status
-                      output = log
-                      build().writeDelimitedTo(realStdOut)
-                    }
-                  }?.let { (status, _) -> status } ?: OK
+  override fun close() {
+    restore.invoke()
+  }
+}
 
-              if (status != OK) {
-                return status
-              }
-              System.gc()
+/** PersistentWorker follows the Bazel worker protocol and executes a CommandLineProgram. */
+class PersistentWorker(
+  private val io: WorkerIO,
+  private val program: CommandLineProgram
+) : Worker {
+  val logger = Logger.getLogger(PersistentWorker::class.java.canonicalName)
+
+  enum class Status {
+    OK, INTERRUPTED, ERROR
+  }
+
+  override fun run(args: List<String>): Int {
+    while (true) {
+      val request = WorkRequest.parseDelimitedFrom(io.input) ?: continue
+
+      val (status, exit) = WorkingDirectoryContext.newContext()
+        .runCatching {
+          request.argumentsList
+            ?.let {
+              maybeExpand(it)
             }
+            .run {
+              Status.OK to program.apply(dir, maybeExpand(request.argumentsList))
+            }
+        }
+        .recover { e: Throwable ->
+          io.execution.write((e.message ?: e.toString()).toByteArray(UTF_8))
+          if (!e.wasInterrupted()) {
+            logger.log(Level.SEVERE,
+                       "ERROR: Worker threw uncaught exception",
+                       e)
+            Status.ERROR to 1
+          } else {
+            Status.INTERRUPTED to 1
           }
         }
-      }
-    } finally {
-      System.setIn(realStdIn)
-      System.setOut(realStdOut)
-      System.setErr(realStdErr)
-    }
-    return OK
-  }
+        .getOrThrow()
 
-  private fun loadArguments(args: List<String>, isWorker: Boolean): List<String> {
-    if (args.isNotEmpty()) {
-      val lastArg = args[args.size - 1]
+      val response = with(WorkResponse.newBuilder()) {
+        output = String(io.execution.toByteArray(), UTF_8)
+        exitCode = exit
+        setRequestId(request.requestId)
+      }.build()
 
-      if (lastArg.startsWith("@")) {
-        val pathElement = lastArg.substring(1)
-        val flagFile = Paths.get(pathElement)
-        if (isWorker && lastArg.startsWith("@@") || Files.exists(flagFile)) {
-          if (!isWorker && mnemonic.isNotEmpty()) {
-            output.printf(
-                "HINT: %s will compile faster if you run: " + "echo \"build --strategy=%s=worker\" >>~/.bazelrc\n",
-                mnemonic, mnemonic
-            )
-          }
-          try {
-            return Files.readAllLines(flagFile, UTF_8)
-          } catch (e: IOException) {
-            throw RuntimeException(e)
-          }
-        }
+      // return the response
+      response.writeDelimitedTo(io.output)
+      io.output.flush()
+
+      // clear execution logs
+      io.execution.reset()
+
+      if (status == Status.INTERRUPTED) {
+        break
       }
     }
-    return args
+    logger.info("Shutting down worker.")
+    return 0
   }
 }
 
 class InvocationWorker(
-  private val delegate: CommandLineProgram,
-  private val buffer: ByteArrayOutputStream
-) {
-
-  fun invoke(args: List<String>): Pair<Int, String> = WorkingDirectoryContext.newContext()
-      .use { wdCtx ->
-        return try {
-          delegate.apply(wdCtx.dir, args)
-        } catch (e: RuntimeException) {
-          if (e.wasInterrupted()) BazelWorker.INTERRUPTED_STATUS
-          else BazelWorker.ERROR_STATUS.also {
-            System.err.println(
-                "ERROR: Worker threw uncaught exception with args: ${args}"
-            )
-            e.printStackTrace(System.err)
-          }
-        } to buffer.toString()
-      }
+  private val io: WorkerIO,
+  private val program: CommandLineProgram
+) : Worker {
+  val logger: Logger = Logger.getLogger(InvocationWorker::class.java.canonicalName)
+  override fun run(args: List<String>): Int {
+    return WorkingDirectoryContext.newContext().runCatching {
+      program.apply(dir, maybeExpand(args))
+    }.recover { e ->
+      logger.log(Level.SEVERE,
+                 "ERROR: Worker threw uncaught exception with args: ${maybeExpand(args)}",
+                 e)
+      1
+    }.also {
+      println(String(io.execution.toByteArray(), UTF_8))
+    }.getOrDefault(0)
+  }
 }
+

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/BazelWorker.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/BazelWorker.kt
@@ -31,7 +31,7 @@ import java.nio.charset.StandardCharsets.UTF_8
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.logging.Level
+import java.util.logging.Level.SEVERE
 import java.util.logging.Logger
 
 /**
@@ -150,7 +150,7 @@ class PersistentWorker(
   private val io: WorkerIO,
   private val program: CommandLineProgram
 ) : Worker {
-  val logger = Logger.getLogger(PersistentWorker::class.java.canonicalName)
+  private val logger = Logger.getLogger(PersistentWorker::class.java.canonicalName)
 
   enum class Status {
     OK, INTERRUPTED, ERROR
@@ -163,9 +163,7 @@ class PersistentWorker(
       val (status, exit) = WorkingDirectoryContext.newContext()
         .runCatching {
           request.argumentsList
-            ?.let {
-              maybeExpand(it)
-            }
+            ?.let { maybeExpand(it) }
             .run {
               Status.OK to program.apply(dir, maybeExpand(request.argumentsList))
             }
@@ -173,7 +171,7 @@ class PersistentWorker(
         .recover { e: Throwable ->
           io.execution.write((e.message ?: e.toString()).toByteArray(UTF_8))
           if (!e.wasInterrupted()) {
-            logger.log(Level.SEVERE,
+            logger.log(SEVERE,
                        "ERROR: Worker threw uncaught exception",
                        e)
             Status.ERROR to 1
@@ -183,10 +181,10 @@ class PersistentWorker(
         }
         .getOrThrow()
 
-      val response = with(WorkResponse.newBuilder()) {
+      val response = WorkResponse.newBuilder().apply {
         output = String(io.execution.toByteArray(), UTF_8)
         exitCode = exit
-        setRequestId(request.requestId)
+        requestId = request.requestId
       }.build()
 
       // return the response
@@ -209,18 +207,20 @@ class InvocationWorker(
   private val io: WorkerIO,
   private val program: CommandLineProgram
 ) : Worker {
-  val logger: Logger = Logger.getLogger(InvocationWorker::class.java.canonicalName)
-  override fun run(args: List<String>): Int {
-    return WorkingDirectoryContext.newContext().runCatching {
-      program.apply(dir, maybeExpand(args))
-    }.recover { e ->
-      logger.log(Level.SEVERE,
+  private val logger: Logger = Logger.getLogger(InvocationWorker::class.java.canonicalName)
+  override fun run(args: List<String>): Int = WorkingDirectoryContext.newContext()
+    .runCatching { program.apply(dir, maybeExpand(args)) }
+    .recover { e ->
+      logger.log(SEVERE,
                  "ERROR: Worker threw uncaught exception with args: ${maybeExpand(args)}",
                  e)
-      1
-    }.also {
+      return@recover 1 // return non-0 exitcode
+    }
+    .also {
+      // print execution log
       println(String(io.execution.toByteArray(), UTF_8))
-    }.getOrDefault(0)
-  }
+    }
+    .getOrDefault(0)
 }
+
 

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 load("//src/test/kotlin/io/bazel/kotlin:defs.bzl", "kt_rules_test")
+load("//kotlin:kotlin.bzl", "kt_jvm_test")
+load("@rules_jvm_external//:defs.bzl", "artifact")
 
 kt_rules_test(
     name = "JdepsParserTest",
@@ -30,6 +32,19 @@ kt_rules_test(
 kt_rules_test(
     name = "KotlinBuilderJvmBasicTest",
     srcs = ["jvm/KotlinBuilderJvmBasicTest.java"],
+)
+
+kt_jvm_test(
+    name = "BazelWorkerTest",
+    srcs = ["BazelWorkerTest.kt"],
+    test_class = "io.bazel.kotlin.builder.tasks.BazelWorkerTest",
+    deps = [
+      "//src/main/kotlin/io/bazel/kotlin/builder/tasks:tasks",
+      "//src/test/kotlin/io/bazel/kotlin/builder:test_lib",
+      artifact("org.jetbrains.kotlinx:kotlinx-coroutines-core", repository_name="kotlin_rules_maven"),
+      artifact("org.jetbrains.kotlinx:kotlinx-coroutines-test", repository_name="kotlin_rules_maven"),
+      artifact("org.jetbrains.kotlinx:kotlinx-coroutines-debug", repository_name="kotlin_rules_maven"),
+    ]
 )
 
 

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -32,6 +32,7 @@ kt_rules_test(
 kt_rules_test(
     name = "KotlinBuilderJvmBasicTest",
     srcs = ["jvm/KotlinBuilderJvmBasicTest.java"],
+    size = "large"
 )
 
 kt_jvm_test(

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BazelWorkerTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BazelWorkerTest.kt
@@ -18,6 +18,7 @@
 package io.bazel.kotlin.builder.tasks
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse
 import kotlinx.coroutines.CoroutineName
@@ -27,10 +28,10 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.sendBlocking
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runBlockingTest
+import kotlinx.coroutines.yield
 import org.junit.Rule
 import org.junit.Test
 import java.io.ByteArrayOutputStream
@@ -68,8 +69,6 @@ class BazelWorkerTest {
 
   @Test
   fun persistentWorker() {
-    val workerInput = WorkerChannel("in")
-    val workerOutput = WorkerChannel("out")
     runBlockingTest {
       val program = object : CommandLineProgram {
         override fun apply(workingDir: Path, args: List<String>): Int {
@@ -83,23 +82,27 @@ class BazelWorkerTest {
         }
       }
 
+      val workerInput = WorkerChannel("in")
+      val workerOutput = WorkerChannel("out")
       val execution = ByteArrayOutputStream()
 
-      val done = GlobalScope.async(CoroutineName("worker")) {
+      val worker = GlobalScope.async(CoroutineName("worker")) {
         WorkerIO(workerInput.input,
                  PrintStream(workerOutput.output),
-                 execution) {}.use { io ->
-          PersistentWorker(io, program).run(listOf())
-        }
+                 execution) {}
+          .use { io ->
+            PersistentWorker(io, program).run(listOf())
+          }
       }
 
-      // asserts scope to ensure all asserts are run.
+      // asserts scope to ensure all cases are run.
       // messy, can be cleaned up -- since kotlin channels love to block and can easily starve a
       // dispatcher, it's necessary to read each channel in a different coroutine.
       // The coroutineScope prevents the assertions from happening outside of the expected
       // asynchronicity.
       coroutineScope {
         launch {
+          assertWithMessage("worker is active").that(worker.isActive).isTrue()
           workerInput.send(request(1, "ok"))
         }
         launch {
@@ -110,6 +113,7 @@ class BazelWorkerTest {
 
       coroutineScope {
         launch {
+          assertWithMessage("worker is active").that(worker.isActive).isTrue()
           workerInput.send(request(2, "fail"))
         }
         launch {
@@ -120,6 +124,7 @@ class BazelWorkerTest {
 
       coroutineScope {
         launch {
+          assertWithMessage("worker is active").that(worker.isActive).isTrue()
           workerInput.send(request(3, "error"))
         }
         launch {
@@ -131,6 +136,7 @@ class BazelWorkerTest {
       // an interrupt kills the worker.
       coroutineScope {
         launch {
+          assertWithMessage("worker is active").that(worker.isActive).isTrue()
           workerInput.send(request(4, "interrupt"))
           workerInput.close()
         }
@@ -140,22 +146,20 @@ class BazelWorkerTest {
         }
       }
 
-
-      assertThat(done.await()).isEqualTo(0)
+      assertThat(worker.await()).isEqualTo(0)
     }
   }
 
-  private fun request(id: Int, vararg args: String) = with(WorkRequest.newBuilder()) {
-    setRequestId(id)
+  private fun request(id: Int, vararg args: String) = WorkRequest.newBuilder().apply {
+    requestId = id
     addAllArguments(args.asList())
   }.build()
 
-  private fun response(id: Int, exitCode: Int, output: String = "") =
-    with(WorkResponse.newBuilder()) {
-      setExitCode(exitCode)
-      setOutput(output)
-      setRequestId(id)
-    }.build()
+  private fun response(id: Int, code: Int, out: String = "") = WorkResponse.newBuilder().apply {
+    exitCode = code
+    output = out
+    requestId = id
+  }.build()
 
   /** WorkerChannel encapsulates the communication between the test and the worker. */
   class WorkerChannel(
@@ -181,10 +185,8 @@ class BazelWorkerTest {
   class ChannelInputStream(val channel: Channel<Byte>, val name: String) : InputStream() {
     override fun read(): Int {
       return runBlocking(CoroutineName("$name.read()")) {
-        // since pipes block until the next event, this simulates that without starving
-        // other routines.
-        while (channel.isEmpty) {
-          delay(5L)
+        if (channel.isEmpty) {
+          yield()
         }
         // read blocking -- this better simulates the java InputStream behaviour.
         return@runBlocking channel.receive().toInt()
@@ -193,14 +195,11 @@ class BazelWorkerTest {
 
     override fun read(b: ByteArray, off: Int, len: Int): Int {
       return runBlocking(CoroutineName("$name.read(ByteArray,Int,Int)")) {
-        // since pipes block until the next event, this simulates that without starving
-        // other routines.
-        while (channel.isEmpty) {
-          delay(5L)
+        if (channel.isEmpty) {
+          yield()
         }
-        val end = Math.min(b.size, off + len - 1)
         var read = 0
-        for (i in off..end) {
+        for (i in off..b.size.coerceAtMost(off + len - 1)) {
           val rb = channel.receive()
           b[i] = rb
           read++
@@ -218,10 +217,8 @@ class BazelWorkerTest {
 
     override fun write(ba: ByteArray, off: Int, len: Int) {
       runBlocking(CoroutineName("$name.write(ByteArray, Int, Int)")) {
-        var sent = 0
-        for (i in off..Math.min(ba.size, off + len - 1)) {
+        for (i in off..ba.size.coerceAtMost(off + len - 1)) {
           channel.sendBlocking(ba[i])
-          sent++
         }
       }
     }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BazelWorkerTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BazelWorkerTest.kt
@@ -1,0 +1,230 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+
+package io.bazel.kotlin.builder.tasks
+
+import com.google.common.truth.Truth.assertThat
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest
+import com.google.devtools.build.lib.worker.WorkerProtocol.WorkResponse
+import kotlinx.coroutines.CoroutineName
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.sendBlocking
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.debug.junit4.CoroutinesTimeout
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Rule
+import org.junit.Test
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.io.PrintStream
+import java.nio.file.Path
+
+class BazelWorkerTest {
+
+  val passingProgram: CommandLineProgram = object : CommandLineProgram {
+    override fun apply(workingDir: Path, args: List<String>): Int {
+      return 0
+    }
+  }
+
+  val failingProgram: CommandLineProgram = object : CommandLineProgram {
+    override fun apply(workingDir: Path, args: List<String>): Int {
+      return 5
+    }
+  }
+
+  @Test
+  fun invocationWorkerPass() {
+    assertThat(InvocationWorker(WorkerIO.noop(), passingProgram).run(listOf())).isEqualTo(0)
+  }
+
+  @Test
+  fun invocationWorkerFail() {
+    assertThat(InvocationWorker(WorkerIO.noop(), failingProgram).run(listOf())).isEqualTo(5)
+  }
+
+  @get:Rule
+  val timeout = CoroutinesTimeout.seconds(15)
+
+  @Test
+  fun persistentWorker() {
+    val workerInput = WorkerChannel("in")
+    val workerOutput = WorkerChannel("out")
+    runBlockingTest {
+      val program = object : CommandLineProgram {
+        override fun apply(workingDir: Path, args: List<String>): Int {
+          return when (args.last()) {
+            "ok" -> 0
+            "fail" -> 255
+            "interrupt" -> throw InterruptedException("interrupted")
+            "error" -> throw RuntimeException("unexpected")
+            else -> throw IllegalArgumentException("unknown $args")
+          }
+        }
+      }
+
+      val execution = ByteArrayOutputStream()
+
+      val done = GlobalScope.async(CoroutineName("worker")) {
+        WorkerIO(workerInput.input,
+                 PrintStream(workerOutput.output),
+                 execution) {}.use { io ->
+          PersistentWorker(io, program).run(listOf())
+        }
+      }
+
+      // asserts scope to ensure all asserts are run.
+      // messy, can be cleaned up -- since kotlin channels love to block and can easily starve a
+      // dispatcher, it's necessary to read each channel in a different coroutine.
+      // The coroutineScope prevents the assertions from happening outside of the expected
+      // asynchronicity.
+      coroutineScope {
+        launch {
+          workerInput.send(request(1, "ok"))
+        }
+        launch {
+          assertThat(workerOutput.read())
+            .isEqualTo(response(1, 0))
+        }
+      }
+
+      coroutineScope {
+        launch {
+          workerInput.send(request(2, "fail"))
+        }
+        launch {
+          assertThat(workerOutput.read())
+            .isEqualTo(response(2, 255))
+        }
+      }
+
+      coroutineScope {
+        launch {
+          workerInput.send(request(3, "error"))
+        }
+        launch {
+          assertThat(workerOutput.read())
+            .isEqualTo(response(3, 1, "unexpected"))
+        }
+      }
+
+      // an interrupt kills the worker.
+      coroutineScope {
+        launch {
+          workerInput.send(request(4, "interrupt"))
+          workerInput.close()
+        }
+        launch {
+          assertThat(workerOutput.read())
+            .isEqualTo(response(4, 1, "interrupted"))
+        }
+      }
+
+
+      assertThat(done.await()).isEqualTo(0)
+    }
+  }
+
+  private fun request(id: Int, vararg args: String) = with(WorkRequest.newBuilder()) {
+    setRequestId(id)
+    addAllArguments(args.asList())
+  }.build()
+
+  private fun response(id: Int, exitCode: Int, output: String = "") =
+    with(WorkResponse.newBuilder()) {
+      setExitCode(exitCode)
+      setOutput(output)
+      setRequestId(id)
+    }.build()
+
+  /** WorkerChannel encapsulates the communication between the test and the worker. */
+  class WorkerChannel(
+    val name: String,
+    val channel: Channel<Byte> = Channel(20),
+    val input: ChannelInputStream = ChannelInputStream(channel, name),
+    val output: ChannelOutputStream = ChannelOutputStream(channel, name)
+  ) {
+    fun send(work: WorkRequest) {
+      work.writeDelimitedTo(output)
+    }
+
+    fun read(): WorkResponse? {
+      return WorkResponse.parseDelimitedFrom(input)
+    }
+
+    fun close() {
+      channel.close()
+    }
+  }
+
+  /** ChannelInputStream implements the InputStream using a channel and coroutines. */
+  class ChannelInputStream(val channel: Channel<Byte>, val name: String) : InputStream() {
+    override fun read(): Int {
+      return runBlocking(CoroutineName("$name.read()")) {
+        // since pipes block until the next event, this simulates that without starving
+        // other routines.
+        while (channel.isEmpty) {
+          delay(5L)
+        }
+        // read blocking -- this better simulates the java InputStream behaviour.
+        return@runBlocking channel.receive().toInt()
+      }
+    }
+
+    override fun read(b: ByteArray, off: Int, len: Int): Int {
+      return runBlocking(CoroutineName("$name.read(ByteArray,Int,Int)")) {
+        // since pipes block until the next event, this simulates that without starving
+        // other routines.
+        while (channel.isEmpty) {
+          delay(5L)
+        }
+        val end = Math.min(b.size, off + len - 1)
+        var read = 0
+        for (i in off..end) {
+          val rb = channel.receive()
+          b[i] = rb
+          read++
+        }
+        return@runBlocking read
+      }
+    }
+  }
+
+  /** ChannelOutputStream implements the OutputStream using a channel and coroutines. */
+  class ChannelOutputStream(val channel: Channel<Byte>, val name: String) : OutputStream() {
+    override fun write(b: Int) {
+      write(byteArrayOf(b.toByte()))
+    }
+
+    override fun write(ba: ByteArray, off: Int, len: Int) {
+      runBlocking(CoroutineName("$name.write(ByteArray, Int, Int)")) {
+        var sent = 0
+        for (i in off..Math.min(ba.size, off + len - 1)) {
+          channel.sendBlocking(ba[i])
+          sent++
+        }
+      }
+    }
+  }
+}
+

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
@@ -18,11 +18,12 @@
 package io.bazel.kotlin.builder.tasks.jvm
 
 import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
 import io.bazel.kotlin.builder.KotlinJvmTestBuilder
-import io.bazel.kotlin.builder.tasks.BazelWorker.Companion.OK
 import io.bazel.kotlin.builder.tasks.InvocationWorker
 import io.bazel.kotlin.builder.tasks.KotlinBuilder.Companion.JavaBuilderFlags
 import io.bazel.kotlin.builder.tasks.KotlinBuilder.Companion.KotlinBuilderFlags
+import io.bazel.kotlin.builder.tasks.WorkerIO
 import io.bazel.kotlin.model.CompilationTaskInfo
 import io.bazel.kotlin.model.Platform
 import io.bazel.kotlin.model.RuleKind
@@ -30,9 +31,6 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 import java.io.ByteArrayOutputStream
-import java.io.IOException
-import java.io.OutputStream
-import java.io.PrintStream
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
 import java.nio.file.Path
@@ -70,23 +68,23 @@ class KotlinWorkerTest {
   }
 
   private fun args(src: Path, jar: Path, info: CompilationTaskInfo) = listOf(
-      JavaBuilderFlags.TARGET_LABEL.flag, info.label,
-      KotlinBuilderFlags.MODULE_NAME.flag, info.moduleName,
-      KotlinBuilderFlags.API_VERSION.flag, info.toolchainInfo.common.apiVersion,
-      KotlinBuilderFlags.LANGUAGE_VERSION.flag, info.toolchainInfo.common.languageVersion,
-      JavaBuilderFlags.RULE_KIND.flag, "kt_${info.platform.name}_${info.ruleKind.name}",
-      JavaBuilderFlags.OUTPUT.flag, jar.toString(),
-      KotlinBuilderFlags.OUTPUT_SRCJAR.flag, "$jar.srcjar",
-      KotlinBuilderFlags.OUTPUT_JDEPS.flag, "out.jdeps",
-      JavaBuilderFlags.CLASSDIR.flag, "kt_classes",
-      KotlinBuilderFlags.GENERATED_CLASSDIR.flag, "generated_classes",
-      JavaBuilderFlags.TEMPDIR.flag, "tmp",
-      JavaBuilderFlags.SOURCEGEN_DIR.flag, "generated_sources",
-      JavaBuilderFlags.CLASSPATH.flag, KotlinJvmTestBuilder.KOTLIN_STDLIB.singleCompileJar(),
-      JavaBuilderFlags.SOURCES.flag, src.toString(),
-      KotlinBuilderFlags.PASSTHROUGH_FLAGS.flag, info.passthroughFlags,
-      KotlinBuilderFlags.DEBUG.flag, info.debugList.joinToString(","),
-      KotlinBuilderFlags.JVM_TARGET.flag, info.toolchainInfo.jvm.jvmTarget
+    JavaBuilderFlags.TARGET_LABEL.flag, info.label,
+    KotlinBuilderFlags.MODULE_NAME.flag, info.moduleName,
+    KotlinBuilderFlags.API_VERSION.flag, info.toolchainInfo.common.apiVersion,
+    KotlinBuilderFlags.LANGUAGE_VERSION.flag, info.toolchainInfo.common.languageVersion,
+    JavaBuilderFlags.RULE_KIND.flag, "kt_${info.platform.name}_${info.ruleKind.name}",
+    JavaBuilderFlags.OUTPUT.flag, jar.toString(),
+    KotlinBuilderFlags.OUTPUT_SRCJAR.flag, "$jar.srcjar",
+    KotlinBuilderFlags.OUTPUT_JDEPS.flag, "out.jdeps",
+    JavaBuilderFlags.CLASSDIR.flag, "kt_classes",
+    KotlinBuilderFlags.GENERATED_CLASSDIR.flag, "generated_classes",
+    JavaBuilderFlags.TEMPDIR.flag, "tmp",
+    JavaBuilderFlags.SOURCEGEN_DIR.flag, "generated_sources",
+    JavaBuilderFlags.CLASSPATH.flag, KotlinJvmTestBuilder.KOTLIN_STDLIB.singleCompileJar(),
+    JavaBuilderFlags.SOURCES.flag, src.toString(),
+    KotlinBuilderFlags.PASSTHROUGH_FLAGS.flag, info.passthroughFlags,
+    KotlinBuilderFlags.DEBUG.flag, info.debugList.joinToString(","),
+    KotlinBuilderFlags.JVM_TARGET.flag, info.toolchainInfo.jvm.jvmTarget
   )
 
   @Test
@@ -112,48 +110,31 @@ class KotlinWorkerTest {
       l("  }")
       l("}")
     }
-
-    // output buffer for compiler logs.
-    val outputStream = ByteArrayOutputStream()
-    val stdOut = System.out
-
-    // tee the stdout -- useful for debugging, but also used as
-    // part of the compilation task output.
-    System.setOut(PrintStream(object : OutputStream() {
-      @Throws(IOException::class) override fun write(b: Int) {
-        outputStream.write(b)
-        stdOut.write(b)
-      }
-    }))
-
-    val worker = InvocationWorker(delegate = builder, buffer = outputStream)
-
     val jarOne = out("one.jar")
 
-    assertThat(worker.invoke(args(one, jarOne, compilationTaskInfo))).isEqualTo(OK to "")
+    WorkerIO.open().use { io ->
+      val worker = InvocationWorker(io, builder)
 
-    System.err.println(ZipFile(jarOne.toFile())
-        .stream()
-        .map(ZipEntry::getName)
-        .toList())
+      assertThat(worker.run(args(one, jarOne, compilationTaskInfo))).isEqualTo(0)
 
-    assertThat(
+      assertWithMessage(io.execution.toString(StandardCharsets.UTF_8)).that(
         ZipFile(jarOne.toFile())
-            .stream()
-            .map(ZipEntry::getName)
-            .filter { it.endsWith(".class") }
-            .toList()
-    ).containsExactly("harry/nilsson/One.class")
+          .stream()
+          .map(ZipEntry::getName)
+          .filter { it.endsWith(".class") }
+          .toList()
+      ).containsExactly("harry/nilsson/One.class")
 
-    val jarTwo = out("two.jar")
-    assertThat(worker.invoke(args(two, jarTwo, compilationTaskInfo))).isEqualTo(OK to "")
-    assertThat(
+      val jarTwo = out("two.jar")
+      assertThat(worker.run(args(two, jarTwo, compilationTaskInfo))).isEqualTo(0)
+      assertWithMessage(io.execution.toString(StandardCharsets.UTF_8)).that(
         ZipFile(jarTwo.toFile())
-            .stream()
-            .map(ZipEntry::getName)
-            .filter { it.endsWith(".class") }
-            .toList()
-    ).containsExactly("harry/nilsson/Two.class")
+          .stream()
+          .map(ZipEntry::getName)
+          .filter { it.endsWith(".class") }
+          .toList()
+      ).containsExactly("harry/nilsson/Two.class")
+    }
   }
 
   private fun out(name: String): Path {
@@ -169,8 +150,8 @@ class KotlinWorkerTest {
         ruleKind = RuleKind.LIBRARY
         toolchainInfo = with(toolchainInfoBuilder) {
           common =
-              commonBuilder.setApiVersion("1.3").setCoroutines("enabled").setLanguageVersion("1.3")
-                  .build()
+            commonBuilder.setApiVersion("1.3").setCoroutines("enabled").setLanguageVersion("1.3")
+              .build()
           jvm = jvmBuilder.setJvmTarget("1.8").build()
           build()
         }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
@@ -117,7 +117,7 @@ class KotlinWorkerTest {
 
       assertThat(worker.run(args(one, jarOne, compilationTaskInfo))).isEqualTo(0)
 
-      assertWithMessage(io.execution.toString(StandardCharsets.UTF_8)).that(
+      assertWithMessage(String(io.execution.toByteArray(), StandardCharsets.UTF_8)).that(
         ZipFile(jarOne.toFile())
           .stream()
           .map(ZipEntry::getName)
@@ -127,7 +127,7 @@ class KotlinWorkerTest {
 
       val jarTwo = out("two.jar")
       assertThat(worker.run(args(two, jarTwo, compilationTaskInfo))).isEqualTo(0)
-      assertWithMessage(io.execution.toString(StandardCharsets.UTF_8)).that(
+      assertWithMessage(String(io.execution.toByteArray(), StandardCharsets.UTF_8)).that(
         ZipFile(jarTwo.toFile())
           .stream()
           .map(ZipEntry::getName)


### PR DESCRIPTION
Restructure the worker for improved (hopefully) clarity and better management of empty pipes.
Adds BazelWorkerTest that checks the behaviours of both invocation workers and persistent.

Fixed: #325.