### PR TITLE
Stubs phase compiler plugins now works for JavaBuilder flow

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -605,7 +605,7 @@ def _run_kt_java_builder_actions(ctx, rule_kind, toolchains, srcs, generated_src
             compile_deps = compile_deps,
             annotation_processors = annotation_processors,
             transitive_runtime_jars = transitive_runtime_jars,
-            plugins = [],
+            plugins = plugins,
             outputs = {
                 "generated_java_srcjar": kapt_generated_src_jar,
                 "kapt_generated_stub_jar": kapt_generated_stub_jar,

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -263,6 +263,7 @@ class KotlinBuilder @Inject internal constructor(
           generatedClasses = workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "generated_classes")).toString()
           temp = workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "temp")).toString()
           generatedSources = workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "generated_sources")).toString()
+          generatedJavaSources = workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "generated_java_sources")).toString()
           generatedStubClasses = workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "stubs")).toString()
       }
 

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -119,7 +119,7 @@ internal fun JvmCompilationTask.kaptArgs(
     .xFlag("plugin", plugins.kapt.jarPath)
     .base64Encode(
       "-P",
-      "sources" to listOf(directories.generatedSources),
+      "sources" to listOf(directories.generatedJavaSources),
       "classes" to listOf(directories.generatedClasses),
       "stubs" to listOf(directories.stubs),
       "incrementalData" to listOf(directories.incrementalData),
@@ -211,7 +211,7 @@ internal fun JvmCompilationTask.createGeneratedJavaSrcJar() {
     normalize = true,
     verbose = false
   ).also {
-    it.addDirectory(Paths.get(directories.generatedSources))
+    it.addDirectory(Paths.get(directories.generatedJavaSources))
     it.setJarOwner(info.label, info.bazelRuleKind)
     it.execute()
   }
@@ -280,6 +280,7 @@ fun JvmCompilationTask.compileKotlin(
                   directories.classes,
                   directories.generatedClasses,
                   directories.generatedSources,
+                  directories.generatedJavaSources,
                   directories.temp
                 )
                   .map { Paths.get(it) }
@@ -329,7 +330,7 @@ private val Directories.incrementalData
  */
 internal fun JvmCompilationTask.expandWithGeneratedSources(): JvmCompilationTask =
   expandWithSources(
-    Stream.of(directories.generatedSources)
+    Stream.of(directories.generatedSources, directories.generatedJavaSources)
       .map { s -> Paths.get(s) }
       .flatMap { p -> walk(p) }
       .filter { !isDirectory(it) }

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -95,6 +95,7 @@ message JvmCompilationTask {
     // The directory used by annotation processors containing generated stub classes.
     string generated_stub_classes = 5;
     string abi_classes = 6;
+    string generated_java_sources = 7;
   }
 
   // Outputs produced by the builder.

--- a/src/test/kotlin/io/bazel/kotlin/builder/DirectoryType.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/DirectoryType.java
@@ -13,6 +13,7 @@ public enum DirectoryType {
     GENERATED_CLASSES("generated classes", Paths.get("generated_classes")),
     TEMP("temp directory", Paths.get("temp")),
     SOURCE_GEN("generated sources directory", Paths.get("generated_sources")),
+    JAVA_SOURCE_GEN("generated sources directory", Paths.get("generated_java_sources")),
     GENERATED_STUBS("generated kotlin stubs directory", Paths.get("stubs")),
     INCREMENTAL_DATA("generated kotlin stubs class directory", Paths.get("temp","incrementalData"));
 

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -48,6 +48,7 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
                     DirectoryType.SOURCES,
                     DirectoryType.CLASSES,
                     DirectoryType.SOURCE_GEN,
+                    DirectoryType.JAVA_SOURCE_GEN,
                     DirectoryType.GENERATED_CLASSES,
                     DirectoryType.TEMP);
 
@@ -63,6 +64,7 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
                 .getDirectoriesBuilder()
                 .setClasses(directory(DirectoryType.CLASSES).toAbsolutePath().toString())
                 .setGeneratedSources(directory(DirectoryType.SOURCE_GEN).toAbsolutePath().toString())
+                .setGeneratedJavaSources(directory(DirectoryType.JAVA_SOURCE_GEN).toAbsolutePath().toString())
                 .setGeneratedStubClasses(directory(DirectoryType.GENERATED_STUBS).toAbsolutePath().toString())
                 .setTemp(directory(DirectoryType.TEMP).toAbsolutePath().toString())
                 .setGeneratedClasses(

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmKaptTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmKaptTest.java
@@ -89,7 +89,7 @@ public class KotlinBuilderJvmKaptTest {
         ctx.assertFilesExist(
                 DirectoryType.INCREMENTAL_DATA,
                 "autovalue/TestKtValue.class");
-        ctx.assertFilesExist(DirectoryType.SOURCE_GEN, "autovalue/AutoValue_TestKtValue.java");
+        ctx.assertFilesExist(DirectoryType.JAVA_SOURCE_GEN, "autovalue/AutoValue_TestKtValue.java");
     }
 
     @Test
@@ -142,7 +142,7 @@ public class KotlinBuilderJvmKaptTest {
                     ctx.outputJar();
                 });
         ctx.assertFilesExist(
-                DirectoryType.SOURCE_GEN,
+                DirectoryType.JAVA_SOURCE_GEN,
                 "autovalue/a/AutoValue_TestKtValue.java",
                 "autovalue/b/AutoValue_TestAutoValue.java");
     }


### PR DESCRIPTION
Previously in the new JavaBuilder flow Kotlin compiler plugins were only run during compile phase. This limitation meant when kapt generated Java source depended on Kotlin compiler plugin generated Kotlin source (e.g: targets applying both Anvil + Dagger) developers had to work around the limitation by breaking anvil + dagger into separate targets.

An important thing to note here is that KAPT generated Java source must now be separated from Kotlin compiler plugin Kotlin source. This is because we don't want Kotlin code generated at stubs phase clashing with Kotlin code generated at compile phase, i.e: a plugin running in both phases may generate the same code resulting in duplicate definitions.