### PR TITLE
Fix java_plugins to work with Android rules

### DIFF
--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -23,6 +23,8 @@ maven_install(
         "com.google.dagger:dagger:2.28",
         "com.google.dagger:dagger-compiler:2.28",
         "com.google.dagger:dagger-producers:2.28",
+        "com.google.auto.value:auto-value:1.6.5",
+        "com.google.auto.value:auto-value-annotations:1.6.5",
     ],
     repositories = [
         "https://jcenter.bintray.com/",

--- a/examples/android/lib/BUILD.bazel
+++ b/examples/android/lib/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_android_library", "kt_compiler_plugin")
+load("@rules_java//java:defs.bzl", "java_plugin")
 
 kt_compiler_plugin(
     name = "serialization_plugin",
@@ -10,6 +11,13 @@ kt_compiler_plugin(
     ],
 )
 
+java_plugin(
+    name = "autovalue",
+    generates_api = 1,
+    processor_class = "com.google.auto.value.processor.AutoValueProcessor",
+    deps = ["@maven//:com_google_auto_value_auto_value"],
+)
+
 kt_android_library(
     name = "lib",
     srcs = glob(["src/main/kotlin/**/*.kt"]),
@@ -17,10 +25,13 @@ kt_android_library(
     manifest = "src/main/AndroidManifest.xml",
     plugins = [
         ":serialization_plugin",
+        ":autovalue",
     ],
+    tags = ["trace"],
     visibility = ["//visibility:public"],
     deps = [
         "@maven//:androidx_appcompat_appcompat",
         "@maven//:org_jetbrains_kotlinx_kotlinx_serialization_runtime",
+        "@maven//:com_google_auto_value_auto_value_annotations"
     ],
 )

--- a/examples/android/lib/src/main/kotlin/examples/android/lib/MainActivity.kt
+++ b/examples/android/lib/src/main/kotlin/examples/android/lib/MainActivity.kt
@@ -20,5 +20,7 @@ class MainActivity : Activity() {
         .show()
     // Ensure Serialization plugin has run and generated code correctly.
     Data.serializer()
+
+    AutoValue_TestKtValue.Builder().setName("Auto Value Test").build()
   }
 }

--- a/examples/android/lib/src/main/kotlin/examples/android/lib/TestKtValue.kt
+++ b/examples/android/lib/src/main/kotlin/examples/android/lib/TestKtValue.kt
@@ -1,0 +1,15 @@
+package examples.android.lib
+
+import com.google.auto.value.AutoValue
+
+@AutoValue
+abstract class TestKtValue {
+  abstract fun name(): String
+  fun builder(): Builder = AutoValue_TestKtValue.Builder()
+
+  @AutoValue.Builder
+  abstract class Builder {
+    abstract fun setName(name: String): Builder
+    abstract fun build(): TestKtValue
+  }
+}

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -483,7 +483,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
     compile_deps = _jvm_deps(
         toolchains,
         friend,
-        deps = ctx.attr.deps + ctx.attr.plugins,
+        deps = ctx.attr.deps,
         runtime_deps = ctx.attr.runtime_deps,
     )
     annotation_processors = _plugin_mappers.targets_to_annotation_processors(ctx.attr.plugins + ctx.attr.deps)


### PR DESCRIPTION
`java_plugin` rules used from Android rules fail with the following error:-

```
ERROR: /Users/jgerrish/indiekid/rules_kotlin/examples/android/app/BUILD.bazel:29:15: in deps attribute of android_binary rule //app:app3: Dependencies on .jar artifacts are not allowed in Android binaries, please use a java_import to depend on kotlin_rules_maven/v1/https/maven-central.storage.googleapis.com/repos/central/data/com/google/auto/value/auto-value/1.6.5/auto-value-1.6.5.jar. If this is an implicit dependency then the rule that introduces it will need to be fixed to account for it correctly.. Since this rule was created by the macro 'android_binary', the error might have been caused by the macro implementation
```

This is due to including plugins as compile dependencies.

Remove plugins from compile dependencies and add a test to ensure annotation processed code is available when using Android rules.

Similar to https://github.com/bazelbuild/rules_kotlin/pull/388