### PR TITLE
Java builder flow fixes

### DIFF
--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -64,7 +64,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_reg
 
 kotlin_repositories()
 
-kt_register_toolchains()
+register_toolchains("//bzl:experimental_toolchain")
 
 http_archive(
     name = "rules_pkg",

--- a/examples/android/bzl/BUILD.bazel
+++ b/examples/android/bzl/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain")
+
+define_kt_toolchain(
+    name = "experimental_toolchain",
+    api_version = "1.4",
+    experimental_use_abi_jars = True,
+    experimental_use_java_builder = True,
+    language_version = "1.4",
+)

--- a/examples/android/bzl/BUILD.bazel
+++ b/examples/android/bzl/BUILD.bazel
@@ -1,9 +1,21 @@
 load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain")
 
+load("@io_bazel_rules_kotlin//kotlin/internal:opts.bzl", "kt_javac_options", "kt_kotlinc_options")
+
+kt_kotlinc_options(
+    name = "default_kotlinc_options",
+)
+
+kt_javac_options(
+    name = "default_javac_options",
+)
+
 define_kt_toolchain(
     name = "experimental_toolchain",
     api_version = "1.4",
     experimental_use_abi_jars = True,
     experimental_use_java_builder = True,
     language_version = "1.4",
+    javac_options = ":default_javac_options",
+    kotlinc_options = ":default_kotlinc_options"
 )

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -490,10 +490,10 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
     transitive_runtime_jars = _plugin_mappers.targets_to_transitive_runtime_jars(ctx.attr.plugins + ctx.attr.deps)
     plugins = ctx.attr.plugins + _exported_plugins(deps = ctx.attr.deps)
 
-    output_jars = []
     generated_src_jars = []
     if toolchains.kt.experimental_use_java_builder:
-        _run_kt_java_builder_actions(
+        compile_jar = ctx.actions.declare_file(ctx.label.name + ".abi.jar")
+        output_jars = _run_kt_java_builder_actions(
             ctx = ctx,
             rule_kind = rule_kind,
             toolchains = toolchains,
@@ -504,6 +504,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
             annotation_processors = annotation_processors,
             transitive_runtime_jars = transitive_runtime_jars,
             plugins = plugins,
+            compile_jar = compile_jar
         )
 
     else:
@@ -524,7 +525,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
             },
         )
         compile_jar = kt_java_output_jar
-        output_jars.append(kt_java_output_jar)
+        output_jars = [kt_java_output_jar]
 
     # If this rule has any resources declared setup a zipper action to turn them into a jar.
     if len(ctx.files.resources) > 0:
@@ -593,8 +594,9 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
 
 """Runs the necessary KotlinBuilder and JavaBuilder actions to compile a jar
 """
-def _run_kt_java_builder_actions(ctx, rule_kind, toolchains, srcs, generated_src_jars, friend, compile_deps, annotation_processors, transitive_runtime_jars, plugins):
+def _run_kt_java_builder_actions(ctx, rule_kind, toolchains, srcs, generated_src_jars, friend, compile_deps, annotation_processors, transitive_runtime_jars, plugins, compile_jar):
     compile_jars = []
+    output_jars = []
     kt_stubs_for_java = []
 
     # Run KAPT
@@ -717,6 +719,8 @@ def _run_kt_java_builder_actions(ctx, rule_kind, toolchains, srcs, generated_src
         action_type = "Abi",
         input_jars = compile_jars,
     )
+
+    return output_jars
 
 def export_only_providers(ctx, actions, attr, outputs):
     """_export_only_providers creates a series of forwarding providers without compilation overhead.

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -448,7 +448,7 @@ def _run_kt_builder_action(
     )
 
     ctx.actions.run(
-        mnemonic = "KotlinCompile",
+        mnemonic = mnemonic,
         inputs = depset(
             srcs.all_srcs + srcs.src_jars,
             transitive = [compile_deps.compile_jars, transitive_runtime_jars] + [p.classpath for p in compiler_plugins],

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -68,7 +68,7 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
                     }
                     .given(outputs.abijar).notEmpty {
                       plugin(plugins.jvmAbiGen) {
-                        flag("outputDir", directories.classes)
+                        flag("outputDir", directories.abiClasses)
                       }
                       given(outputs.jar).empty {
                         plugin(plugins.skipCodeGen)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -112,7 +112,8 @@ internal fun JvmCompilationTask.kaptArgs(
   aptMode: String
 ): CompilationArgs {
   val javacArgs = mapOf<String, String>(
-    "-target" to info.toolchainInfo.jvm.jvmTarget
+    "-target" to info.toolchainInfo.jvm.jvmTarget,
+    "-source" to info.toolchainInfo.jvm.jvmTarget
   )
   return CompilationArgs()
     .xFlag("plugin", plugins.kapt.jarPath)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -196,7 +196,7 @@ internal fun JvmCompilationTask.createAbiJar() =
         normalize = true,
         verbose = false
     ).also {
-      it.addDirectory(Paths.get(directories.classes))
+      it.addDirectory(Paths.get(directories.abiClasses))
       it.addDirectory(Paths.get(directories.generatedClasses))
       it.setJarOwner(info.label, info.bazelRuleKind)
       it.execute()


### PR DESCRIPTION
1. experimental_use_java_builder flow is broken at head. Fix breakages, convert examples/android project to use custom toolchain with both experimental_use_java_builder + experimental_use_abi_jars to validate this flow.

2. Java source version must be passed to KAPT so that generated source matches the target. When targeting Java 8 but omitting the source value, incorrectly Dagger generates @javax.annotation.processing.Generated when it actually needs to generate @javax.annotation.Generated.

3. ABI classes should be written to a separate output folder to regular compilation output so that output in the compile jar is not polluted by non-ABI classes. 
