### PR TITLE
Fix bazel kapt to support generating non-compilable `source` files

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -508,6 +508,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
 
     else:
         kt_java_output_jar = ctx.actions.declare_file(ctx.label.name + "-kt-java.jar")
+        kt_generated_java_srcjar = ctx.actions.declare_file(ctx.label.name + "-gensrc.jar")
         _run_kt_builder_action(
             ctx = ctx,
             rule_kind = rule_kind,
@@ -522,6 +523,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
             outputs = {
                 "output": kt_java_output_jar,
                 "kotlin_output_jdeps": ctx.outputs.jdeps,
+                "generated_java_srcjar": kt_generated_java_srcjar,
             },
         )
         compile_jar = kt_java_output_jar
@@ -592,7 +594,7 @@ def _run_kt_java_builder_actions(ctx, rule_kind, toolchains, srcs, generated_src
 
     # Run KAPT
     if srcs.kt and annotation_processors:
-        kapt_generated_src_jar = ctx.actions.declare_file(ctx.label.name + "-kapt-generated-src.jar")
+        kapt_generated_src_jar = ctx.actions.declare_file(ctx.label.name + "-kapt-gensrc.jar")
         kapt_generated_stub_jar = ctx.actions.declare_file(ctx.label.name + "-kapt-generated-stub.jar")
         kapt_generated_class_jar = ctx.actions.declare_file(ctx.label.name + "-kapt-generated-class.jar")
         _run_kt_builder_action(

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -23,7 +23,6 @@ import io.bazel.kotlin.builder.toolchain.KotlinToolchain
 import io.bazel.kotlin.builder.utils.IS_JVM_SOURCE_FILE
 import io.bazel.kotlin.builder.utils.bazelRuleKind
 import io.bazel.kotlin.builder.utils.jars.JarCreator
-import io.bazel.kotlin.builder.utils.jars.SourceJarCreator
 import io.bazel.kotlin.builder.utils.jars.SourceJarExtractor
 import io.bazel.kotlin.builder.utils.partitionJvmSources
 import io.bazel.kotlin.model.JvmCompilationTask
@@ -341,7 +340,7 @@ internal fun JvmCompilationTask.expandWithGeneratedSources(): JvmCompilationTask
 
 private fun JvmCompilationTask.expandWithSources(sources: Iterator<String>): JvmCompilationTask =
   updateBuilder { builder ->
-    sources.partitionJvmSources(
+    sources.filterOutNonCompilableSources().partitionJvmSources(
       { builder.inputsBuilder.addKotlinSources(it) },
       { builder.inputsBuilder.addJavaSources(it) })
   }
@@ -353,3 +352,14 @@ private fun JvmCompilationTask.updateBuilder(
     block(it)
     it.build()
   }
+
+/**
+ * Only keep java and kotlin files for the iterator. Filter our all other non-compilable files.
+ */
+private fun Iterator<String>.filterOutNonCompilableSources(): Iterator<String> {
+   val result = mutableListOf<String>()
+   this.forEach {
+     if (it.endsWith(".kt") or it.endsWith(".java")) result.add(it)
+   }
+  return result.iterator()
+}

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -107,7 +107,7 @@ message JvmCompilationTask {
     string srcjar = 3;
     // The path to the abijar
     string abijar = 4;
-    // The path to the jar containing Java source generated from Kotlin annotation processors.
+    // The path to the jar containing source generated from KAPT annotation processors.
     string generated_java_src_jar = 5;
     // The path to the jar containing stub classes generated from Kotlin annotation processors.
     string generated_java_stub_jar = 6;


### PR DESCRIPTION
**Background**
`kt_xxx_library` doesn't support annotation processor generating source files other than `java` and `kt` classes. For example, if we are trying to use a plugin similar to [auto service](https://github.com/google/auto/tree/master/service) but changing the output option to be [StandardLocation.SOURCE_OUTPUT](https://github.com/google/auto/blob/afe607c395bc34efe56ac34bd3613c3d9a04d0eb/service/processor/src/main/java/com/google/auto/service/processor/AutoServiceProcessor.java#L173), the compile will fail and report `IllegalStateException: invalid source file type xxx`. The reason is that we assume all the generated `source` files to be compilable, which is not always the case.

**Change**
* Keep `generated_java_srcjar` (which contains all kapt generated files under StandardLocation.SOURCE_OUTPUT) as an output in both `experimental_use_abi_jars` and normal mode.
* Filter out non-compilable files before running `expandWithSources`

Note: `android_library` doesn't have this issue and it always put generated files under `xx-gensrc.jar`. Therefore, in this PR, I'm unifying the naming for output to both end with `-gensrc.jar`

**Test**
* Tested on local repo, both normal mode and
 `abit_jar` mode can generate `-gensrc.jar` target which contains the generated files
<img src="https://user-images.githubusercontent.com/6951238/103249732-74600700-4925-11eb-85c8-df4e0524f632.png" width=500>
