### PR TITLE
Add anvil example to CI, and fix release artifact so jarjar works for un-shaded compiler uses in plugins.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -43,8 +43,8 @@ tasks:
     shell_commands:
       - "cd ../.. && bazel build //:rules_kotlin_release && rm -rf /tmp/rules_kotlin_release && mkdir -p /tmp/rules_kotlin_release && tar -C /tmp/rules_kotlin_release -xvf bazel-bin/rules_kotlin_release.tgz"
     working_directory: examples/anvil
-    test_flags:
-      - "--override_repository=io_bazel_rules_kotlin=/tmp/rules_kotlin_release"
+    #test_flags:
+    #  - "--override_repository=io_bazel_rules_kotlin=/tmp/rules_kotlin_release"
     test_targets:
       - //...
   examples-trivial:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -37,6 +37,16 @@ tasks:
       - "--override_repository=io_bazel_rules_kotlin=/tmp/rules_kotlin_release"
     test_targets:
       - //...
+  example-anvil:
+    name: "Example - Anvil"
+    platform: ubuntu1804
+    shell_commands:
+      - "cd ../.. && bazel build //:rules_kotlin_release && rm -rf /tmp/rules_kotlin_release && mkdir -p /tmp/rules_kotlin_release && tar -C /tmp/rules_kotlin_release -xvf bazel-bin/rules_kotlin_release.tgz"
+    working_directory: examples/anvil
+    test_flags:
+      - "--override_repository=io_bazel_rules_kotlin=/tmp/rules_kotlin_release"
+    test_targets:
+      - //...
   examples-trivial:
     name: "Example - Trivial"
     platform: ubuntu1804

--- a/examples/anvil/app/src/test/java/com/squareup/anvil/sample/BUILD.bazel
+++ b/examples/anvil/app/src/test/java/com/squareup/anvil/sample/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kt_jvm_library", "kt_jvm_test
 kt_jvm_test(
     name = "LoggedInComponentTest",
     srcs = ["LoggedInComponentTest.kt"],
+    test_class = "com.squareup.anvil.sample.LoggedInComponentTest",
     deps = [
         "//app/src/main/java/com/squareup/anvil/sample",
         "@maven//:com_google_truth_truth",

--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -87,6 +87,10 @@ release_archive(
         "empty.jdeps",
         "jarjar.bzl",
         "@kotlin_rules_maven//:org_pantsbuild_jarjar",
+        "@kotlin_rules_maven//:org_ow2_asm_asm_tree",
+        "@kotlin_rules_maven//:org_ow2_asm_asm",
+        "@kotlin_rules_maven//:org_ow2_asm_asm_commons",
+        "@kotlin_rules_maven//:org_ow2_asm_asm_analysis",
     ],
     src_map = {
         "BUILD.release.bazel": "BUILD.bazel",

--- a/third_party/BUILD.release.bazel
+++ b/third_party/BUILD.release.bazel
@@ -21,8 +21,20 @@ java_binary(
     name = "jarjar_runner",
     main_class = "org.pantsbuild.jarjar.Main",
     visibility = ["//visibility:public"],
-    runtime_deps = [":jarjar-1.7.2.jar"],
+    runtime_deps = [
+        ":jarjar",
+        ":asm",
+        ":asm-analysis",
+        ":asm-commons",
+        ":asm-tree",
+    ],
 )
+
+java_import(name = "jarjar", jars = ["jarjar-1.7.2.jar"])
+java_import(name = "asm", jars = ["asm-7.0.jar"])
+java_import(name = "asm-analysis", jars = ["asm-analysis-7.0.jar"])
+java_import(name = "asm-commons", jars = ["asm-commons-7.0.jar"])
+java_import(name = "asm-tree", jars = ["asm-tree-7.0.jar"])
 
 java_import(
     name = "android_sdk",


### PR DESCRIPTION
  - Add the anvil example to the CI.
  - Explicitly declare the test class for anvil's test, since src/test/java isn't inferred for kotlin tests.
  - Add in the dependencies of jarjar, so compiler de-shading works in the release package.
  - Temporarily disable `--override_repository` until #417 is figured out.