### PR TITLE
fix a bug that annotation processors not propagated via android_library

### DIFF
--- a/kotlin/internal/jvm/plugins.bzl
+++ b/kotlin/internal/jvm/plugins.bzl
@@ -74,7 +74,7 @@ def _kt_jvm_plugin_aspect_impl(target, ctx):
             ]),
             transitive_runtime_jars = depset(transitive = [merged_deps.transitive_runtime_jars]),
         )]
-    elif ctx.rule.kind == "java_library":
+    elif ctx.rule.kind == "java_library" or ctx.rule.kind == 'android_library':
         return [merge_plugin_infos(ctx.rule.attr.exported_plugins)]
     else:
         return _EMPTY_PLUGIN_INFO


### PR DESCRIPTION
fix a bug that annotation processors not propagated via android_library rule, specifically it prevents kotlin + hilt working in bazel.