### PR TITLE
Expose kt_kotlinc_options and kt_javac_options

### DIFF
--- a/kotlin/internal/BUILD
+++ b/kotlin/internal/BUILD
@@ -18,11 +18,15 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 kt_kotlinc_options(
     name = "default_kotlinc_options",
+    # Used internally as the rule default. This should be 
+    # considered an implementation detail and not used externally
     visibility = ["//visibility:public"],
 )
 
 kt_javac_options(
     name = "default_javac_options",
+    # Used internally as the rule default. This should be 
+    # considered an implementation detail and not used externally
     visibility = ["//visibility:public"],
 )
 

--- a/kotlin/kotlin.bzl
+++ b/kotlin/kotlin.bzl
@@ -19,6 +19,8 @@ load(
 load(
     "//kotlin:rules.bzl",
     _define_kt_toolchain = "define_kt_toolchain",
+    _kt_kotlinc_options = "kt_kotlinc_options",
+    _kt_javac_options = "kt_javac_options",
     _kt_android_library = "kt_android_library",
     _kt_compiler_plugin = "kt_compiler_plugin",
     _kt_js_import = "kt_js_import",
@@ -32,6 +34,8 @@ load(
 
 kotlin_repositories = _kotlin_repositories
 define_kt_toolchain = _define_kt_toolchain
+kt_kotlinc_options = _kt_kotlinc_options
+kt_javac_options = _kt_javac_options
 kt_js_library = _kt_js_library
 kt_js_import = _kt_js_import
 kt_register_toolchains = _kt_register_toolchains

--- a/kotlin/rules.bzl
+++ b/kotlin/rules.bzl
@@ -20,6 +20,11 @@ load(
     _kt_register_toolchains = "kt_register_toolchains",
 )
 load(
+    "//kotlin/internal:opts.bzl",
+    _kt_kotlinc_options = "kt_kotlinc_options",
+    _kt_javac_options = "kt_javac_options",
+)
+load(
     "//kotlin/internal/jvm:jvm.bzl",
     _kt_compiler_plugin = "kt_compiler_plugin",
     _kt_jvm_binary = "kt_jvm_binary",
@@ -38,6 +43,8 @@ load(
 )
 
 define_kt_toolchain = _define_kt_toolchain
+kt_kotlinc_options = _kt_kotlinc_options
+kt_javac_options = _kt_javac_options
 kt_js_library = _kt_js_library
 kt_js_import = _kt_js_import
 kt_register_toolchains = _kt_register_toolchains


### PR DESCRIPTION
What changed in this PR
- `kt_kotlinc_options` and `kt_javac_options` are being exposed by `kotlin/kotlin.bzl` so that we can optionally override the default kotlinc and javac options