### PR TITLE
Support multiple source jars

### DIFF
--- a/examples/dagger/BUILD
+++ b/examples/dagger/BUILD
@@ -34,11 +34,29 @@ rm TeaPot.kt
     toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
 )
 
+genrule(
+    name = "chai_lib_src",
+    outs = ["chai_lib_src.srcjar"],
+    cmd = """
+cat << EOF > ChaiCup.kt
+package chai
+object ChaiCup {
+    fun isEmpty() = true
+}
+EOF
+$(JAVABASE)/bin/jar -cf $@ ChaiCup.kt
+rm ChaiCup.kt
+""",
+    toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
+)
+
+
 kt_jvm_library(
     name = "coffee_lib",
     srcs = glob(["src/**"]) + [
         # Adding a file ending with .srcjar is how code generation patterns are implemented.
         ":tea_lib_src",
+        ":chai_lib_src",
     ],
     deps = [
         "//third_party:dagger",

--- a/examples/dagger/src/coffee/CoffeeApp.kt
+++ b/examples/dagger/src/coffee/CoffeeApp.kt
@@ -18,6 +18,7 @@ package coffee
 import dagger.Component
 import kotlinx.coroutines.runBlocking
 import tea.TeaPot
+import chai.ChaiCup
 import javax.inject.Singleton
 
 class CoffeeApp {
@@ -30,7 +31,7 @@ class CoffeeApp {
   companion object {
     @JvmStatic
     fun main(args: Array<String>) {
-      if (TeaPot.isEmpty()) {
+      if (TeaPot.isEmpty() && ChaiCup.isEmpty()) {
         val coffeeShop = DaggerCoffeeApp_CoffeeShop.builder().build()
         runBlocking {
           coffeeShop.maker().brew()

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarExtractor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarExtractor.kt
@@ -24,10 +24,15 @@ class SourceJarExtractor(destDir: Path, val fileMatcher: Predicate<String> = Pre
   val sourcesList = mutableListOf<String>()
 
   override fun preWrite(isDirectory: Boolean, target: Path): Boolean {
-    if (!isDirectory && fileMatcher.test(target.toString())) {
-      sourcesList.add(target.toString())
+    if (isDirectory) {
+      return true
     }
-    return true
+
+    if (fileMatcher.test(target.toString())) {
+      sourcesList.add(target.toString())
+      return true
+    }
+    return false
   }
 
   fun execute() {


### PR DESCRIPTION
Including multiple source jars currently does not work as SourceJarExtractor fails to overwrite META-INF/MANIFEST.MF which is present in all jars.

Fix this by having SourceJarExtractor.preWrite() return true only for directories and files that match the extraction pattern.