### PR TITLE
Fix deep dependency generation

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
@@ -56,7 +56,7 @@ internal class JDepsGenerator @Inject constructor(
             val multiRelease =
               if (version < 9) arrayOf() else arrayOf("--multi-release", "base")
             val jarPath = command.outputs.jar
-            val args = multiRelease + arrayOf("-v", "-cp", joinedClasspath, jarPath)
+            val args = multiRelease + arrayOf("-R", "-summary", "-cp", joinedClasspath, jarPath)
             val res = invoker.run(args, writer)
             out.toByteArray().inputStream().bufferedReader().readLines().let {
               if (res != 0) {

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
@@ -26,12 +26,8 @@ internal class JdepsParser private constructor(
   private val filename: String,
   private val isImplicit: Predicate<String>
 ) {
-  private val packageSuffix: String = " ($filename)"
-
   private val depMap = HashMap<String, Deps.Dependency.Builder>()
-  private val packages = HashSet<String>()
-
-  private var mode = Mode.COLLECT_DEPS
+  private val moduleDeps = HashMap<String, MutableList<String>>()
 
   private fun consumeJarLine(classJarPath: String, kind: Deps.Dependency.Kind) {
     val path = Paths.get(classJarPath)
@@ -57,51 +53,29 @@ internal class JdepsParser private constructor(
     }
   }
 
-  private enum class Mode {
-    COLLECT_DEPS,
-    DETERMINE_JDK,
-    COLLECT_PACKAGES_JDK8,
-    COLLECT_PACKAGES_JDK9
+  private fun addModuleDependency(module: String, jarFile: String) {
+    val entry = moduleDeps.computeIfAbsent(module) {
+      mutableListOf<String>()
+    }
+    entry.add(jarFile)
   }
 
-  // maybe simplify this by tokenizing on whitespace and arrows.
   private fun processLine(line: String) {
-    val trimmedLine = line.trim { it <= ' ' }
-    when (mode) {
-      Mode.COLLECT_DEPS -> if (!line.startsWith(" ")) {
-        val parts = line.split(" -> ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-        if (parts.size == 2) {
-          if (parts[0] != filename) {
-            throw RuntimeException("should only get dependencies for dep: $filename")
-          }
-          consumeJarLine(parts[1], Deps.Dependency.Kind.EXPLICIT)
+    val parts = line.split(" -> ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+    if (parts.size == 2 && parts[1].endsWith(".jar")) {
+      addModuleDependency(parts[0], parts[1]);
+    }
+  }
+
+  private fun markFromEntry(entry: String, kind: Deps.Dependency.Kind) {
+    moduleDeps[entry]?.forEach { jarPath ->
+      val dependency = depMap[jarPath]
+      if (dependency != null) {
+        if (dependency.kind == Deps.Dependency.Kind.UNUSED) {
+          dependency.kind = kind
+          val jarFile = Paths.get(jarPath).getFileName().toString()
+          markFromEntry(jarFile, Deps.Dependency.Kind.IMPLICIT)
         }
-      } else {
-        mode = Mode.DETERMINE_JDK
-        processLine(line)
-      }
-      Mode.DETERMINE_JDK -> {
-        mode = Mode.COLLECT_PACKAGES_JDK8
-        if (!line.endsWith(packageSuffix)) {
-          mode = Mode.COLLECT_PACKAGES_JDK9
-        }
-        processLine(line)
-      }
-      Mode.COLLECT_PACKAGES_JDK8 -> when {
-        trimmedLine.endsWith(packageSuffix) -> packages.add(
-          trimmedLine.substring(
-            0,
-            trimmedLine.length - packageSuffix.length
-          )
-        )
-        trimmedLine.startsWith("-> ") -> {
-          // ignore package detail lines, in the jdk8 format these start with arrows.
-        }
-        else -> throw RuntimeException("unexpected line while collecting packages: $line")
-      }
-      Mode.COLLECT_PACKAGES_JDK9 -> {
-        val pkg = trimmedLine.split("\\s+".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-        packages.add(pkg[0])
       }
     }
   }
@@ -128,16 +102,15 @@ internal class JdepsParser private constructor(
     ): Deps.Dependencies {
       val filename = Paths.get(jarFile).fileName.toString()
       val jdepsParser = JdepsParser(filename, isImplicit)
+
       classPath.forEach { x -> jdepsParser.consumeJarLine(x, Deps.Dependency.Kind.UNUSED) }
       lines.forEach { jdepsParser.processLine(it) }
+      jdepsParser.markFromEntry(filename, Deps.Dependency.Kind.EXPLICIT)
 
       val rootBuilder = Deps.Dependencies.newBuilder()
       rootBuilder.success = false
       rootBuilder.ruleLabel = label
-
-      rootBuilder.addAllContainedPackage(jdepsParser.packages)
       jdepsParser.depMap.values.forEach { b -> rootBuilder.addDependency(b.build()) }
-
       rootBuilder.success = true
       return rootBuilder.build()
     }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
@@ -28,6 +28,7 @@ internal class JdepsParser private constructor(
 ) {
   private val depMap = HashMap<String, Deps.Dependency.Builder>()
   private val moduleDeps = HashMap<String, MutableList<String>>()
+  private val arrowRegex = " -> ".toRegex()
 
   private fun consumeJarLine(classJarPath: String, kind: Deps.Dependency.Kind) {
     val path = Paths.get(classJarPath)
@@ -61,7 +62,7 @@ internal class JdepsParser private constructor(
   }
 
   private fun processLine(line: String) {
-    val parts = line.split(" -> ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+    val parts = line.split(arrowRegex).dropLastWhile { it.isEmpty() }.toTypedArray()
     if (parts.size == 2 && parts[1].endsWith(".jar")) {
       addModuleDependency(parts[0], parts[1]);
     }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParserTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParserTest.java
@@ -33,120 +33,97 @@ import java.util.stream.Stream;
 @SuppressWarnings({"KotlinInternalInJava", "SpellCheckingInspection"})
 @RunWith(JUnit4.class)
 public class JdepsParserTest {
-    private static final List<String> JDK8_FIXTURE =
-            toPlatformPaths(
-                    "alt.jar -> bazel-server-cloud/external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk7.jar",
-                    "alt.jar -> bazel-server-cloud/external/com_github_jetbrains_kotlin/lib/kotlin-stdlib.jar",
-                    "alt.jar -> bazel-bin/cloud/qa/integrationtests/pkg/extensions/postgres/postgres.jar",
-                    "alt.jar -> bazel-server-cloud/bazel-out/darwin-fastbuild/bin/cloud/qa/integrationtests/pkg/alt/alt.runfiles/__main__/external/org_postgresql_postgresql/jar/postgresql-42.1.1.jar",
-                    "alt.jar -> /Library/Java/JavaVirtualMachines/jdk1.8.0_144.jdk/Contents/Home/jre/lib/rt.jar",
-                    "alt.jar -> bazel-bin/cloud/qa/integrationtests/pkg/utils/utils.jar",
-                    "   com.axsy.testing.alt (alt.jar)",
-                    "      -> com.axsy.testing.extensions.postgres               postgres.jar",
-                    "      -> com.axsy.testing.pkg.utils                         utils.jar",
-                    "      -> java.io                                            ",
-                    "      -> java.lang                                          ",
-                    "      -> java.sql                                           ",
-                    "      -> javax.sql                                          ",
-                    "      -> kotlin                                             kotlin-stdlib.jar",
-                    "      -> kotlin.jdk7                                        kotlin-stdlib-jdk7.jar",
-                    "      -> kotlin.jvm.internal                                kotlin-stdlib.jar",
-                    "      -> org.postgresql.ds                                  postgresql-42.1.1.jar",
-                    "   com.axsy.testing.alt.sub (alt.jar)",
-                    "      -> java.lang                                          ",
-                    "      -> kotlin                                             kotlin-stdlib.jar");
+  private static final List<String> JDEPS_OUTPUT_FIXTURE =
+          toPlatformPaths(
+                  "example-tests.jar -> bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-test-host/1.3.1/ktor-server-test-host-1.3.1.jar",
+                  "example-tests.jar -> /Library/Java/JavaVirtualMachines/jdk1.8.0_152.jdk/Contents/Home/jre/lib/rt.jar",
+                  "example-tests.jar -> bazel-out/darwin-fastbuild/bin/root/example/main/example-lib.jar",
+                  "example-lib.jar -> bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.3.71/kotlin-stdlib-jdk7-1.3.71.jar",
+                  "ktor-server-test-host-1.3.1.jar -> bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-host-common/1.3.1/ktor-server-host-common-1.3.1.jar",
+                  "ktor-server-test-host-1.3.1.jar -> /Library/Java/JavaVirtualMachines/jdk1.8.0_152.jdk/Contents/Home/jre/lib/rt.jar",
+                  "ktor-server-host-common-1.3.1.jar -> /Library/Java/JavaVirtualMachines/jdk1.8.0_152.jdk/Contents/Home/jre/lib/rt.jar",
+                  "rt.jar -> /Library/Java/JavaVirtualMachines/jdk1.8.0_152.jdk/Contents/Home/jre/lib/jce.jar",
+                  "jce.jar -> /Library/Java/JavaVirtualMachines/jdk1.8.0_152.jdk/Contents/Home/jre/lib/rt.jar"
+          );
 
-    private static final List<String> JDK9_FIXTURE =
-            toPlatformPaths(
-                    "alt.jar -> java.base",
-                    "alt.jar -> java.sql",
-                    "alt.jar -> bazel-server-cloud/external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk7.jar",
-                    "alt.jar -> bazel-server-cloud/external/com_github_jetbrains_kotlin/lib/kotlin-stdlib.jar",
-                    "alt.jar -> bazel-bin/cloud/qa/integrationtests/pkg/extensions/postgres/postgres.jar",
-                    "alt.jar -> bazel-server-cloud/bazel-out/darwin-fastbuild/bin/cloud/qa/integrationtests/pkg/alt/alt.runfiles/__main__/external/org_postgresql_postgresql/jar/postgresql-42.1.1.jar",
-                    "alt.jar -> bazel-bin/cloud/qa/integrationtests/pkg/utils/utils.jar",
-                    "   com.axsy.testing.alt                               -> com.axsy.testing.extensions.postgres               postgres.jar",
-                    "   com.axsy.testing.alt                               -> com.axsy.testing.pkg.utils                         utils.jar",
-                    "   com.axsy.testing.alt                               -> java.io                                            java.base",
-                    "   com.axsy.testing.alt                               -> java.lang                                          java.base",
-                    "   com.axsy.testing.alt                               -> java.sql                                           java.sql",
-                    "   com.axsy.testing.alt                               -> javax.sql                                          java.sql",
-                    "   com.axsy.testing.alt                               -> kotlin                                             kotlin-stdlib.jar",
-                    "   com.axsy.testing.alt                               -> kotlin.jdk7                                        kotlin-stdlib-jdk7.jar",
-                    "   com.axsy.testing.alt                               -> kotlin.jvm.internal                                kotlin-stdlib.jar",
-                    "   com.axsy.testing.alt                               -> org.postgresql.ds                                  postgresql-42.1.1.jar",
-                    "   com.axsy.testing.alt.sub                           -> java.lang                                          java.base",
-                    "   com.axsy.testing.alt.sub                           -> kotlin                                             kotlin-stdlib.jar");
+  private static final List<String> CLASSPATH =
+          toPlatformPaths(
+                  "bazel-out/darwin-fastbuild/bin/root/example/main/example-lib.jar",
+                  "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-host-common/1.3.1/ktor-server-host-common-1.3.1.jar",
+                  "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-test-host/1.3.1/ktor-server-test-host-1.3.1.jar",
+                  "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar",
+                  "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.72/kotlin-stdlib-common-1.3.72.jar",
+                  "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.3.71/kotlin-stdlib-jdk7-1.3.71.jar",
+                  "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.3.61/kotlin-stdlib-jdk8-1.3.61.jar",
+                  "external/com_github_jetbrains_kotlin/lib/annotations-13.0.jar",
+                  "external/com_github_jetbrains_kotlin/lib/kotlin-reflect.jar",
+                  "external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk7.jar",
+                  "external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk8.jar",
+                  "external/com_github_jetbrains_kotlin/lib/kotlin-stdlib.jar",
+                  "external/com_github_jetbrains_kotlin/lib/kotlin-test.jar"
+          );
 
-    private static final List<String> CLASSPATH =
-            toPlatformPaths(
-                    "bazel-bin/cloud/qa/integrationtests/pkg/extensions/postgres/unused.jar",
-                    "bazel-server-cloud/external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk8.jar",
-                    "bazel-server-cloud/external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk7.jar",
-                    "bazel-server-cloud/external/com_github_jetbrains_kotlin/lib/kotlin-stdlib.jar",
-                    "bazel-bin/cloud/qa/integrationtests/pkg/extensions/postgres/postgres.jar",
-                    "bazel-server-cloud/bazel-out/darwin-fastbuild/bin/cloud/qa/integrationtests/pkg/alt/alt.runfiles/__main__/external/org_postgresql_postgresql/jar/postgresql-42.1.1.jar",
-                    "bazel-bin/cloud/qa/integrationtests/pkg/utils/utils.jar");
+  private static final String LABEL = "//cloud/qa/integrationtests/pkg/alt";
+  private static final String CLASS_JAR = toPlatformPath("bazel-bin/something/example-tests.jar");
 
-    private static final String LABEL = "//cloud/qa/integrationtests/pkg/alt";
-    private static final String CLASS_JAR = toPlatformPath("bazel-bin/something/alt.jar");
+  private static final Predicate<String> IS_KOTLIN_IMPLICIT =
+          JdepsParser.Companion.pathSuffixMatchingPredicate(
+                  Paths.get("external", "com_github_jetbrains_kotlin", "lib"),
+                  "kotlin-stdlib.jar",
+                  "kotlin-stdlib-jdk7.jar",
+                  "kotlin-stdlib-jdk8.jar");
 
-    private static final Predicate<String> IS_KOTLIN_IMPLICIT =
-            JdepsParser.Companion.pathSuffixMatchingPredicate(
-                    Paths.get("external", "com_github_jetbrains_kotlin", "lib"),
-                    "kotlin-stdlib.jar",
-                    "kotlin-stdlib-jdk7.jar",
-                    "kotlin-stdlib-jdk8.jar");
+  private static void testWithFixture(List<String> fixture) throws IOException {
+    Deps.Dependencies result =
+            JdepsParser.Companion.parse(LABEL, CLASS_JAR, CLASSPATH, fixture, IS_KOTLIN_IMPLICIT);
 
-    private static void testWithFixture(List<String> fixture) throws IOException {
-        Deps.Dependencies result =
-                JdepsParser.Companion.parse(LABEL, CLASS_JAR, CLASSPATH, fixture, IS_KOTLIN_IMPLICIT);
+    Assert.assertEquals(LABEL, result.getRuleLabel());
 
-        Assert.assertEquals(LABEL, result.getRuleLabel());
+    Truth.assertThat(result
+            .getDependencyList()
+            .stream()
+            .map(Deps.Dependency::getPath)
+            .collect(Collectors.toSet()))
+            .containsExactlyElementsIn(CLASSPATH);
 
-        Truth.assertThat(
-                result
-                        .getDependencyList()
-                        .stream()
-                        .map(Deps.Dependency::getPath)
-                        .collect(Collectors.toSet()))
-                .containsExactlyElementsIn(CLASSPATH);
+    Assert.assertEquals(13, result.getDependencyCount());
 
-        Assert.assertEquals(7, result.getDependencyCount());
-        Assert.assertEquals(1, depKinds(result, Deps.Dependency.Kind.UNUSED).size());
-        Assert.assertEquals(3, depKinds(result, Deps.Dependency.Kind.IMPLICIT).size());
-        Assert.assertEquals(3, depKinds(result, Deps.Dependency.Kind.EXPLICIT).size());
+    List<String> unused = depKinds(result, Deps.Dependency.Kind.UNUSED);
+    Assert.assertEquals(6, unused.size());
 
-        Assert.assertEquals(2, result.getContainedPackageCount());
+    List<String> explicit = depKinds(result, Deps.Dependency.Kind.EXPLICIT);
+    Assert.assertEquals(2, explicit.size());
+    Assert.assertTrue(explicit.contains("bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-test-host/1.3.1/ktor-server-test-host-1.3.1.jar"));
+    Assert.assertTrue(explicit.contains("bazel-out/darwin-fastbuild/bin/root/example/main/example-lib.jar"));
 
-        result.writeTo(System.out);
-        System.out.flush();
-    }
+    List<String> implicit = depKinds(result, Deps.Dependency.Kind.IMPLICIT);
+    Assert.assertEquals(5, implicit.size());
+    Assert.assertTrue(implicit.contains("bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-host-common/1.3.1/ktor-server-host-common-1.3.1.jar"));
 
-    private static List<String> toPlatformPaths(String... lines) {
-        return Stream.of(lines).map(JdepsParserTest::toPlatformPath).collect(Collectors.toList());
-    }
+    result.writeTo(System.out);
+    System.out.flush();
+  }
 
-    // on windows translate absolute paths to c:\ . Also swap the seperators from "/" to "\".
-    private static String toPlatformPath(String it) {
-        return File.separatorChar != '/' ? it.replace(" /", "c:\\").replace("/", File.separator) : it;
-    }
+  private static List<String> toPlatformPaths(String... lines) {
+    return Stream.of(lines).map(JdepsParserTest::toPlatformPath).collect(Collectors.toList());
+  }
 
-    private static List<Deps.Dependency> depKinds(Deps.Dependencies result, Deps.Dependency.Kind kind) {
-        return result
-                .getDependencyList()
-                .stream()
-                .filter(x -> x.getKind() == kind)
-                .collect(Collectors.toList());
-    }
+  // on windows translate absolute paths to c:\ . Also swap the seperators from "/" to "\".
+  private static String toPlatformPath(String it) {
+    return File.separatorChar != '/' ? it.replace(" /", "c:\\").replace("/", File.separator) : it;
+  }
 
-    @Test
-    public void parseJDK8Format() throws IOException {
-        testWithFixture(JDK8_FIXTURE);
-    }
+  private static List<String> depKinds(Deps.Dependencies result, Deps.Dependency.Kind kind) {
+    return result
+            .getDependencyList()
+            .stream()
+            .filter(x -> x.getKind() == kind)
+            .map(x -> x.getPath())
+            .collect(Collectors.toList());
+  }
 
-    @Test
-    public void parseJDK9Format() throws IOException {
-        testWithFixture(JDK9_FIXTURE);
-    }
+  @Test
+  public void parseJdepsResult() throws IOException {
+    testWithFixture(JDEPS_OUTPUT_FIXTURE);
+  }
 }


### PR DESCRIPTION
Consider this code:
```
package example

import io.ktor.http.HttpMethod
import io.ktor.http.HttpStatusCode
import io.ktor.server.testing.handleRequest
import io.ktor.server.testing.withTestApplication
import org.assertj.core.api.Assertions.assertThat
import org.junit.jupiter.api.Test

class ExampleTest {
    @Test
    fun testRoot() {
        withTestApplication({ module(testing = true) }) {
            handleRequest(HttpMethod.Get, "/").apply {
                assertThat(response.status()).isEqualTo(HttpStatusCode.OK)
                assertThat(response.content).isEqualTo("<html><table></table></html>")
            }
        }
    }
}
```
with the build file
```
package(default_visibility = ["//visibility:private"])

kt_junit_test(
    name = "Example",
    srcs = glob([
        "*/**",
    ]),
    size = "small",
    main_class = "TestRunner",
    deps = [
        "//src:example",
        "@maven//:io_ktor_ktor_server_netty",
        "@maven//:io_ktor_ktor_server_core",
        "@maven//:io_ktor_ktor_server_tests",
        "@maven//:io_ktor_ktor_server_test_host",
    ],
    args = [
        "--select-package",
        "example",
    ],
)
```
In this case, IntellliJ complains about the handleRequest entry because it cannot find a
base class for the TestApplication.  The base class is in io_ktor_ktor_server_host_common but
doesn't get included in the dependencies.

This change does a deeper search for all dependencies and marks the top level ones as explicit and
the deeper ones as implicit and resolves the missing dependency