### PR TITLE
Upgrade rules_nodejs to 1.7.0

### DIFF
--- a/examples/node/WORKSPACE
+++ b/examples/node/WORKSPACE
@@ -31,13 +31,7 @@ maven_install(
     ],
 )
 
-http_archive(
-    name = "build_bazel_rules_nodejs",
-    sha256 = "3356c6b767403392bab018ce91625f6d15ff8f11c6d772dc84bc9cada01c669a",
-    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/0.36.1/rules_nodejs-0.36.1.tar.gz"],
-)
-
-load("@build_bazel_rules_nodejs//:defs.bzl", "yarn_install")
+load("@build_bazel_rules_nodejs//:index.bzl", "yarn_install")
 
 yarn_install(
     name = "node_ws",

--- a/examples/node/coroutines-helloworld/BUILD
+++ b/examples/node/coroutines-helloworld/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_js_library")
-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
 kt_js_library(
     name = "app",

--- a/examples/node/express/BUILD
+++ b/examples/node/express/BUILD
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_js_library")
-load("@build_bazel_rules_nodejs//:defs.bzl", "nodejs_binary")
+load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 
 # routes and auth have acme prepended to the rule name as these are the names of the resulting jars. The name of the
 # jar is the name of the module, and thus the name of the require statements.

--- a/kotlin/internal/repositories/download.bzl
+++ b/kotlin/internal/repositories/download.bzl
@@ -14,8 +14,8 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive", "http_file", "http_jar")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
-RULES_NODEJS_VERSION = "0.36.1"
-RULES_NODEJS_SHA = "3356c6b767403392bab018ce91625f6d15ff8f11c6d772dc84bc9cada01c669a"
+RULES_NODEJS_VERSION = "1.7.0"
+RULES_NODEJS_SHA = "84abf7ac4234a70924628baa9a73a5a5cbad944c4358cf9abdb4aab29c9a5b77"
 
 BAZEL_TOOLCHAINS_VERSION = "3.7.0"
 BAZEL_TOOLCHAINS_SHA = "8e0633dfb59f704594f19ae996a35650747adc621ada5e8b9fb588f808c89cb0"


### PR DESCRIPTION
rules_nodejs pre 1.6.0 had invalid escape sequences in its Starlark code, which was silently ignored but now throws an error (due to bazelbuild/bazel@73402fa).