### PR TITLE
Fix kt_compiler_plugin not working with android_binary

### DIFF
--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -19,6 +19,7 @@ maven_install(
         "junit:junit:4.12",
         "androidx.test.espresso:espresso-core:3.1.1",
         "org.hamcrest:hamcrest-library:1.3",
+        "org.jetbrains.kotlinx:kotlinx-serialization-runtime:1.0-M1-1.4.0-rc",
     ],
     repositories = [
         "https://jcenter.bintray.com/",

--- a/examples/android/lib/BUILD.bazel
+++ b/examples/android/lib/BUILD.bazel
@@ -1,4 +1,11 @@
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_compiler_plugin", "kt_android_library")
+
+kt_compiler_plugin(
+    name = "serialization_plugin",
+    deps = [
+        "@com_github_jetbrains_kotlin//:kotlinx-serialization-compiler-plugin",
+    ],
+)
 
 kt_android_library(
     name = "lib",
@@ -7,6 +14,10 @@ kt_android_library(
     manifest = "src/main/AndroidManifest.xml",
     visibility = ["//visibility:public"],
     deps = [
+        "@maven//:org_jetbrains_kotlinx_kotlinx_serialization_runtime",
         "@maven//:androidx_appcompat_appcompat",
+    ],
+    plugins = [
+        ":serialization_plugin",
     ],
 )

--- a/examples/android/lib/src/main/kotlin/examples/android/lib/Data.kt
+++ b/examples/android/lib/src/main/kotlin/examples/android/lib/Data.kt
@@ -1,0 +1,6 @@
+package examples.android.lib
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Data(val stringValue: String, val intValue: Int)

--- a/examples/android/lib/src/main/kotlin/examples/android/lib/MainActivity.kt
+++ b/examples/android/lib/src/main/kotlin/examples/android/lib/MainActivity.kt
@@ -18,5 +18,7 @@ class MainActivity : Activity() {
         .setTitle("Blah")
         .setMessage("Blah blah blah?")
         .show()
+    // Ensure Serialization plugin has run and generated code correctly.
+    Data.serializer()
   }
 }

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -236,7 +236,7 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar, compile_jar):
     dirs = _compiler_directories(ctx)
     srcs = _partitioned_srcs(ctx.files.srcs)
     friend = _compiler_friends(ctx, friends = getattr(ctx.attr, "friends", []))
-    compile_deps = _compiler_deps(toolchains, friend, deps = ctx.attr.deps + ctx.attr.plugins)
+    compile_deps = _compiler_deps(toolchains, friend, deps = ctx.attr.deps)
     annotation_processors = _plugin_mappers.targets_to_annotation_processors(ctx.attr.plugins + ctx.attr.deps)
     transitive_runtime_jars = _plugin_mappers.targets_to_transitive_runtime_jars(ctx.attr.plugins + ctx.attr.deps)
     plugins = ctx.attr.plugins


### PR DESCRIPTION
`kt_compiler_plugin` currently doesn't work when used from anywhere in the deps of an `android-binary` target, failing as follows:-

```
ERROR: /Users/jgerrish/indiekid/rules_kotlin/examples/android/app/BUILD.bazel:29:15: in deps attribute of android_binary rule //app:app3: Dependencies on .jar artifacts are not allowed in Android binaries, please use a java_import to depend on kotlin_rules_maven/v1/https/jcenter.bintray.com/org/jetbrains/kotlin/kotlin-serialization-unshaded/1.4.10/kotlin-serialization-unshaded-1.4.10.jar. If this is an implicit dependency then the rule that introduces it will need to be fixed to account for it correctly.. Since this rule was created by the macro 'android_binary', the error might have been caused by the macro implementation
ERROR: Analysis of target '//app:force_build_apks_test' failed; build aborted: Analysis of target '//app:app3' failed
```

The fix is not including plugins as part of the compile deps.

Add `kt_compiler_plugin` to the `kt_android_library` target referenced by an `android_binary` update Activity to reference generated code to validate it was run correctly.