### PR TITLE
Added output of diagnostics

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -306,6 +306,7 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar):
             "output": output_jar,
             "kotlin_output_jdeps": ctx.outputs.jdeps,
             "kotlin_output_srcjar": ctx.outputs.srcjar,
+            "diagnosticsfile": ctx.outputs.diagnosticsfile,
         },
     )
 

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -236,6 +236,7 @@ _common_outputs = dict(
     # The params file, declared here so that validate it can be validated for testing.
     #    jar_2_params = "%{name}.jar-2.params",
     srcjar = "%{name}-sources.jar",
+    diagnosticsfile = "%{name}.diagnosticsproto",
 )
 
 _common_toolchains = [

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -89,6 +89,7 @@ class KotlinBuilder @Inject internal constructor(
       COMPRESS_JAR("--compress_jar"),
       RULE_KIND("--rule_kind"),
       TEST_ONLY("--testonly");
+      //TODO: Add diagnostics for java
     }
 
     enum class KotlinBuilderFlags(override val flag: String) : Flag {
@@ -106,7 +107,8 @@ class KotlinBuilder @Inject internal constructor(
       JS_LIBRARIES("--kotlin_js_libraries"),
       DEBUG("--kotlin_debug_tags"),
       TASK_ID("--kotlin_task_id"),
-      ABI_JAR("--abi_jar");
+      ABI_JAR("--abi_jar"),
+      DIAGNOSTICS_FILE("--diagnosticsfile");
     }
   }
 
@@ -213,7 +215,7 @@ class KotlinBuilder @Inject internal constructor(
     context.whenTracing {
       printProto("jvm task message", task)
     }
-    jvmTaskExecutor.execute(context, task)
+    jvmTaskExecutor.execute(context, task, argMap.optionalSingle(KotlinBuilderFlags.DIAGNOSTICS_FILE))
   }
 
   private fun buildJvmTask(

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JavaCompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JavaCompiler.kt
@@ -53,7 +53,7 @@ internal class JavaCompiler @Inject constructor(
         )
         it.addAll(i.javaSourcesList)
       }
-      context.executeCompilerTask(args, { a, pw ->
+      context.executeCompilerTask(args, { a, pw, _ ->
         javacInvoker.compile(a, PrintWriter(pw))
       })
     }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -51,6 +51,10 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
   }
 
   fun execute(context: CompilationTaskContext, task: JvmCompilationTask) {
+      execute(context, task, null)
+  }
+
+  fun execute(context: CompilationTaskContext, task: JvmCompilationTask, diagnosticsFile: String?) {
     val preprocessedTask = task
       .preProcessingSteps(context)
       .runPlugins(context, pluginArgsEncoderKapt, compiler)
@@ -73,7 +77,8 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
                             plugin(abiPlugins.skipCodeGen)
                           }
                         },
