### PR TITLE
Add support for target level compiler opt

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ kt_register_toolchains() # to use the default toolchain, otherwise see toolchain
 
 The `kt_kotlinc_options` and `kt_javac_options` rules allows passing compiler flags to kotlinc and javac.
 
+Note: Not all compiler flags are supported in all language versions. When this happens, the rules will fail.
+
 For example you can define global compiler flags by doing: 
 ```python
 load("//kotlin:kotlin.bzl", "kt_kotlinc_options", "kt_javac_options", "define_kt_toolchain")

--- a/README.md
+++ b/README.md
@@ -187,6 +187,64 @@ kotlin_repositories() # if you want the default. Otherwise see custom kotlinc di
 kt_register_toolchains() # to use the default toolchain, otherwise see toolchains below
 ```
 
+
+
+
+
+# Kotlin and Java compiler flags
+
+The `kt_kotlinc_options` and `kt_javac_options` rules allows passing compiler flags to kotlinc and javac.
+
+For example you can define global compiler flags by doing: 
+```python
+load("//kotlin:kotlin.bzl", "kt_kotlinc_options", "kt_javac_options", "define_kt_toolchain")
+
+kt_kotlinc_options(
+    name = "kt_kotlinc_options",
+    warn = "report",
+)
+
+kt_javac_options(
+    name = "kt_javac_options",
+    warn = "report",
+    x_ep_disable_all_checks = False,
+)
+
+define_kt_toolchain(
+    name = "kotlin_toolchain",
+    kotlinc_options = "//:kt_kotlinc_options",
+    javac_options = "//:kt_javac_options",
+)
+```
+
+You can optionally override compiler flags at the target level by providing an alternative set of `kt_kotlinc_options` or `kt_javac_options` in your target definitions.
+
+Compiler flags that are passed to the rule definitions will be taken over the toolchain definition.
+
+Example:
+```python
+load("//kotlin:kotlin.bzl", "kt_kotlinc_options", "kt_javac_options", "kt_jvm_library")
+
+kt_kotlinc_options(
+    name = "kt_kotlinc_options_for_package_name",
+    warn = "error",
+)
+
+kt_javac_options(
+    name = "kt_javac_options_for_package_name",
+    warn = "error",
+    x_ep_disable_all_checks = True,
+)
+
+kt_jvm_library(
+    name = "package_name",
+    srcs = glob(["*.kt"]),
+    kotlinc_options = "//:kt_kotlinc_options_for_package_name",
+    javac_options = "//:kt_javac_options_for_package_name",
+    deps = ["//path/to/dependency"],
+)
+```
+
 # Kotlin compiler plugins
 
 The `kt_compiler_plugin` rule allows running Kotlin compiler plugins, such as no-arg, sam-with-receiver and allopen.

