### PR TITLE
Include jdeps as default output

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -34,7 +34,7 @@ def _make_providers(ctx, providers, transitive_files = depset(order = "default")
             providers.java,
             providers.kt,
             DefaultInfo(
-                files = depset([ctx.outputs.jar]),
+                files = depset([ctx.outputs.jar, ctx.outputs.jdeps]),
                 runfiles = ctx.runfiles(
                     # explicitly include data files, otherwise they appear to be missing
                     files = ctx.files.data,


### PR DESCRIPTION
unused_deps tool expects jdeps to be produced as a default output just like with java_* rules so we need to include jdeps for that tool to work with the Kotlin rules.