-                    printOnFail = false
+                    printOnFail = false,
+                    diagnosticsFile =  diagnosticsFile
                 )
               }
             },

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -160,7 +160,8 @@ fun JvmCompilationTask.compileKotlin(
   context: CompilationTaskContext,
   compiler: KotlinToolchain.KotlincInvoker,
   args: CompilationArgs = commonArgs(),
-  printOnFail: Boolean = true
+  printOnFail: Boolean = true,
+  diagnosticsFile: String?
 ) : List<String> {
   if (inputs.kotlinSourcesList.isEmpty()) {
     return emptyList()
@@ -169,7 +170,7 @@ fun JvmCompilationTask.compileKotlin(
     .values(inputs.javaSourcesList)
     .values(inputs.kotlinSourcesList)
         .list().let {
-          return@let context.executeCompilerTask(it, compiler::compile, printOnFail = printOnFail)
+          return@let context.executeCompilerTask(it, compiler::compile, printOnFail = printOnFail, diagnosticsFile = diagnosticsFile)
         }
   }
 }

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/BUILD.bazel
@@ -21,6 +21,7 @@ kt_bootstrap_library(
     visibility = ["//src:__subpackages__"],
     deps = [
         "//src/main/protobuf:kotlin_model_java_proto",
+        "//src/main/protobuf:diagnostics_java_proto",
         "@com_github_jetbrains_kotlin//:kotlin-preloader",
         "@kotlin_rules_maven//:com_google_protobuf_protobuf_java",
         "@kotlin_rules_maven//:com_google_protobuf_protobuf_java_util",

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/CompilationTaskContext.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/CompilationTaskContext.kt
@@ -113,13 +113,14 @@ class CompilationTaskContext(
      */
     fun executeCompilerTask(
         args: List<String>,
-        compile: (Array<String>, PrintStream) -> Int,
+        compile: (Array<String>, PrintStream, String?) -> Int,
         printOnFail: Boolean = true,
-        printOnSuccess: Boolean = true
+        printOnSuccess: Boolean = true,
+        diagnosticsFile: String? = null
     ): List<String> {
       val outputStream = ByteArrayOutputStream()
       val ps = PrintStream(outputStream)
-      val result = compile(args.toTypedArray(), ps)
+      val result = compile(args.toTypedArray(), ps, diagnosticsFile)
       val output = ByteArrayInputStream(outputStream.toByteArray())
           .bufferedReader()
           .readLines()

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
@@ -154,7 +154,7 @@ class KotlinToolchain private constructor(
 
       compiler = compilerClass.getConstructor().newInstance()
       execMethod =
-        compilerClass.getMethod("exec", PrintStream::class.java, Array<String>::class.java)
+        compilerClass.getMethod("exec", PrintStream::class.java, String::class.java, Array<String>::class.java)
       getCodeMethod = exitCodeClass.getMethod("getCode")
     }
 
@@ -162,8 +162,8 @@ class KotlinToolchain private constructor(
     // 1 is a standard compilation error
     // 2 is an internal error
     // 3 is the script execution error
-    fun compile(args: Array<String>, out: PrintStream): Int {
-      val exitCodeInstance = execMethod.invoke(compiler, out, args)
+    fun compile(args: Array<String>, out: PrintStream, diagnosticsFile: String?): Int {
+      val exitCodeInstance = execMethod.invoke(compiler, out, diagnosticsFile, args)
       return getCodeMethod.invoke(exitCodeInstance, *NO_ARGS) as Int
     }
   }
@@ -176,5 +176,5 @@ class KotlinToolchain private constructor(
   @Singleton
   class K2JSCompilerInvoker @Inject constructor(
     toolchain: KotlinToolchain
-  ) : KotlinCliToolInvoker(toolchain, "org.jetbrains.kotlin.cli.js.K2JSCompiler")
+  ) : KotlinCliToolInvoker(toolchain, "io.bazel.kotlin.compiler.BazelK2JSCompiler")
 }

--- a/src/main/kotlin/io/bazel/kotlin/compiler/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/compiler/BUILD.bazel
@@ -24,6 +24,11 @@ kt_bootstrap_library(
         "@com_github_jetbrains_kotlin//:kotlin-annotation-processing",
         "@com_github_jetbrains_kotlin//:kotlin-script-runtime",
     ],
+    deps = [
+      "//src/main/protobuf:diagnostics_java_proto",
+      "@kotlin_rules_maven//:com_google_protobuf_protobuf_java",
+      "@kotlin_rules_maven//:com_google_protobuf_protobuf_java_util",
+    ],
     visibility = ["//src:__subpackages__"],
 )
 

--- a/src/main/kotlin/io/bazel/kotlin/compiler/BazelK2JSCompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/compiler/BazelK2JSCompiler.kt
@@ -1,0 +1,11 @@
+package io.bazel.kotlin.compiler
+
+import org.jetbrains.kotlin.cli.common.ExitCode
+import org.jetbrains.kotlin.cli.js.K2JSCompiler
+
+//TODO: Support kotlin diagnostics
+class BazelK2JSCompiler : K2JSCompiler() {
+  fun exec(errStream: java.io.PrintStream, @Suppress("UNUSED_PARAMETER") diagnosticsFile: String?, vararg args: kotlin.String): ExitCode {
+    return exec(errStream, *args)
+  }
+}

--- a/src/main/kotlin/io/bazel/kotlin/compiler/BazelK2JVMCompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/compiler/BazelK2JVMCompiler.kt
@@ -81,7 +81,7 @@ class BazelK2JVMCompiler(private val delegate: K2JVMCompiler = K2JVMCompiler()) 
         STRONG_WARNING -> Diagnostics.Severity.WARNING
         WARNING -> Diagnostics.Severity.WARNING
         INFO -> Diagnostics.Severity.INFORMATION
-        LOGGING -> Diagnostics.Severity.HINT
+        LOGGING -> Diagnostics.Severity.INFORMATION
         OUTPUT -> Diagnostics.Severity.INFORMATION
       }
     }

--- a/src/main/kotlin/io/bazel/kotlin/compiler/BazelK2JVMCompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/compiler/BazelK2JVMCompiler.kt
@@ -92,8 +92,8 @@ class BazelK2JVMCompiler(private val delegate: K2JVMCompiler = K2JVMCompiler()) 
         .setStart(
           Diagnostics.Position
             .newBuilder()
-            .setLine(location.line)
-            .setCharacter(location.column)
+            .setLine(location.line - 1)
+            .setCharacter(location.column - 1)
             .build()
         )
         .build()

--- a/src/main/kotlin/io/bazel/kotlin/compiler/BazelK2JVMCompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/compiler/BazelK2JVMCompiler.kt
@@ -17,16 +17,101 @@ package io.bazel.kotlin.compiler
 
 import org.jetbrains.kotlin.cli.common.ExitCode
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer
-import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
 import org.jetbrains.kotlin.cli.jvm.K2JVMCompiler
 import org.jetbrains.kotlin.config.Services
+import java.io.PrintStream
+import java.nio.file.Paths
+import io.bazel.kotlin.model.diagnostics.Diagnostics
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageLocation
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity
+import org.jetbrains.kotlin.cli.common.messages.CompilerMessageSeverity.*
+import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.StandardOpenOption
+
 
 @Suppress("unused")
 class BazelK2JVMCompiler(private val delegate: K2JVMCompiler = K2JVMCompiler()) {
-  fun exec(errStream: java.io.PrintStream, vararg args: kotlin.String): ExitCode {
+  fun exec(errStream: PrintStream, diagnosticsFile: String? = null, vararg args: String): ExitCode {
     val arguments = delegate.createArguments().also { delegate.parseArguments(args, it) }
     val collector =
-      PrintingMessageCollector(errStream, MessageRenderer.PLAIN_RELATIVE_PATHS, arguments.verbose)
-    return delegate.exec(collector, Services.EMPTY, arguments)
+      MessageCollectorWithDiagnostics(errStream, MessageRenderer.PLAIN_RELATIVE_PATHS, arguments.verbose)
+    val exitCode = delegate.exec(collector, Services.EMPTY, arguments)
+
+
+    diagnosticsFile?.let {
+      try {
+        val path = Paths.get(it)
+        collector.writeTo(path)
+      } catch (e: Throwable) {
+      }
+    }
+
+    return exitCode
+  }
+
+  class MessageCollectorWithDiagnostics(errStream: PrintStream, messageRenderer: MessageRenderer, verbose: Boolean) : PrintingMessageCollector(errStream, messageRenderer, verbose) {
+    private val builder = mutableMapOf<String, MutableList<Diagnostics.Diagnostic>>()
+
+    override fun report(severity: CompilerMessageSeverity, message: String, location: CompilerMessageLocation?) {
+      super.report(severity, message, location)
+      val builder = Diagnostics.Diagnostic
+        .newBuilder()
+      var path = ""
+      location?.let {
+        builder.range = convertRange(it)
+        path = it.path
+      }
+
+      val diagnostic: Diagnostics.Diagnostic = builder
+        .setSeverity(convertSeverity(severity))
+        .setMessage(message)
+        .build()
+
+
+      this.builder.getOrPut(path) { mutableListOf() }
+        .add(diagnostic)
+    }
+
+    private fun convertSeverity(severity: CompilerMessageSeverity): Diagnostics.Severity {
+      return when (severity) {
+        EXCEPTION -> Diagnostics.Severity.ERROR
+        ERROR -> Diagnostics.Severity.ERROR
+        STRONG_WARNING -> Diagnostics.Severity.WARNING
+        WARNING -> Diagnostics.Severity.WARNING
+        INFO -> Diagnostics.Severity.INFORMATION
+        LOGGING -> Diagnostics.Severity.HINT
+        OUTPUT -> Diagnostics.Severity.INFORMATION
+      }
+    }
+
+    private fun convertRange(location: CompilerMessageLocation): Diagnostics.Range {
+      return Diagnostics.Range
+        .newBuilder()
+        .setStart(
+          Diagnostics.Position
+            .newBuilder()
+            .setLine(location.line)
+            .setCharacter(location.column)
+            .build()
+        )
+        .build()
+    }
+
+    fun writeTo(path: Path) {
+      val targetDiagnostics: Diagnostics.TargetDiagnostics.Builder = Diagnostics.TargetDiagnostics.newBuilder()
+
+      targetDiagnostics.addAllDiagnostics(
+        builder.map { (path, diagnostics) ->
+          Diagnostics.FileDiagnostics
+            .newBuilder()
+            .setPath(path)
+            .addAllDiagnostics(diagnostics)
+            .build()
+        })
+
+      Files.write(path, targetDiagnostics.build().toByteArray(), StandardOpenOption.CREATE, StandardOpenOption.APPEND)
+    }
   }
 }

--- a/src/main/protobuf/BUILD
+++ b/src/main/protobuf/BUILD
@@ -47,3 +47,14 @@ java_library(
         ":worker_protocol_java_proto",
     ],
 )
+
+proto_library(
+    name = "diagnostics_proto",
+    srcs = ["diagnostics.proto"],
+)
+
+java_proto_library(
+    name = "diagnostics_java_proto",
+    visibility = ["//visibility:public"],
+    deps = [":diagnostics_proto"],
+)

--- a/src/main/protobuf/diagnostics.proto
+++ b/src/main/protobuf/diagnostics.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+option java_package = "io.bazel.kotlin.model.diagnostics";
+
+enum Severity {
+  UNKNOWN = 0;
+  ERROR = 1;
+  WARNING = 2;
+  INFORMATION = 3;
+  HINT = 4;
+}
+
+message Position {
+  // 1-indexed
+  int32 line = 1;
+  // 1-indexed
+  int32 character = 2;
+}
+
+message Range {
+  Position start = 1;
+  Position end = 2;
+}
+
+message Location {
+  string path = 1;
+  Range range = 2;
+}
+
+message DiagnosticRelatedInformation {
+  Location location = 1;
+  string message = 2;
+}
+
+message Diagnostic {
+  Range range = 1;
+  Severity severity = 2;
+  int64 code = 3;
+  string message = 5;
+  repeated DiagnosticRelatedInformation related_information = 6;
+}
+
+message FileDiagnostics {
+  string path = 1;
+  repeated Diagnostic diagnostics = 2;
+}
+
+message TargetDiagnostics {
+  repeated FileDiagnostics diagnostics = 1;
+}

--- a/src/test/data/jvm/diagnostics/BUILD
+++ b/src/test/data/jvm/diagnostics/BUILD
@@ -1,0 +1,21 @@
+package(default_visibility = ["//visibility:private"])
+load("//kotlin:kotlin.bzl", "kt_jvm_binary", "kt_jvm_library", "kt_jvm_test")
+
+kt_jvm_library(
+    name = "test_info_file",
+    srcs = ["InfoFile.kt"],
+)
+
+kt_jvm_library(
+    name = "test_warning_and_info_file",
+    srcs = ["WarningAndInfoFile.kt"],
+)
+
+filegroup(
+    name = "diagnostics",
+    srcs = [
+        ":test_info_file.diagnosticsproto",
+        ":test_warning_and_info_file.diagnosticsproto",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/src/test/data/jvm/diagnostics/InfoFile.kt
+++ b/src/test/data/jvm/diagnostics/InfoFile.kt
@@ -1,0 +1,3 @@
+fun main() {
+  println("Hello World!")
+}

--- a/src/test/data/jvm/diagnostics/WarningAndInfoFile.kt
+++ b/src/test/data/jvm/diagnostics/WarningAndInfoFile.kt
@@ -1,0 +1,4 @@
+fun main() {
+  val s: Array<Any>
+  println("Hello World!")
+}

--- a/src/test/kotlin/io/bazel/kotlin/BUILD
+++ b/src/test/kotlin/io/bazel/kotlin/BUILD
@@ -30,6 +30,7 @@ kt_jvm_library(
     deps = [
         "@com_github_jetbrains_kotlin//:kotlin-test",
         "@kotlin_rules_maven//:com_google_guava_guava",
+        "//src/main/protobuf:diagnostics_java_proto",
     ],
 )
 
@@ -68,6 +69,17 @@ kt_rules_e2e_test(
     srcs = ["KotlinJvm13Test.kt"],
 )
 
+kt_rules_e2e_test(
+    name = "KotlinJvmDiagnosticsTest",
+    srcs = ["KotlinJvmDiagnosticsTest.kt"],
+    data = ["//src/test/data/jvm/diagnostics"],
+    deps = [
+        "//src/main/protobuf:diagnostics_java_proto",
+        "@kotlin_rules_maven//:com_google_protobuf_protobuf_java",
+        "@kotlin_rules_maven//:com_google_protobuf_protobuf_java_util",
+    ]
+)
+
 test_suite(
     name = "assertion_tests",
     tests = [
@@ -76,6 +88,7 @@ test_suite(
         "KotlinJvmDaggerExampleTest",
         "KotlinJvmFriendsVisibilityTest",
         "KotlinJvmKaptAssertionTest",
+        "KotlinJvmDiagnosticsTest",
     ],
 )
 

--- a/src/test/kotlin/io/bazel/kotlin/KotlinJvmDiagnosticsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/KotlinJvmDiagnosticsTest.kt
@@ -1,0 +1,38 @@
+package io.bazel.kotlin
+
+import org.junit.Test
+import io.bazel.kotlin.model.diagnostics.Diagnostics
+
+
+class KotlinJvmDiagnosticsTest: KotlinAssertionTestCase("src/test/data/jvm/diagnostics"){
+  //No tests for error compilation messages were added, since that would make it uncompilable
+  @Test
+  fun testDiagnostics(){
+    val infoDiagnostic = Diagnostics.Diagnostic
+      .newBuilder()
+      .setSeverity(Diagnostics.Severity.INFORMATION)
+      .build()
+
+    val warningDiagnostic = Diagnostics.Diagnostic
+      .newBuilder()
+      .setSeverity(Diagnostics.Severity.WARNING)
+      .setRange(
+        Diagnostics.Range
+          .newBuilder()
+          .setStart(Diagnostics.Position.newBuilder().setLine(2).setCharacter(7))
+      )
+      .build()
+
+    diagnosticsTestCase(
+      "test_info_file.diagnosticsproto",
+      description = "Output of an info diagnostics message",
+      expectedDiagnostics =  listOf(infoDiagnostic)
+    )
+
+    diagnosticsTestCase(
+      "test_warning_and_info_file.diagnosticsproto",
+      description = "Output of a warning and an info diagnostics message",
+      expectedDiagnostics =  listOf(infoDiagnostic, warningDiagnostic)
+    )
+  }
+}

--- a/src/test/kotlin/io/bazel/kotlin/KotlinJvmDiagnosticsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/KotlinJvmDiagnosticsTest.kt
@@ -19,7 +19,7 @@ class KotlinJvmDiagnosticsTest: KotlinAssertionTestCase("src/test/data/jvm/diagn
       .setRange(
         Diagnostics.Range
           .newBuilder()
-          .setStart(Diagnostics.Position.newBuilder().setLine(2).setCharacter(7))
+          .setStart(Diagnostics.Position.newBuilder().setLine(1).setCharacter(6))
       )
       .build()
 


### PR DESCRIPTION
In the light of the developments regarding [BSP support for bazel](https://github.com/bazelbuild/bazel/pull/11766), added the output of a diagnostics file for `kotlinc` compilation.

With this, diagnostics information will be served to clients through BSP.