### PR TITLE
Compile Java source generated from annotation processors run by kapt

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -106,7 +106,8 @@ class KotlinBuilder @Inject internal constructor(
       JS_LIBRARIES("--kotlin_js_libraries"),
       DEBUG("--kotlin_debug_tags"),
       TASK_ID("--kotlin_task_id"),
-      ABI_JAR("--abi_jar");
+      ABI_JAR("--abi_jar"),
+      GENERATED_JAVA_SRC_JAR("--generated_java_srcjar");
     }
   }
 
@@ -232,8 +233,10 @@ class KotlinBuilder @Inject internal constructor(
             argMap.hasAll(KotlinBuilderFlags.ABI_JAR)
           }?.let { srcjar = it }
 
-        argMap.optionalSingle(KotlinBuilderFlags.OUTPUT_JDEPS)?.apply { jdeps = this }
-
+          argMap.optionalSingle(KotlinBuilderFlags.OUTPUT_JDEPS)?.apply { jdeps = this }
+          argMap.optionalSingle(KotlinBuilderFlags.GENERATED_JAVA_SRC_JAR)?.apply {
+            generatedJavaSrcJar = this
+          }
           argMap.optionalSingleIf(KotlinBuilderFlags.ABI_JAR) {
             argMap.hasAll(JavaBuilderFlags.OUTPUT, KotlinBuilderFlags.OUTPUT_SRCJAR)
           }?.let { abijar = it }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -114,6 +114,9 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
         if (outputs.jdeps.isNotEmpty()) {
           context.execute("generate jdeps") { jDepsGenerator.generateJDeps(this) }
         }
+        if (outputs.generatedJavaSrcJar.isNotEmpty()) {
+          context.execute("creating generated Java source jar", ::createGeneratedJavaSrcJar)
+        }
       }
     }
   }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -154,6 +154,21 @@ internal fun JvmCompilationTask.createAbiJar() =
     }
 
 /**
+ * Produce the primary output jar.
+ */
+internal fun JvmCompilationTask.createGeneratedJavaSrcJar() {
+  JarCreator(
+    path = Paths.get(outputs.generatedJavaSrcJar),
+    normalize = true,
+    verbose = false
+  ).also {
+    it.addDirectory(Paths.get(directories.generatedSources))
+    it.setJarOwner(info.label, info.bazelRuleKind)
+    it.execute()
+  }
+}
+
+/**
  * Compiles Kotlin sources to classes. Does not compile Java sources.
  */
 fun JvmCompilationTask.compileKotlin(

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KaptCompilerPluginArgsEncoder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KaptCompilerPluginArgsEncoder.kt
@@ -84,7 +84,8 @@ class KaptCompilerPluginArgsEncoder(
 
   fun encode(context: CompilationTaskContext, task: JvmCompilationTask): List<String> {
     val javacArgs = mutableMapOf<String, String>(
-      "-target" to task.info.toolchainInfo.jvm.jvmTarget
+      "-target" to task.info.toolchainInfo.jvm.jvmTarget,
+      "-source" to task.info.toolchainInfo.jvm.jvmTarget
     )
     val d = task.directories
     return if (task.inputs.processorsList.isNotEmpty()) {

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -103,6 +103,8 @@ message JvmCompilationTask {
     string srcjar = 3;
     // The path to the abijar
     string abijar = 4;
+    // The path to the jar containing Java source generated from Kotlin annotation processors.
+    string generated_java_src_jar = 5;
   }
 
   message Inputs {


### PR DESCRIPTION
Where kapt runs annotation processors that generate Java source code (e.g: Dagger) that generated Java source must be compiled with any project Java source code.