### PR TITLE
[rfc] Enable `use_default_shell_env` in kotlin compiling action to allow passing in `action_env`

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -338,6 +338,9 @@ def _run_kt_builder_action(ctx, rule_kind, toolchains, dirs, srcs, friend, compi
         execution_requirements = {"supports-workers": "1"},
         arguments = [args],
         progress_message = progress_message,
+        # In order to make kotlin targets being compiled by java 8. Please define --action_env=JAVA_HOME
+        # in the `.bazelrc` file in your repository to pass in JAVA_HOME to default shell
+        use_default_shell_env = True,
         env = {
             "LC_CTYPE": "en_US.UTF-8",  # For Java source files
         },

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
@@ -44,7 +44,6 @@ class KotlinToolchain private constructor(
 
   companion object {
     internal val NO_ARGS = arrayOf<Any>()
-
     private val isJdk9OrNewer = !System.getProperty("java.version").startsWith("1.")
 
     private fun createClassLoader(javaHome: Path, baseJars: List<File>): ClassLoader =


### PR DESCRIPTION
### Background
https://github.com/bazelbuild/rules_kotlin/issues/188
Previously, `action_env` cannot be passed into kotlin compile environment due to the reason that `use_default_shell_env` is not set. This PR fixes it.

### Regrading Kotlin being compiled by Jdk11 Issue
There are two issues under the hood which leads to the annoying fact that kotlin target is always being compiled using jdk11.

**Problem 1**
The first problem is as https://github.com/bazelbuild/rules_kotlin/issues/188 stated, `JAVA_HOME` hasn't been defined in kotlin rule's compiling sandbox environment. As a result, it's using the default jdk11 which comes with bazel tool. The fix for this problem, is to enable `use_default_shell_env` in kotlin rule's compile action so that it will take in the `JAVA_HOME` we defined locally.  

**Note: It is required to specify `--action_env=JAVA_HOME` in `.bazelrc` file of your codebase to make sure this env variable is passed to default environment [doc link](https://bazel.build/designs/2016/06/21/environment.html#new-flag---action_env)** 

**Problem 2**
However, even after fixing the first problem, the kotlin target doesn't compile and keep throwing NPE error, which is caused by having two different jdk version being loaded into classloader.
```
java.lang.NullPointerException
	at com.sun.tools.javac.file.Locations.getPathEntries(Locations.java:149)
	at com.sun.tools.javac.file.Locations.getPathEntries(Locations.java:134)
```

This problem, is the result of 
bazel build tool's Java Builder Stub Action is by default using jdk11 as javabin https://github.com/bazelbuild/bazel/issues/11382 and kotlin_rule is using the stub java action directly

Fix for problem 2 see https://github.com/bazelbuild/bazel/pull/11402

**Other options**
- Can we reuse javaToolchain? 
  - JavaToolchain's logic is embedded inside bazel's internal codebase. Kotlin rule, as an external rule, cannot easily access and utilize it. 
- We've already define `jvm_target` inside KotlinToolChain, why does it not help?
  - Well, this `jvm_target` is never used anywhere in kotlin rule's code. Probably never been used correctly.