### PR TITLE
Use third_party jarjar.

### DIFF
--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -500,7 +500,7 @@ kt_compiler_plugin = rule(
         "_jarjar": attr.label(
             executable = True,
             cfg = "host",
-            default = Label("@bazel_tools//third_party/jarjar:jarjar_bin"),
+            default = Label("@io_bazel_rules_kotlin//third_party:jarjar_runner"),
         ),
     },
     implementation = _kt_compiler_plugin_impl,

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -86,6 +86,7 @@ release_archive(
         "empty.jar",
         "empty.jdeps",
         "jarjar.bzl",
+        "@kotlin_rules_maven//:org_pantsbuild_jarjar",
     ],
     src_map = {
         "BUILD.release.bazel": "BUILD.bazel",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -57,6 +57,13 @@ java_library(
     ],
 )
 
+java_binary(
+    name = "jarjar_runner",
+    main_class = "org.pantsbuild.jarjar.Main",
+    visibility = ["//visibility:public"],
+    runtime_deps = ["@kotlin_rules_maven//:org_pantsbuild_jarjar"],
+)
+
 # TODO(bazelbuild/rules_kotlin/issues/273): Remove android_sdk import.
 java_import(
     name = "android_sdk",

--- a/third_party/BUILD.release.bazel
+++ b/third_party/BUILD.release.bazel
@@ -21,7 +21,7 @@ java_binary(
     name = "jarjar_runner",
     main_class = "org.pantsbuild.jarjar.Main",
     visibility = ["//visibility:public"],
-    runtime_deps = ["@kotlin_rules_maven//:org_pantsbuild_jarjar"],
+    runtime_deps = [":jarjar-1.7.2.jar"],
 )
 
 java_import(

--- a/third_party/BUILD.release.bazel
+++ b/third_party/BUILD.release.bazel
@@ -17,6 +17,13 @@ exports_files([
     "empty.jdeps",
 ])
 
+java_binary(
+    name = "jarjar_runner",
+    main_class = "org.pantsbuild.jarjar.Main",
+    visibility = ["//visibility:public"],
+    runtime_deps = ["@kotlin_rules_maven//:org_pantsbuild_jarjar"],
+)
+
 java_import(
     name = "android_sdk",
     jars = ["@bazel_tools//tools/android:android_jar"],

--- a/third_party/jarjar.bzl
+++ b/third_party/jarjar.bzl
@@ -50,7 +50,7 @@ jar_jar = rule(
         "jarjar_runner": attr.label(
             executable = True,
             cfg = "host",
-            default = Label("@bazel_tools//third_party/jarjar:jarjar_bin"),
+            default = Label("@io_bazel_rules_kotlin//third_party:jarjar_runner"),
         ),
     },
     outputs = {


### PR DESCRIPTION
JarJar was removed from @bazel_tools, because it is not something that should be generally packed with Bazel.