### PR TITLE
Add -Xinline-classes to kotlinc args

### DIFF
--- a/kotlin/internal/utils/utils.bzl
+++ b/kotlin/internal/utils/utils.bzl
@@ -34,7 +34,7 @@ def _init_builder_args(ctx, rule_kind, module_name):
     args.add("--kotlin_jvm_target", toolchain.jvm_target)
     args.add("--kotlin_api_version", toolchain.api_version)
     args.add("--kotlin_language_version", toolchain.language_version)
-    args.add("--kotlin_passthrough_flags", "-Xuse-experimental=kotlin.Experimental")
+    args.add("--kotlin_passthrough_flags", "-Xinline-classes,-Xuse-experimental=kotlin.Experimental")
 
     debug = depset(toolchain.debug)
     for tag in ctx.attr.tags:


### PR DESCRIPTION
For #367 

Does not address long-term stated goals of providing a mechanism to do this. 