### PR TITLE
Support the new Kotlin IR backend

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -342,6 +342,12 @@ def _kotlinc_options_provider_to_flags(opts):
         flags.append("-nowarn")
     if opts.x_use_experimental:
         flags.append("-Xuse-experimental=kotlin.Experimental")
+    if opts.x_use_ir:
+        flags.append("-Xuse-ir")
+    if opts.x_allow_jvm_ir_dependencies:
+        flags.append("-Xallow-jvm-ir-dependencies")
+    if opts.x_skip_prerelease_check:
+        flags.append("-Xskip-prerelease-check")
     return flags
 
 def _javac_options_provider_to_flags(opts):

--- a/kotlin/internal/opts.bzl
+++ b/kotlin/internal/opts.bzl
@@ -27,6 +27,27 @@ _KOPTS = {
         ),
         type = attr.bool,
     ),
+    "x_use_ir": struct(
+        args = dict(
+            default = False,
+            doc = "Enable or disable the experimental IR backend.",
+        ),
+        type = attr.bool,
+    ),
+    "x_allow_jvm_ir_dependencies": struct(
+        args = dict(
+            default = False,
+            doc = "Suppress errors thrown when using dependencies not compiled by the IR backend.",
+        ),
+        type = attr.bool,
+    ),
+    "x_skip_prerelease_check": struct(
+        args = dict(
+            default = False,
+            doc = "Suppress errors thrown when using pre-release classes.",
+        ),
+        type = attr.bool,
+    ),
 }
 
 KotlincOptions = provider(


### PR DESCRIPTION
In order to support Jetpack Compose we need to support enabling the experimental IR backend.

Compose setup examples: https://developer.android.com/jetpack/androidx/releases/compose#declaring_dependencies
Docs for the new IR backend: https://kotlinlang.org/docs/reference/whatsnew14.html#new-jvm-ir-backend