### PR TITLE
Unify experimental java builder + abi jar flags

### DIFF
--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -276,7 +276,7 @@ kt_jvm_test(<a href="#kt_jvm_test-name">name</a>, <a href="#kt_jvm_test-data">da
 ## define_kt_toolchain
 
 <pre>
-define_kt_toolchain(<a href="#define_kt_toolchain-name">name</a>, <a href="#define_kt_toolchain-language_version">language_version</a>, <a href="#define_kt_toolchain-api_version">api_version</a>, <a href="#define_kt_toolchain-jvm_target">jvm_target</a>, <a href="#define_kt_toolchain-experimental_use_abi_jars">experimental_use_abi_jars</a>, <a href="#define_kt_toolchain-experimental_use_java_builder">experimental_use_java_builder</a>
+define_kt_toolchain(<a href="#define_kt_toolchain-name">name</a>, <a href="#define_kt_toolchain-language_version">language_version</a>, <a href="#define_kt_toolchain-api_version">api_version</a>, <a href="#define_kt_toolchain-jvm_target">jvm_target</a>, <a href="#define_kt_toolchain-experimental_use_abi_jars">experimental_use_abi_jars</a>
                     <a href="#define_kt_toolchain-javac_options">javac_options</a>, <a href="#define_kt_toolchain-kotlinc_options">kotlinc_options</a>)
 </pre>
 
@@ -292,7 +292,6 @@ Define the Kotlin toolchain.
 | api_version |  <p align="center"> - </p>   |  <code>None</code> |
 | jvm_target |  <p align="center"> - </p>   |  <code>None</code> |
 | experimental_use_abi_jars |  <p align="center"> - </p>   |  <code>False</code> |
-| experimental_use_java_builder |  <p align="center"> - </p>   |  <code>False</code> |
 | javac_options |  <p align="center"> - </p>   |  <code>None</code> |
 | kotlinc_options |  <p align="center"> - </p>   |  <code>None</code> |
 

--- a/examples/android/bzl/BUILD.bazel
+++ b/examples/android/bzl/BUILD.bazel
@@ -14,7 +14,6 @@ define_kt_toolchain(
     name = "experimental_toolchain",
     api_version = "1.4",
     experimental_use_abi_jars = True,
-    experimental_use_java_builder = True,
     language_version = "1.4",
     javac_options = ":default_javac_options",
     kotlinc_options = ":default_kotlinc_options"

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -491,7 +491,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
     plugins = ctx.attr.plugins + _exported_plugins(deps = ctx.attr.deps)
 
     generated_src_jars = []
-    if toolchains.kt.experimental_use_java_builder:
+    if toolchains.kt.experimental_use_abi_jars:
         compile_jar = ctx.actions.declare_file(ctx.label.name + ".abi.jar")
         output_jars = _run_kt_java_builder_actions(
             ctx = ctx,
@@ -632,7 +632,7 @@ def _run_kt_java_builder_actions(ctx, rule_kind, toolchains, srcs, generated_src
     # Build Kotlin
     if srcs.kt or srcs.src_jars:
         kt_runtime_jar = ctx.actions.declare_file(ctx.label.name + "-kt.jar")
-        if toolchains.kt.experimental_use_abi_jars and not "kt_abi_plugin_incompatible" in ctx.attr.tags:
+        if not "kt_abi_plugin_incompatible" in ctx.attr.tags:
             kt_compile_jar = ctx.actions.declare_file(ctx.label.name + "-kt.abi.jar")
             outputs = {
                 "output": kt_runtime_jar,
@@ -707,8 +707,6 @@ def _run_kt_java_builder_actions(ctx, rule_kind, toolchains, srcs, generated_src
             for jars in java_info.outputs.jars
         ]
         java_infos.append(java_info)
-
-    compile_jar = ctx.actions.declare_file(ctx.label.name + ".abi.jar")
 
     # Merge ABI jars into final compile jar.
     _fold_jars_action(

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -73,7 +73,6 @@ def _kotlin_toolchain_impl(ctx):
         jvm_stdlibs = java_common.merge(compile_time_providers + runtime_providers),
         js_stdlibs = ctx.attr.js_stdlibs,
         experimental_use_abi_jars = ctx.attr.experimental_use_abi_jars,
-        experimental_use_java_builder = ctx.attr.experimental_use_java_builder,
         javac_options = ctx.attr.javac_options[JavacOptions] if ctx.attr.javac_options else None,
         kotlinc_options = ctx.attr.kotlinc_options[KotlincOptions] if ctx.attr.kotlinc_options else None,
         empty_jar = ctx.file._empty_jar,
@@ -171,12 +170,8 @@ _kt_toolchain = rule(
             providers = [_KtJsInfo],
         ),
         "experimental_use_abi_jars": attr.bool(
-            doc = """Compile using abi jars, requires experimental_use_java_builder. Can be disabled
-            for an individual target using the tag `kt_abi_plugin_incompatible`""",
-            default = False,
-        ),
-        "experimental_use_java_builder" : attr.bool(
-            doc="Use Bazel JavaBuilder for Java source",
+            doc = """Compile using abi jars. Can be disabled for an individual target using the tag
+            `kt_abi_plugin_incompatible`""",
             default = False,
         ),
         "javac_options": attr.label(
@@ -216,7 +211,6 @@ def define_kt_toolchain(
         api_version = None,
         jvm_target = None,
         experimental_use_abi_jars = False,
-        experimental_use_java_builder = False,
         javac_options = None,
         kotlinc_options = None):
     """Define the Kotlin toolchain."""
@@ -239,11 +233,6 @@ def define_kt_toolchain(
             "@io_bazel_rules_kotlin//kotlin/internal:experimental_use_abi_jars": True,
             "@io_bazel_rules_kotlin//kotlin/internal:noexperimental_use_abi_jars": False,
             "//conditions:default": experimental_use_abi_jars,
-        }),
-        experimental_use_java_builder = select({
-            "@io_bazel_rules_kotlin//kotlin/internal:experimental_use_java_builder": True,
-            "@io_bazel_rules_kotlin//kotlin/internal:noexperimental_use_java_builder": False,
-            "//conditions:default": experimental_use_java_builder,
         }),
         javac_options = javac_options,
         kotlinc_options = kotlinc_options,
@@ -268,15 +257,6 @@ def kt_configure_toolchains():
     native.config_setting(
         name = "noexperimental_use_abi_jars",
         values = {"define": "experimental_use_abi_jars=0"},
-    )
-
-    native.config_setting(
-        name = "experimental_use_java_builder",
-        values = {"define": "experimental_use_java_builder=1"},
-    )
-    native.config_setting(
-        name = "noexperimental_use_java_builder",
-        values = {"define": "experimental_use_java_builder=0"},
     )
 
     native.config_setting(


### PR DESCRIPTION
Previously using `experimental_use_abi_jars` implied using Bazel's Java Builder for Java compilation. This PR removes the additional `experimental_use_java_builder` flag for simplicity, i.e: not having to support a mode using Bazel's Java builder but not using Kotlin ABI jars. Such a mode doesn't make much sense since JavaBuilder would produce header jars for Java sources, but Kotlin sources would result regular jars for compilation.

An escape hatch still exists to work around targets that expose bugs in the ABI plugin by tagging such targets with`kt_abi_plugin_incompatible`