### PR TITLE
Option to tag a rule as kt_abi_plugin_incompatible

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -630,7 +630,7 @@ def _run_kt_java_builder_actions(ctx, rule_kind, toolchains, srcs, generated_src
     # Build Kotlin
     if srcs.kt or srcs.src_jars:
         kt_runtime_jar = ctx.actions.declare_file(ctx.label.name + "-kt.jar")
-        if toolchains.kt.experimental_use_abi_jars:
+        if toolchains.kt.experimental_use_abi_jars and not "kt_abi_plugin_incompatible" in ctx.attr.tags:
             kt_compile_jar = ctx.actions.declare_file(ctx.label.name + "-kt.abi.jar")
             outputs = {
                 "output": kt_runtime_jar,

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -171,11 +171,8 @@ _kt_toolchain = rule(
             providers = [_KtJsInfo],
         ),
         "experimental_use_abi_jars": attr.bool(
-            doc = "Compile using abi jars, requires experimental_use_java_builder",
-            default = False,
-        ),
-        "experimental_use_java_builder" : attr.bool(
-            doc="Use Bazel JavaBuilder for Java source",
+            doc = """Compile using abi jars, requires experimental_use_java_builder. Can be disabled
+            for an individual target using the tag `kt_abi_plugin_incompatible`""",
             default = False,
         ),
         "experimental_use_java_builder" : attr.bool(

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -178,6 +178,10 @@ _kt_toolchain = rule(
             doc="Use Bazel JavaBuilder for Java source",
             default = False,
         ),
+        "experimental_use_java_builder" : attr.bool(
+            doc="Use Bazel JavaBuilder for Java source",
+            default = False,
+        ),
         "javac_options": attr.label(
             doc = "Compiler options for javac",
             providers = [JavacOptions],


### PR DESCRIPTION
Allow work around of bugs in Kotlin ABI compiler plugin on a target by target basis.

https://youtrack.jetbrains.com/issue/KT-40133
https://youtrack.jetbrains.com/issue/KT-40340
https://youtrack.jetbrains.com/issue/KT-41381