### PR TITLE
Separate Xplugin options to support multiple compiler plugins at a time

### DIFF
--- a/examples/plugin/src/allopennoarg/BUILD
+++ b/examples/plugin/src/allopennoarg/BUILD
@@ -1,0 +1,66 @@
+load("//kotlin:kotlin.bzl", "kt_compiler_plugin", "kt_jvm_library", "kt_jvm_test")
+
+kt_compiler_plugin(
+    name = "open_for_testing_plugin",
+    id = "org.jetbrains.kotlin.allopen",
+    options = {
+        "annotation": "plugin.allopennoarg.OpenForTesting",
+    },
+    deps = [
+        "@com_github_jetbrains_kotlin//:allopen-compiler-plugin",
+    ],
+)
+
+kt_compiler_plugin(
+    name = "no_arg_plugin",
+    id = "org.jetbrains.kotlin.noarg",
+    options = {
+        "annotation": "plugin.allopennoarg.NoArgConstructor",
+    },
+    deps = [
+        "@com_github_jetbrains_kotlin//:noarg-compiler-plugin",
+    ],
+)
+
+kt_jvm_library(
+    name = "no_arg_constructor",
+    srcs = ["NoArgConstructor.kt"],
+)
+
+kt_jvm_library(
+    name = "open_for_testing",
+    srcs = ["OpenForTesting.kt"],
+)
+
+kt_jvm_library(
+    name = "user",
+    srcs = ["User.kt"],
+    plugins = [
+        ":open_for_testing_plugin",
+        ":no_arg_plugin"
+    ],
+    deps = [
+        ":open_for_testing",
+        ":no_arg_constructor"
+    ],
+)
+
+kt_jvm_library(
+    name = "user_is_open_test",
+    srcs = ["UserIsOpenTest.kt"],
+    deps = [
+        ":user",
+    ],
+)
+
+kt_jvm_test(
+    name = "user_has_noarg_constructor_test",
+    srcs = ["UserHasNoargConstructorTest.kt"],
+    test_class = "plugin.allopennoarg.UserHasNoargConstructorTest",
+    deps = [
+        ":user",
+        "@com_github_jetbrains_kotlin//:kotlin-reflect",
+        "@kotlin_rules_maven//:junit_junit",
+    ],
+)
+

--- a/examples/plugin/src/allopennoarg/NoArgConstructor.kt
+++ b/examples/plugin/src/allopennoarg/NoArgConstructor.kt
@@ -1,0 +1,3 @@
+package plugin.allopennoarg
+
+annotation class NoArgConstructor

--- a/examples/plugin/src/allopennoarg/OpenForTesting.kt
+++ b/examples/plugin/src/allopennoarg/OpenForTesting.kt
@@ -1,0 +1,3 @@
+package plugin.allopennoarg
+
+annotation class OpenForTesting

--- a/examples/plugin/src/allopennoarg/User.kt
+++ b/examples/plugin/src/allopennoarg/User.kt
@@ -1,0 +1,10 @@
+package plugin.allopennoarg
+
+import java.util.*
+
+@OpenForTesting
+@NoArgConstructor
+data class User(
+        val userId: UUID,
+        val emails: String
+)

--- a/examples/plugin/src/allopennoarg/UserHasNoargConstructorTest.kt
+++ b/examples/plugin/src/allopennoarg/UserHasNoargConstructorTest.kt
@@ -1,0 +1,13 @@
+package plugin.allopennoarg
+
+import org.junit.*
+import java.lang.Exception
+
+class UserHasNoargConstructorTest {
+  @Test
+  fun userShouldHaveNoargConstructor() {
+    if (User::class.java.constructors.none { it.parameters.isEmpty() }) {
+      throw Exception("Expected an empty constructor to exist")
+    }
+  }
+}

--- a/examples/plugin/src/allopennoarg/UserIsOpenTest.kt
+++ b/examples/plugin/src/allopennoarg/UserIsOpenTest.kt
@@ -1,0 +1,5 @@
+package plugin.allopennoarg
+
+import java.util.*
+
+class Subclass : User(UUID.randomUUID(), "test@example.org")

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -56,8 +56,11 @@ fun JvmCompilationTask.baseArgs(): CompilationArgs = CompilationArgs()
 
 internal fun pluginArgs(context: JvmCompilationTask, args: CompilationArgs): CompilationArgs = args
     .let {
-        val pluginsPath = context.inputs.pluginpathsList.joinToString(":")
-        it.value("-Xplugin=${pluginsPath}")
+        var r = it
+        val pluginsPath = context.inputs.pluginpathsList.forEach { pluginPath ->
+            r = r.value("-Xplugin=${pluginPath}")
+        }
+        r
     }
     .let {
         var r = it


### PR DESCRIPTION
When two plugins are joined together by `:` in the same -Xplugin option, kotlinc does not apply these. Separating out the options appears to solve the issue.

Fixes https://github.com/bazelbuild/rules_kotlin/issues/365