### PR TITLE
Include kt_compiler_plugin deps as input to Kotlin builder action.

### DIFF
--- a/kotlin/internal/compiler_plugins.bzl
+++ b/kotlin/internal/compiler_plugins.bzl
@@ -3,6 +3,10 @@ load(
     _KtCompilerPluginInfo = "KtCompilerPluginInfo",
 )
 
+def targets_to_compiler_plugins_transitive(targets):
+    kt_compiler_plugin_providers = [providers[_KtCompilerPluginInfo] for providers in targets if _KtCompilerPluginInfo in providers]
+    return depset(transitive = [depset(t.classpath) for t in kt_compiler_plugin_providers])
+
 def plugins_to_classpaths(providers_list):
     flattened_files = []
     for providers in providers_list:

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -27,6 +27,7 @@ load(
     "//kotlin/internal:compiler_plugins.bzl",
     _plugins_to_classpaths = "plugins_to_classpaths",
     _plugins_to_options = "plugins_to_options",
+    _targets_to_compiler_plugins_transitive = "targets_to_compiler_plugins_transitive",
 )
 load(
     "//kotlin/internal/utils:utils.bzl",
@@ -238,7 +239,10 @@ def kt_jvm_compile_action(ctx, rule_kind, output_jar, compile_jar):
     friend = _compiler_friends(ctx, friends = getattr(ctx.attr, "friends", []))
     compile_deps = _compiler_deps(toolchains, friend, deps = ctx.attr.deps)
     annotation_processors = _plugin_mappers.targets_to_annotation_processors(ctx.attr.plugins + ctx.attr.deps)
-    transitive_runtime_jars = _plugin_mappers.targets_to_transitive_runtime_jars(ctx.attr.plugins + ctx.attr.deps)
+    transitive_runtime_jars =  depset(transitive = [
+        _plugin_mappers.targets_to_transitive_runtime_jars(ctx.attr.plugins + ctx.attr.deps),
+        _targets_to_compiler_plugins_transitive(ctx.attr.plugins),
+    ])
     plugins = ctx.attr.plugins
 
     if toolchains.kt.experimental_use_abi_jars:


### PR DESCRIPTION
Currently transitive deps for `kt_compiler_plugin` targets are not included in the inputs to the Kotlin Builder action.

This results in a runtime error when running compiler plugins that try to load classes from their dependencies.