### PR TITLE
Add kotlin-reflect on the builder classpath

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/BUILD
+++ b/src/main/kotlin/io/bazel/kotlin/builder/BUILD
@@ -31,6 +31,7 @@ java_library(
         "//third_party:dagger",
         "@com_github_jetbrains_kotlin//:annotations",
         "@com_github_jetbrains_kotlin//:kotlin-stdlib",
+        "@com_github_jetbrains_kotlin//:kotlin-reflect",
         "@kotlin_rules_maven//:javax_annotation_javax_annotation_api",
         "@kotlin_rules_maven//:javax_inject_javax_inject",
     ],


### PR DESCRIPTION
The issue in #342 boils down to how Java classloaders and reflection in Kotlin work. Classloaders form a tree, where a classloader will first ask its parent for any requested class, and only if the parent doesn't provide it, it will try itself. Kotlin reflection works by the kotlin-stdlib [Reflection](https://github.com/JetBrains/kotlin/blob/master/libraries/stdlib/jvm/runtime/kotlin/jvm/internal/Reflection.java#L23) class attempting to load a `ReflectionFactory` implementation defined in kotlin-reflect, and using a default one if that fails. The current setup in rules_kotlin, where the builder loads kotlin-stdlib into the System classloader, and kotlin-reflect may be added as a dependency of an annotation processor or compiler plugin, leads to the following sequence of events:

1. Some code in an annotation processor tries to do reflection.
2. The annotation processor classloader asks its parent for the `Reflection` class. 
3. Parents are asked all the way down to the boot loader (which doesn't have it).
4. Requests bounce back up to the System classloader, which has the class. 
5. The `Reflection` class initialises itself, and tries to load `kotlin.reflect.jvm.internal.ReflectionFactoryImpl` - but that is only available in a child classloader (that of the annotation processor), so it fails.
6. Reflection is not fully supported in the annotation processor.

Kotlin reflection support is distributed separately [for size reasons](https://kotlinlang.org/docs/reference/reflection.html), and that shouldn't be an issue in this context, so supporting it in the builder is safe. 

This change is a workaround, however, in the sense that the builder chooses the same kotlin-stdlib version as is selected for the compiler, not the one that is selected in dependencies. So users may be confused when they, for instance, ask to use compiler version 1.3.72 and kotlin-stdlib+reflect version 1.3.50, and in fact the application gets built with stdlib+reflect version 1.3.72. (I won't swear that that's what actually happens, but it's what it looks like to me). It would be better to separate the class loaders so that the system classloader stays kotlin-free and builder gets loaded into a separate branch from the compiler and annotation processor, meaning that annotation processor classpaths and compiler classpaths actually work. That change is quite large, though, and this change is at least an improvement over the current state.