### PR TITLE
Add support for Android data-binding when building with Kotlin

### DIFF
--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -16,7 +16,7 @@ load(
     _kt_jvm_library = "kt_jvm_library",
 )
 
-def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
+def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], enable_data_binding = False, **kwargs):
     """Delegates Android related build attributes to the native rules but uses the Kotlin builder to compile Java and
     Kotlin srcs. Returns a sequence of labels that a wrapping macro should export.
     """
@@ -30,7 +30,8 @@ def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
         name = base_name,
         visibility = ["//visibility:private"],
         exports = base_deps,
-        deps = deps if kwargs.get('enable_data_binding', default = False) else [],
+        deps = deps if enable_data_binding else [],
+        enable_data_binding = enable_data_binding,
         **kwargs
     )
     _kt_jvm_library(

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -30,6 +30,7 @@ def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], **kwargs):
         name = base_name,
         visibility = ["//visibility:private"],
         exports = base_deps,
+        deps = deps if kwargs.get('enable_data_binding', default = False) else [],
         **kwargs
     )
     _kt_jvm_library(


### PR DESCRIPTION
There's a lot of context behind this PR, but to summarize: data-binding v2 is currently in the process of being introduced in upstream Bazel (see https://github.com/bazelbuild/bazel/pull/10795). While this solution works correctly with Java-based Android apps, the Kotlin macros seem to break for similar Kotlin + data-binding apps. With trivial data-binding projects, the generated databinding file fails to build due to missing dependencies. This seems to be happening because the Kotlin macro splits up the library into a native android_library target, and a separate kt_jvm_library to actually build the sources. When data-binding is enabled, android_library may also run the Javac compiler which means the dependencies passed into the top-level kt_android_library also need to be passed into the native android_library to satisfy dependencies.

There's one issue with the above: it's not valid for android_library to have deps but no sources (hence why the warning suggests using exports instead). However, it's valid to do this in exactly the data-binding case per https://docs.bazel.build/versions/master/be/android.html (see ``enable_data_binding``).

This solution is a bit hacky, so please advise on:
1. A cleaner solution, if any
2. Any suggested comments and/or documentation I should add for future maintainers
3. Any tests that I should add
4. Any tests that I should run to verify this doesn't regress any existing system behaviors