### PR TITLE
setting tags = ["trace", "timings"] on a rule is currently broken.

### DIFF
--- a/kotlin/internal/utils/utils.bzl
+++ b/kotlin/internal/utils/utils.bzl
@@ -36,7 +36,7 @@ def _init_builder_args(ctx, rule_kind, module_name):
     args.add("--kotlin_language_version", toolchain.language_version)
     args.add("--kotlin_passthrough_flags", "-Xuse-experimental=kotlin.Experimental")
 
-    debug = depset(toolchain.debug)
+    debug = toolchain.debug
     for tag in ctx.attr.tags:
         if tag == "trace":
             debug = debug + [tag]


### PR DESCRIPTION
Tags should be a sequence, not a depset.