--- a/README.md
+++ b/README.md
@@ -187,10 +187,6 @@ kotlin_repositories() # if you want the default. Otherwise see custom kotlinc di
 kt_register_toolchains() # to use the default toolchain, otherwise see toolchains below
 ```
 
-
-
-
-
 # Kotlin and Java compiler flags
 
 The `kt_kotlinc_options` and `kt_javac_options` rules allows passing compiler flags to kotlinc and javac.

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -16,7 +16,7 @@ load(
     _kt_jvm_library = "kt_jvm_library",
 )
 
-def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], enable_data_binding = False, **kwargs):
+def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], kotlinc_opts = None, javac_opts = None, enable_data_binding = False, **kwargs):
     """Delegates Android related build attributes to the native rules but uses the Kotlin builder to compile Java and
     Kotlin srcs. Returns a sequence of labels that a wrapping macro should export.
     """
@@ -41,6 +41,8 @@ def _kt_android_artifact(name, srcs = [], deps = [], plugins = [], enable_data_b
         plugins = plugins,
         testonly = kwargs.get("testonly", default = 0),
         visibility = ["//visibility:private"],
+        kotlinc_opts = kotlinc_opts,
+        javac_opts = javac_opts,
     )
     return [base_name, kt_name]
 

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -25,6 +25,11 @@ load(
     _plugin_mappers = "mappers",
 )
 load(
+    "//kotlin/internal:opts.bzl",
+    _KotlincOptions = "KotlincOptions",
+    _JavacOptions = "JavacOptions",
+)
+load(
     "//kotlin/internal:compiler_plugins.bzl",
     _plugins_to_classpaths = "plugins_to_classpaths",
     _plugins_to_options = "plugins_to_options",
@@ -343,8 +348,13 @@ def _run_kt_builder_action(
     for f, path in outputs.items():
         args.add("--" + f, path)
 
-    args.add_all("--kotlin_passthrough_flags", _kotlinc_options_provider_to_flags(toolchains.kt.kotlinc_options))
-    args.add_all("--javacopts", _javac_options_provider_to_flags(toolchains.kt.javac_options))
+    # Unwrap kotlinc_options/javac_options options or default to the ones being provided by the toolchain
+    kotlinc_options = ctx.attr.kotlinc_opts[_KotlincOptions] if ctx.attr.kotlinc_opts else toolchains.kt.kotlinc_options
+    javac_options = ctx.attr.javac_opts[_JavacOptions] if ctx.attr.javac_opts else toolchains.kt.javac_options
+    
+    args.add_all("--kotlin_passthrough_flags", _kotlinc_options_provider_to_flags(kotlinc_options))
+    args.add_all("--javacopts", _javac_options_provider_to_flags(javac_options))
+    
     # TODO: Implement Strict Kotlin deps: (https://github.com/bazelbuild/rules_kotlin/issues/419)
     # This flag is currently unused by the builder but required for the unused_deps tool
     args.add_all("--direct_dependencies", _java_infos_to_compile_jars(compile_deps.deps))

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -104,6 +104,11 @@ load(
     _kt_jvm_plugin_aspect = "kt_jvm_plugin_aspect",
 )
 load(
+    "//kotlin/internal:opts.bzl",
+    _KotlincOptions = "KotlincOptions",
+    _JavacOptions = "JavacOptions",
+)
+load(
     "//kotlin/internal/jvm:impl.bzl",
     _kt_compiler_deps_aspect_impl = "kt_compiler_deps_aspect_impl",
     _kt_compiler_plugin_impl = "kt_compiler_plugin_impl",
@@ -203,6 +208,18 @@ _common_attr = utils.add_dicts(
             doc = """The name of the module, if not provided the module name is derived from the label. --e.g.,
         `//some/package/path:label_name` is translated to
         `some_package_path-label_name`.""",
+            mandatory = False,
+        ),
+        "kotlinc_opts": attr.label(
+            doc = """Kotlinc options to be used when compiling this target""",
+            default = None,
+            providers = [_KotlincOptions],
+            mandatory = False,
+        ),
+        "javac_opts": attr.label(
+            doc = """Javac options to be used when compiling this target""",
+            default = None,
+            providers = [_JavacOptions],
             mandatory = False,
         ),
     },

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -211,13 +211,15 @@ _common_attr = utils.add_dicts(
             mandatory = False,
         ),
         "kotlinc_opts": attr.label(
-            doc = """Kotlinc options to be used when compiling this target""",
+            doc = """Kotlinc options to be used when compiling this target. These opts if provided 
+            will be used instead of the ones provided to the toolchain.""",
             default = None,
             providers = [_KotlincOptions],
             mandatory = False,
         ),
         "javac_opts": attr.label(
-            doc = """Javac options to be used when compiling this target""",
+            doc = """Javac options to be used when compiling this target. These opts if provided will 
+            be used instead of the ones provided to the toolchain.""",
             default = None,
             providers = [_JavacOptions],
             mandatory = False,


### PR DESCRIPTION
Adds support for target-level control over compiler flags. Example usage:

```kotlin
# Provided to the toolchain as the default
kt_kotlinc_options(name = "kt_kotlinc_options", x_use_ir = False)

define_kt_toolchain(
    name = "kotlin_toolchain",
    ...
    kotlinc_options = "//:kt_kotlinc_options",
)

# Define a custom toolchain that uses the IR backend
kt_kotlinc_options(name = "kt_kotlinc_options_compose", x_use_ir = True)

kt_android_library(
    name = "compose_demo",
    ...
    kotlinc_options = "//:kt_kotlinc_options_compose",
)
```