### PR TITLE
Add misisng arguments for experimental abi jars

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -254,6 +254,8 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
             srcs = srcs,
             friend = friend,
             compile_deps = compile_deps,
+            annotation_processors = annotation_processors,
+            transitive_runtime_jars = transitive_runtime_jars,
             plugins = plugins,
             outputs = {
                 "abi_jar": kt_compile_jar,


### PR DESCRIPTION
Two arguments were missing in the call to `_run_kt_builder_action()` when running with `experimental_use_abi_jars = True`