### PR TITLE
Add 0 to allowed package name characters

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreator.kt
@@ -35,7 +35,7 @@ class SourceJarCreator(
     private const val BL = """\p{Blank}*"""
     private const val COM_BL = """$BL(?:/\*[^\n]*\*/$BL)*"""
     private val PKG_PATTERN: Pattern =
-      Pattern.compile("""^${COM_BL}package$COM_BL([a-zA-Z1-9._]+)$COM_BL(?:;?.*)$""")
+      Pattern.compile("""^${COM_BL}package$COM_BL([a-zA-Z0-9._]+)$COM_BL(?:;?.*)$""")
 
     @JvmStatic
     fun extractPackage(line: String): String? =

--- a/src/test/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreatorTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreatorTest.java
@@ -54,7 +54,7 @@ public class SourceJarCreatorTest {
     public void testPackageNameRegexWithZero() {
         cases.forEach(
                 (testCase) -> {
-                    testCase = testCase.replace("some1", "some0")
+                    testCase = testCase.replace("some1", "some0");
                     String pkg = SourceJarCreator.Companion.extractPackage(testCase);
                     StandardSubjectBuilder subj = assertWithMessage("positive test case: " + testCase);
                     subj.that(pkg).isNotNull();

--- a/src/test/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreatorTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreatorTest.java
@@ -49,4 +49,16 @@ public class SourceJarCreatorTest {
                     subj.that(pkg).isEqualTo(expectedPackage);
                 });
     }
+
+    @Test
+    public void testPackageNameRegexWithZero() {
+        cases.forEach(
+                (testCase) -> {
+                    testCase = testCase.replace("some1", "some0")
+                    String pkg = SourceJarCreator.Companion.extractPackage(testCase);
+                    StandardSubjectBuilder subj = assertWithMessage("positive test case: " + testCase);
+                    subj.that(pkg).isNotNull();
+                    subj.that(pkg).isEqualTo("iO.some0.package");
+                });
+    }
 }


### PR DESCRIPTION
For some unknown reason, `0` is the only alphanumeric character that wasn't recognized as in a package name. This led to odd scenarios that when you tried to compile code that had a `0` in the package name, the kotlin builder would package the code as the string before the `0` which led to some problems in auto-generated code.