### PR TITLE
Expose -Werror as a compiler option

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -338,8 +338,10 @@ def _kotlinc_options_provider_to_flags(opts):
     if not opts:
         return ""
     flags = []
-    if not opts.warn:
+    if opts.warn == "off":
         flags.append("-nowarn")
+    elif opts.warn == "error":
+        flags.append("-Werror")
     if opts.x_use_experimental:
         flags.append("-Xuse-experimental=kotlin.Experimental")
     return flags
@@ -348,8 +350,10 @@ def _javac_options_provider_to_flags(opts):
     if not opts:
         return ""
     flags = []
-    if not opts.warn:
+    if opts.warn == "off":
         flags.append("-nowarn")
+    elif opts.warn == "error":
+        flags.append("-Werror")
     if opts.x_ep_disable_all_checks:
         flags.append("-XepDisableAllChecks")
     if opts.x_lint:

--- a/kotlin/internal/opts.bzl
+++ b/kotlin/internal/opts.bzl
@@ -15,10 +15,11 @@
 _KOPTS = {
     "warn": struct(
         args = dict(
-            default = True,
-            doc = "Enable or disable compiler warnings.",
+            default = "report",
+            doc = "Control warning behaviour.",
+            values = ["off", "report", "error"],
         ),
-        type = attr.bool,
+        type = attr.string,
     ),
     "x_use_experimental": struct(
         args = dict(
@@ -56,10 +57,11 @@ kt_kotlinc_options = rule(
 _JOPTS = {
     "warn": struct(
         args = dict(
-            default = True,
-            doc = "Enable or disable compiler warnings.",
+            default = "report",
+            doc = "Control warning behaviour.",
+            values = ["off", "report", "error"],
         ),
-        type = attr.bool,
+        type = attr.string,
     ),
     "x_ep_disable_all_checks": struct(
         args = dict(


### PR DESCRIPTION
The user-facing option name (`all_warnings_as_errors`) matches Gradle's equivalent option (`AllWarningsAsErrors`). Not sure if that makes lots of sense, and I'm happy to change it for a better suggestion - `werror` or `w_error` don't sound exactly great.

This PR does this for both javac and kotlinc.