### PR TITLE
Switch to using javax.annotation:jsr250 dependency

### DIFF
--- a/kotlin/internal/repositories/setup.bzl
+++ b/kotlin/internal/repositories/setup.bzl
@@ -40,7 +40,6 @@ def kt_configure():
             "com.google.dagger:dagger:2.26",
             "com.google.dagger:dagger-compiler:2.26",
             "com.google.dagger:dagger-producers:2.26",
-            "javax.annotation:javax.annotation-api:1.3.2",
             "javax.inject:javax.inject:1",
             "org.pantsbuild:jarjar:1.7.2",
             "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.6",

--- a/src/main/kotlin/io/bazel/kotlin/builder/BUILD
+++ b/src/main/kotlin/io/bazel/kotlin/builder/BUILD
@@ -31,7 +31,7 @@ java_library(
         "//third_party:dagger",
         "@com_github_jetbrains_kotlin//:annotations",
         "@com_github_jetbrains_kotlin//:kotlin-stdlib",
-        "@kotlin_rules_maven//:javax_annotation_javax_annotation_api",
+        "@kotlin_rules_maven//:javax_annotation_jsr250_api",
         "@kotlin_rules_maven//:javax_inject_javax_inject",
     ],
 )

--- a/src/test/kotlin/io/bazel/kotlin/builder/BUILD
+++ b/src/test/kotlin/io/bazel/kotlin/builder/BUILD
@@ -52,7 +52,7 @@ java_library(
     deps = _COMMON_DEPS + [
         "//third_party:autovalue",
         "//third_party:dagger",
-        "@kotlin_rules_maven//:javax_annotation_javax_annotation_api",
+         "@kotlin_rules_maven//:javax_annotation_jsr250_api",
         "//src/main/kotlin/io/bazel/kotlin/builder/tasks",
     ],
 )


### PR DESCRIPTION
Fixes #321.

Dagger transitively depends on this depedency and it is already fetched
by rules_jvm_external, so that it can be used and recently added
explicit dependency on javax.annotation can be removed.