### PR TITLE
Rework Jdeps

### DIFF
--- a/examples/android/bzl/BUILD.bazel
+++ b/examples/android/bzl/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "define_kt_toolchain")
 load("@io_bazel_rules_kotlin//kotlin/internal:opts.bzl", "kt_javac_options", "kt_kotlinc_options")
 
 kt_kotlinc_options(
-    name = "default_kotlinc_options",
+    name = "default_kotlinc_options"
 )
 
 kt_javac_options(

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -540,6 +540,9 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
     else:
         kt_java_output_jar = ctx.actions.declare_file(ctx.label.name + "-kt-java.jar")
         kt_generated_java_srcjar = ctx.actions.declare_file(ctx.label.name + "-gensrc.jar")
+
+        kt_jdeps = ctx.actions.declare_file(ctx.label.name + "-kt.jdeps")
+        java_jdeps = ctx.actions.declare_file(ctx.label.name + "-java.jdeps")
         _run_kt_builder_action(
             ctx = ctx,
             rule_kind = rule_kind,
@@ -554,7 +557,17 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
             outputs = {
                 "output": kt_java_output_jar,
                 "kotlin_output_jdeps": ctx.outputs.jdeps,
+                "output_deps_proto": java_jdeps,
                 "generated_java_srcjar": kt_generated_java_srcjar,
+            },
+        )
+        _run_merge_jdeps_action(
+            ctx = ctx,
+            rule_kind = rule_kind,
+            toolchains = toolchains,
+            jdeps = [kt_jdeps, java_jdeps],
+            outputs = {
+                "output": ctx.outputs.jdeps,
             },
         )
         compile_jar = kt_java_output_jar

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -556,7 +556,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
             plugins = plugins,
             outputs = {
                 "output": kt_java_output_jar,
-                "kotlin_output_jdeps": ctx.outputs.jdeps,
+                "kotlin_output_jdeps": kt_jdeps,
                 "output_deps_proto": java_jdeps,
                 "generated_java_srcjar": kt_generated_java_srcjar,
             },

--- a/src/main/kotlin/BUILD
+++ b/src/main/kotlin/BUILD
@@ -37,10 +37,18 @@ jar_jar(
     visibility = ["//visibility:public"],
 )
 
+jar_jar(
+    name = "jdeps-gen",
+    input_jar = "//src/main/kotlin/io/bazel/kotlin/plugin/jdeps:jdeps-gen_deploy.jar",
+    rules = "shade.jarjar",
+    visibility = ["//visibility:public"],
+)
+
 java_binary(
     name = "builder",
     data = [
         "//src/main/kotlin:skip-code-gen",
+        "//src/main/kotlin:jdeps-gen",
         "//src/main/kotlin/io/bazel/kotlin/compiler",
         "@com_github_jetbrains_kotlin//:lib/kotlin-compiler.jar",
     ],
@@ -72,6 +80,7 @@ release_archive(
     name = "pkg",
     srcs = [
         ":skip-code-gen.jar",
+        ":jdeps-gen.jar",
     ],
     package_dir = "src/main/kotlin",  # explicitly set the package directory, as there are no parent release_archives.
     src_map = {

--- a/src/main/kotlin/BUILD.release.bazel
+++ b/src/main/kotlin/BUILD.release.bazel
@@ -27,10 +27,16 @@ java_import(
     jars = ["skip-code-gen.jar"],
 )
 
+java_import(
+    name = "jdeps-gen",
+    jars = ["jdeps-gen.jar"],
+)
+
 java_binary(
     name = "builder",
     data = [
         ":skip-code-gen",
+        ":jdeps-gen",
         "//src/main/kotlin/io/bazel/kotlin/compiler",
         "@com_github_jetbrains_kotlin//:lib/kotlin-compiler.jar",
     ],

--- a/src/main/kotlin/io/bazel/kotlin/builder/KotlinBuilderComponent.java
+++ b/src/main/kotlin/io/bazel/kotlin/builder/KotlinBuilderComponent.java
@@ -64,7 +64,7 @@ public interface KotlinBuilderComponent {
         @Provides
         public InternalCompilerPlugins provideAbiPlugin(KotlinToolchain toolchain) {
             return new InternalCompilerPlugins(
-                    toolchain.getJvmAbiGen(), toolchain.getSkipCodeGen(), toolchain.getKapt3Plugin());
+                    toolchain.getJvmAbiGen(), toolchain.getSkipCodeGen(), toolchain.getKapt3Plugin(), toolchain.getJdepsGen());
         }
     }
 }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -242,6 +242,7 @@ class KotlinBuilder @Inject internal constructor(
           argMap.optionalSingle(KotlinBuilderFlags.OUTPUT_SRCJAR)?.let { srcjar = it }
 
           argMap.optionalSingle(KotlinBuilderFlags.OUTPUT_JDEPS)?.apply { jdeps = this }
+          argMap.optionalSingle(JavaBuilderFlags.OUTPUT_DEPS_PROTO)?.apply { javaJdeps = this }
           argMap.optionalSingle(KotlinBuilderFlags.GENERATED_JAVA_SRC_JAR)?.apply {
             generatedJavaSrcJar = this
           }
@@ -259,6 +260,8 @@ class KotlinBuilder @Inject internal constructor(
           val moduleName = argMap.mandatorySingle(KotlinBuilderFlags.MODULE_NAME)
           classes =
             workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "classes")).toString()
+          javaClasses =
+            workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "java_classes")).toString()
           if (argMap.hasAll(KotlinBuilderFlags.ABI_JAR)) abiClasses = workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "abi_classes")).toString()
           generatedClasses = workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "generated_classes")).toString()
           temp = workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "temp")).toString()

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -272,8 +272,7 @@ class KotlinBuilder @Inject internal constructor(
 
       with(root.inputsBuilder) {
         addAllClasspath(argMap.mandatory(JavaBuilderFlags.CLASSPATH))
-        putAllIndirectDependencies(argMap.labelDepMap(JavaBuilderFlags.DIRECT_DEPENDENCY))
-        putAllIndirectDependencies(argMap.labelDepMap(JavaBuilderFlags.INDIRECT_DEPENDENCY))
+        addAllDirectDependencies(argMap.mandatory(JavaBuilderFlags.DIRECT_DEPENDENCIES))
 
         addAllProcessors(argMap.optional(JavaBuilderFlags.PROCESSORS) ?: emptyList())
         addAllProcessorpaths(argMap.optional(JavaBuilderFlags.PROCESSOR_PATH) ?: emptyList())

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/InternalCompilerPlugins.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/InternalCompilerPlugins.kt
@@ -22,5 +22,6 @@ import io.bazel.kotlin.builder.toolchain.KotlinToolchain
 class InternalCompilerPlugins constructor(
   val jvmAbiGen: KotlinToolchain.CompilerPlugin,
   val skipCodeGen: KotlinToolchain.CompilerPlugin,
-  val kapt: KotlinToolchain.CompilerPlugin
+  val kapt: KotlinToolchain.CompilerPlugin,
+  val jdeps: KotlinToolchain.CompilerPlugin
 )

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
@@ -65,7 +65,7 @@ internal class JDepsGenerator @Inject constructor(
                 JdepsParser.parse(
                   command.info.label,
                   javaClassDir,
-                  command.inputs.classpathList,
+                  command.inputs.directDependenciesList,
                   it,
                   isKotlinImplicit
                 )

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
@@ -55,8 +55,8 @@ internal class JDepsGenerator @Inject constructor(
             val version = System.getProperty("java.version").majorJavaVersion()
             val multiRelease =
               if (version < 9) arrayOf() else arrayOf("--multi-release", "base")
-            val jarPath = command.outputs.jar
-            val args = multiRelease + arrayOf("-R", "-summary", "-cp", joinedClasspath, jarPath)
+            val javaClassDir = command.directories.javaClasses
+            val args = multiRelease + arrayOf("-R", "-summary", "-cp", joinedClasspath, javaClassDir)
             val res = invoker.run(args, writer)
             out.toByteArray().inputStream().bufferedReader().readLines().let {
               if (res != 0) {
@@ -64,7 +64,7 @@ internal class JDepsGenerator @Inject constructor(
               } else try {
                 JdepsParser.parse(
                   command.info.label,
-                  jarPath,
+                  javaClassDir,
                   command.inputs.classpathList,
                   it,
                   isKotlinImplicit
@@ -76,7 +76,7 @@ internal class JDepsGenerator @Inject constructor(
           }
         }
       }
-    Paths.get(command.outputs.jdeps).also {
+    Paths.get(command.outputs.javaJdeps).also {
       Files.deleteIfExists(it)
       FileOutputStream(Files.createFile(it).toFile()).use(jdepsContent::writeTo)
     }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JavaCompiler.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JavaCompiler.kt
@@ -41,7 +41,7 @@ internal class JavaCompiler @Inject constructor(
     if (i.javaSourcesList.isNotEmpty()) {
       val args = mutableListOf(
         "-cp", "${d.classes}$DIR_SEP${d.temp}$DIR_SEP${i.joinedClasspath}",
-        "-d", d.classes
+        "-d", d.javaClasses
       ).also {
         it.addAll(
           // Kotlin takes care of annotation processing.

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
@@ -19,11 +19,9 @@ import com.google.devtools.build.lib.view.proto.Deps
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.HashMap
-import java.util.HashSet
 import java.util.function.Predicate
 
 internal class JdepsParser private constructor(
-  private val filename: String,
   private val isImplicit: Predicate<String>
 ) {
   private val depMap = HashMap<String, Deps.Dependency.Builder>()
@@ -31,8 +29,6 @@ internal class JdepsParser private constructor(
   private val arrowRegex = " -> ".toRegex()
 
   private fun consumeJarLine(classJarPath: String, kind: Deps.Dependency.Kind) {
-    val path = Paths.get(classJarPath)
-
     // ignore absolute files, -- jdk jar paths etc.
     // only process jar files
     if (classJarPath.endsWith(".jar")) {
@@ -102,7 +98,7 @@ internal class JdepsParser private constructor(
       isImplicit: Predicate<String>
     ): Deps.Dependencies {
       val filename = Paths.get(jarFile).fileName.toString()
-      val jdepsParser = JdepsParser(filename, isImplicit)
+      val jdepsParser = JdepsParser(isImplicit)
 
       classPath.forEach { x -> jdepsParser.consumeJarLine(x, Deps.Dependency.Kind.UNUSED) }
       lines.forEach { jdepsParser.processLine(it) }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
@@ -35,7 +35,7 @@ internal class JdepsParser private constructor(
 
     // ignore absolute files, -- jdk jar paths etc.
     // only process jar files
-    if (!(path.isAbsolute || !classJarPath.endsWith(".jar"))) {
+    if (classJarPath.endsWith(".jar")) {
       val entry = depMap.computeIfAbsent(classJarPath) {
         val depBuilder = Deps.Dependency.newBuilder()
         depBuilder.path = classJarPath

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -63,6 +63,10 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
                   context,
                   compiler,
                   args = baseArgs()
+                    .plugin(plugins.jdeps) {
+                      flag("output", outputs.jdeps)
+                      flag("target_label", info.label)
+                    }
                     .given(outputs.jar).notEmpty {
                       append(codeGenArgs())
                     }
@@ -73,6 +77,7 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
                       given(outputs.jar).empty {
                         plugin(plugins.skipCodeGen)
                       }
+
                     },
                   printOnFail = false)
               } else {

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -116,8 +116,8 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
         if (outputs.abijar.isNotEmpty()) {
           context.execute("create abi jar", ::createAbiJar)
         }
-        if (outputs.jdeps.isNotEmpty()) {
-          context.execute("generate jdeps") { jDepsGenerator.generateJDeps(this) }
+        if (outputs.javaJdeps.isNotEmpty()) {
+          context.execute("generate jdeps for Java compilation") { jDepsGenerator.generateJDeps(this) }
         }
         if (outputs.generatedJavaSrcJar.isNotEmpty()) {
           context.execute("creating KAPT generated Java source jar", ::createGeneratedJavaSrcJar)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -66,6 +66,9 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
                     .plugin(plugins.jdeps) {
                       flag("output", outputs.jdeps)
                       flag("target_label", info.label)
+                      inputs.directDependenciesList.forEach {
+                        flag("direct_dependencies", it)
+                      }
                     }
                     .given(outputs.jar).notEmpty {
                       append(codeGenArgs())

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -181,6 +181,7 @@ internal fun JvmCompilationTask.createOutputJar() =
     verbose = false
   ).also {
     it.addDirectory(Paths.get(directories.classes))
+    it.addDirectory(Paths.get(directories.javaClasses))
     it.addDirectory(Paths.get(directories.generatedClasses))
     it.setJarOwner(info.label, info.bazelRuleKind)
     it.execute()

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/BUILD.bazel
@@ -26,6 +26,7 @@ kt_bootstrap_library(
     deps = [
         "//src/main/kotlin/io/bazel/kotlin/builder/utils",
         "//src/main/kotlin/io/bazel/kotlin/plugin:skip-code-gen-lib",
+        "//src/main/kotlin/io/bazel/kotlin/plugin/jdeps:jdeps-gen-lib",
         "//src/main/protobuf:kotlin_model_java_proto",
         "@com_github_jetbrains_kotlin//:kotlin-preloader",
         "@kotlin_rules_maven//:com_google_protobuf_protobuf_java",

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
@@ -45,7 +45,8 @@ class KotlinToolchain private constructor(
     "org.jetbrains.kotlin.kapt3"
   ),
   val jvmAbiGen: CompilerPlugin,
-  val skipCodeGen: CompilerPlugin
+  val skipCodeGen: CompilerPlugin,
+  val jdepsGen: CompilerPlugin
 ) {
 
   companion object {
@@ -69,6 +70,11 @@ class KotlinToolchain private constructor(
       RULES_REPOSITORY_NAME,
       "src", "main", "kotlin",
       "skip-code-gen.jar").toPath()
+
+    private val JDEPS_GEN_PLUGIN = BazelRunFiles.resolveVerified(
+      RULES_REPOSITORY_NAME,
+      "src", "main", "kotlin",
+      "jdeps-gen.jar").toPath()
 
     internal val NO_ARGS = arrayOf<Any>()
 
@@ -100,6 +106,7 @@ class KotlinToolchain private constructor(
       }.verifiedPath()
 
       val skipCodeGenFile = SKIP_CODE_GEN_PLUGIN.verified().absoluteFile
+      val jdepsGenFile = JDEPS_GEN_PLUGIN.verified().absoluteFile
 
       val kotlinCompilerJar = BazelRunFiles.resolveVerified(
         "external", "com_github_jetbrains_kotlin", "lib", "kotlin-compiler.jar")
@@ -116,7 +123,8 @@ class KotlinToolchain private constructor(
             // (and a NoClassDef err) in the compiler extension interfaces.
             // This may cause issues in accepting user defined compiler plugins.
             jvmAbiGenFile.absoluteFile,
-            skipCodeGenFile
+            skipCodeGenFile,
+            jdepsGenFile
           )
         ),
         jvmAbiGen = CompilerPlugin(
@@ -124,7 +132,11 @@ class KotlinToolchain private constructor(
           "org.jetbrains.kotlin.jvm.abi"),
         skipCodeGen = CompilerPlugin(
           skipCodeGenFile.absolutePath,
-          "io.bazel.kotlin.plugin.SkipCodeGen")
+          "io.bazel.kotlin.plugin.SkipCodeGen"),
+        jdepsGen = CompilerPlugin(
+          jdepsGenFile.absolutePath,
+          "io.bazel.kotlin.plugin.jdeps.JDepsGen"
+        )
       )
     }
   }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/BUILD.bazel
@@ -1,0 +1,47 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("//src/main/kotlin:bootstrap.bzl", "kt_bootstrap_library")
+load("//kotlin/internal/utils:generate_jvm_service.bzl", "generate_jvm_service")
+
+# The compiler binary, this is co-located in the kotlin compiler classloader.
+kt_bootstrap_library(
+    name = "jdeps-gen-lib",
+    srcs = glob(["*.kt"]),
+    visibility = ["//src:__subpackages__"],
+    deps = [
+        "//src/main/protobuf:deps_java_proto",
+        "@com_github_jetbrains_kotlin//:kotlin-compiler",
+        "@kotlin_rules_maven//:com_google_protobuf_protobuf_java",
+    ],
+)
+
+# services to integrate with the plugin.
+generate_jvm_service(
+    name = "jdeps-gen-services",
+    services = {
+        "io.bazel.kotlin.plugin.jdeps.JdepsGenComponentRegistrar": "org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar",
+        "io.bazel.kotlin.plugin.jdeps.JdepsGenCommandLineProcessor": "org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor",
+    },
+)
+
+# The plugin binary.
+java_binary(
+    name = "jdeps-gen",
+    visibility = ["//src:__subpackages__"],
+    runtime_deps = [
+        ":jdeps-gen-lib",
+        ":jdeps-gen-services",
+    ],
+)

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
@@ -1,0 +1,31 @@
+package io.bazel.kotlin.plugin.jdeps
+
+import org.jetbrains.kotlin.compiler.plugin.AbstractCliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOption
+import org.jetbrains.kotlin.compiler.plugin.CliOptionProcessingException
+import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
+import org.jetbrains.kotlin.config.CompilerConfiguration
+
+class JdepsGenCommandLineProcessor : CommandLineProcessor {
+  companion object {
+    val COMPILER_PLUGIN_ID = "io.bazel.kotlin.plugin.jdeps.JDepsGen"
+
+    val OUTPUT_JDEPS_FILE_OPTION: CliOption =
+      CliOption("output", "<path>", "Output path for generated jdeps", required = true)
+    val TARGET_LABEL_OPTION: CliOption =
+      CliOption("target_label", "<String>", "Label of target being analyzed", required = true)
+  }
+
+  override val pluginId: String
+    get() = COMPILER_PLUGIN_ID
+  override val pluginOptions: Collection<AbstractCliOption>
+    get() = listOf(OUTPUT_JDEPS_FILE_OPTION, TARGET_LABEL_OPTION)
+
+  override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
+    when (option) {
+      OUTPUT_JDEPS_FILE_OPTION -> configuration.put(JdepsGenConfigurationKeys.OUTPUT_JDEPS, value)
+      TARGET_LABEL_OPTION -> configuration.put(JdepsGenConfigurationKeys.TARGET_LABEL, value)
+      else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
+    }
+  }
+}

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
@@ -14,17 +14,20 @@ class JdepsGenCommandLineProcessor : CommandLineProcessor {
       CliOption("output", "<path>", "Output path for generated jdeps", required = true)
     val TARGET_LABEL_OPTION: CliOption =
       CliOption("target_label", "<String>", "Label of target being analyzed", required = true)
+     val DIRECT_DEPENDENCIES_OPTION: CliOption =
+      CliOption("direct_dependencies", "<List>", "List of targets direct dependencies", required = false, allowMultipleOccurrences = true)
   }
 
   override val pluginId: String
     get() = COMPILER_PLUGIN_ID
   override val pluginOptions: Collection<AbstractCliOption>
-    get() = listOf(OUTPUT_JDEPS_FILE_OPTION, TARGET_LABEL_OPTION)
+    get() = listOf(OUTPUT_JDEPS_FILE_OPTION, TARGET_LABEL_OPTION, DIRECT_DEPENDENCIES_OPTION)
 
   override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
     when (option) {
       OUTPUT_JDEPS_FILE_OPTION -> configuration.put(JdepsGenConfigurationKeys.OUTPUT_JDEPS, value)
       TARGET_LABEL_OPTION -> configuration.put(JdepsGenConfigurationKeys.TARGET_LABEL, value)
+      DIRECT_DEPENDENCIES_OPTION -> configuration.appendList(JdepsGenConfigurationKeys.DIRECT_DEPENDENCIES, value)
       else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
     }
   }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenComponentRegistrar.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenComponentRegistrar.kt
@@ -1,0 +1,86 @@
+package io.bazel.kotlin.plugin.jdeps
+
+import com.google.devtools.build.lib.view.proto.Deps
+import com.intellij.mock.MockProject
+import com.intellij.openapi.project.Project
+import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.psi.KtClassOrObject
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.psi.KtFunction
+import org.jetbrains.kotlin.psi.KtProperty
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.BindingTrace
+import org.jetbrains.kotlin.resolve.descriptorUtil.classId
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
+import java.io.BufferedOutputStream
+import java.io.File
+
+class JdepsGenComponentRegistrar : ComponentRegistrar {
+
+  override fun registerProjectComponents(
+    project: MockProject,
+    configuration: CompilerConfiguration
+  ) {
+
+    // Capture all types referenced by the compiler for this module and look up the jar from which
+    // they were loaded from
+    AnalysisHandlerExtension.registerExtension(
+      project, JdepsAnalysisHandlerExtension()
+    )
+
+    // Build and write out deps.proto
+    val targetLabel = configuration.getNotNull(JdepsGenConfigurationKeys.TARGET_LABEL)
+    val jdepsOutput = configuration.getNotNull(JdepsGenConfigurationKeys.OUTPUT_JDEPS)
+
+    val rootBuilder = Deps.Dependencies.newBuilder()
+    rootBuilder.success = true
+    rootBuilder.ruleLabel = targetLabel
+
+    // TODO: For every jar from which a type was referenced add it here.
+    val dependency = Deps.Dependency.newBuilder()
+    dependency.kind = Deps.Dependency.Kind.EXPLICIT
+    dependency.path = "/path/to/dependency.jar"
+    rootBuilder.addDependency(dependency)
+
+    BufferedOutputStream(File(jdepsOutput).outputStream()).use {
+      it.write(rootBuilder.build().toByteArray())
+    }
+  }
+
+  internal class JdepsAnalysisHandlerExtension : AnalysisHandlerExtension {
+
+    override fun analysisCompleted(project: Project, module: ModuleDescriptor, bindingTrace: BindingTrace, files: Collection<KtFile>): AnalysisResult? {
+      // TODO: Capture all referenced non-local types, e.g: supertypes, generics, return types etc
+      files.forEach {file ->
+        file.declarations.forEach { ktDeclaration ->
+          when (ktDeclaration) {
+            is KtClassOrObject -> {
+
+            }
+            is KtFunction -> {
+            }
+            is KtProperty -> {
+              val variable = bindingTrace.bindingContext.get(BindingContext.VARIABLE, ktDeclaration);
+              val type = variable?.type
+              val declarationDescriptor = type?.constructor?.declarationDescriptor
+              when(declarationDescriptor) {
+                is ClassDescriptor -> {
+                  println("ClassId.isLocal: ${declarationDescriptor.classId?.isLocal}")
+                  println("Declaration Descriptor ${declarationDescriptor.fqNameSafe}")
+                }
+                else -> null
+              }
+            }
+            else -> error("Unsupported declaration $ktDeclaration")          }
+        }
+      }
+
+      return super.analysisCompleted(project, module, bindingTrace, files)
+    }
+  }
+}

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenConfigurationKeys.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenConfigurationKeys.kt
@@ -1,0 +1,17 @@
+package io.bazel.kotlin.plugin.jdeps
+
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
+
+object JdepsGenConfigurationKeys {
+  /**
+   * Output path of generated Jdeps proto file.
+   */
+  val OUTPUT_JDEPS: CompilerConfigurationKey<String> =
+    CompilerConfigurationKey.create(JdepsGenCommandLineProcessor.OUTPUT_JDEPS_FILE_OPTION.description)
+
+  /**
+   * Label of the Bazel target being analyzed.
+   */
+  val TARGET_LABEL: CompilerConfigurationKey<String> =
+    CompilerConfigurationKey.create(JdepsGenCommandLineProcessor.TARGET_LABEL_OPTION.description)
+}

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenConfigurationKeys.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenConfigurationKeys.kt
@@ -14,4 +14,10 @@ object JdepsGenConfigurationKeys {
    */
   val TARGET_LABEL: CompilerConfigurationKey<String> =
     CompilerConfigurationKey.create(JdepsGenCommandLineProcessor.TARGET_LABEL_OPTION.description)
+
+  /**
+   * List of direct dependencies of the target.
+   */
+  val DIRECT_DEPENDENCIES: CompilerConfigurationKey<List<String>> =
+    CompilerConfigurationKey.create(JdepsGenCommandLineProcessor.DIRECT_DEPENDENCIES_OPTION.description)
 }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -155,10 +155,19 @@ class JdepsGenExtension(
     // Build and write out deps.proto
     val targetLabel = configuration.getNotNull(JdepsGenConfigurationKeys.TARGET_LABEL)
     val jdepsOutput = configuration.getNotNull(JdepsGenConfigurationKeys.OUTPUT_JDEPS)
+    val directDeps = configuration.getList(JdepsGenConfigurationKeys.DIRECT_DEPENDENCIES)
 
     val rootBuilder = Deps.Dependencies.newBuilder()
     rootBuilder.success = true
     rootBuilder.ruleLabel = targetLabel
+
+    val unusedDeps = directDeps.subtract(result.keys)
+    unusedDeps.forEach { jarPath ->
+      val dependency = Deps.Dependency.newBuilder()
+      dependency.kind = Deps.Dependency.Kind.UNUSED
+      dependency.path = jarPath
+      rootBuilder.addDependency(dependency)
+    }
 
     result.forEach { (jarPath, classes) ->
       val dependency = Deps.Dependency.newBuilder()

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -1,0 +1,251 @@
+package io.bazel.kotlin.plugin.jdeps
+
+import com.google.devtools.build.lib.view.proto.Deps
+import com.intellij.mock.MockProject
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.analyzer.AnalysisResult
+import org.jetbrains.kotlin.codegen.ClassBuilder
+import org.jetbrains.kotlin.codegen.ClassBuilderFactory
+import org.jetbrains.kotlin.codegen.extensions.ClassBuilderInterceptorExtension
+import org.jetbrains.kotlin.codegen.inline.RemappingClassBuilder
+import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.JVMConfigurationKeys
+import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.ModuleDescriptor
+import org.jetbrains.kotlin.descriptors.SourceElement
+import org.jetbrains.kotlin.descriptors.findClassAcrossModuleDependencies
+import org.jetbrains.kotlin.diagnostics.DiagnosticSink
+import org.jetbrains.kotlin.load.java.sources.JavaSourceElement
+import org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass
+import org.jetbrains.kotlin.load.kotlin.KotlinJvmBinarySourceElement
+import org.jetbrains.kotlin.load.kotlin.VirtualFileKotlinClass
+import org.jetbrains.kotlin.name.ClassId
+import org.jetbrains.kotlin.name.FqName
+import org.jetbrains.kotlin.psi.KtFile
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.BindingTrace
+import org.jetbrains.kotlin.resolve.descriptorUtil.classId
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
+import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperclassesWithoutAny
+import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
+import org.jetbrains.kotlin.resolve.jvm.diagnostics.JvmDeclarationOrigin
+import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
+import org.jetbrains.org.objectweb.asm.commons.Remapper
+import java.io.BufferedOutputStream
+import java.io.File
+
+/**
+ * Kotlin compiler extension that tracks classes (and corresponding classpath jars) needed to
+ * compile current kotlin target. Tracked data should include all classes whose changes could
+ * affect target's compilation out : direct class dependencies (i.e external classes directly
+ * used), but also their superclass, interfaces, etc.
+ * The primary use of this extension is to improve Kotlin module compilation avoidance in build
+ * systems (like Buck).
+ *
+ * Tracking of classes is done with a Remapper, which exposes all object types used by the class
+ * bytecode being generated. Tracking of the ancestor classes is done via modules and class
+ * descriptors that got generated during analysis/resolve phase of Kotlin compilation.
+ *
+ * Note: annotation processors dependencies may need to be tracked separatly (and may not need
+ * per-class ABI change tracking)
+ *
+ * @param project the current compilation project
+ * @param configuration the current compilation configuration
+ */
+class JdepsGenExtension(
+  val project: MockProject,
+  val configuration: CompilerConfiguration) :
+  ClassBuilderInterceptorExtension, AnalysisHandlerExtension {
+
+  companion object {
+
+    /**
+     * Returns whether class is coming from JVM runtime env. There is no need to track these
+     * classes.
+     *
+     * @param className the class name of the class
+     * @return whether class is provided by jvm runtime or not
+     */
+    fun isJvmClass(className: String): Boolean {
+      return className.startsWith("java") || className.startsWith("kotlin")
+    }
+
+    /**
+     * Returns the path of the jar archive file corresponding to the provided class descriptor.
+     *
+     * @classDescriptor the class descriptor, typically obtained from compilation analyze phase
+     * @return the path corresponding to the JAR where this class was loaded from, or null.
+     */
+    fun getClassCanonicalPath(classDescriptor: ClassDescriptor): String? {
+      return when (val sourceElement: SourceElement = classDescriptor.source
+      ) {
+        is JavaSourceElement ->
+          (sourceElement.javaElement as BinaryJavaClass).virtualFile.canonicalPath
+        is KotlinJvmBinarySourceElement ->
+          (sourceElement.binaryClass as VirtualFileKotlinClass).file.canonicalPath
+        else -> null
+      }
+    }
+  }
+
+  private val moduleClasses: HashSet<String> = HashSet() // classes defined in current module
+  private val moduleDepClasses: HashSet<String> = HashSet() // external  classes used directly by module
+  private val classesCanonicalPaths: HashSet<String> = HashSet()
+  private var moduleDescriptor: ModuleDescriptor? = null
+
+  override fun analysisCompleted(
+    project: Project,
+    module: ModuleDescriptor,
+    bindingTrace: BindingTrace,
+    files: Collection<KtFile>
+  ): AnalysisResult? {
+    // Hold module descriptor until end of class generation, seems safe to do so. Otherwise, we need
+    // to extract list of used classes differently (i.e not relaying on ClassBuilderInterceptor).
+    moduleDescriptor = module
+    return super.analysisCompleted(project, module, bindingTrace, files)
+  }
+
+  override fun interceptClassBuilderFactory(
+    interceptedFactory: ClassBuilderFactory,
+    bindingContext: BindingContext,
+    diagnostics: DiagnosticSink
+  ): ClassBuilderFactory {
+    return UsageTrackerClassBuilderFactory(interceptedFactory, bindingContext)
+  }
+
+  private fun onClassBuilderComplete() {
+    assert(moduleDescriptor != null)
+
+    moduleDepClasses.filter(::isExternalModuleClass).forEach {
+      val fqName = FqName(it.replace("/", "."))
+      val classId = ClassId.topLevel(fqName)
+      moduleDescriptor?.findClassAcrossModuleDependencies(classId)?.let(::handleExternalModuleClass)
+    }
+    moduleDescriptor = null
+
+    writeOutput()
+  }
+
+  private fun handleExternalModuleClass(classDescriptor: ClassDescriptor) {
+    // Ignore internal or JVM classes
+    val className: String = classDescriptor.fqNameSafe.asString()
+    if (isExternalModuleClass(className)) {
+      // Ignore already visited classes
+      val path: String = getClassCanonicalPath(classDescriptor) ?: return
+      if (classesCanonicalPaths.contains(path)) return
+
+      classesCanonicalPaths.add(path)
+
+      // Iterate through parent classes and interfaces
+      classDescriptor.getAllSuperclassesWithoutAny().forEach(::handleExternalModuleClass)
+      classDescriptor.getSuperInterfaces().forEach(::handleExternalModuleClass)
+    }
+  }
+
+  private fun writeOutput() {
+    // Build mapping jar -> [used classes]
+    val result: HashMap<String, ArrayList<String>> = HashMap()
+    classesCanonicalPaths.forEach {
+      val parts = it.split("!/")
+      result.computeIfAbsent(parts[0]) { ArrayList() }.add(parts[1])
+    }
+
+    // Build and write out deps.proto
+    val targetLabel = configuration.getNotNull(JdepsGenConfigurationKeys.TARGET_LABEL)
+    val jdepsOutput = configuration.getNotNull(JdepsGenConfigurationKeys.OUTPUT_JDEPS)
+
+    val rootBuilder = Deps.Dependencies.newBuilder()
+    rootBuilder.success = true
+    rootBuilder.ruleLabel = targetLabel
+
+    result.forEach { (jarPath, classes) ->
+      val dependency = Deps.Dependency.newBuilder()
+      dependency.kind = Deps.Dependency.Kind.EXPLICIT
+      dependency.path = jarPath
+      rootBuilder.addDependency(dependency)
+    }
+
+    BufferedOutputStream(File(jdepsOutput).outputStream()).use {
+      it.write(rootBuilder.build().toByteArray())
+    }
+  }
+
+  private fun isExternalModuleClass(className: String): Boolean {
+    return !isModuleClass(className) && !isJvmClass(className)
+  }
+
+  private fun isModuleClass(className: String): Boolean {
+    return moduleClasses.contains(className)
+  }
+
+  /*
+     * Class builder factory, wrapping usage of UsageTrackerRemappingClassBuilder
+     */
+  private inner class UsageTrackerClassBuilderFactory(
+    private val delegateFactory: ClassBuilderFactory, val bindingContext: BindingContext
+  ) : ClassBuilderFactory {
+
+    override fun newClassBuilder(origin: JvmDeclarationOrigin): ClassBuilder {
+      return UsageTrackerRemappingClassBuilder(delegateFactory.newClassBuilder(origin))
+    }
+
+    override fun getClassBuilderMode() = delegateFactory.classBuilderMode
+
+    override fun asText(builder: ClassBuilder?): String? {
+      return delegateFactory.asText((builder as UsageTrackerRemappingClassBuilder).builder)
+    }
+
+    override fun asBytes(builder: ClassBuilder?): ByteArray? {
+      return delegateFactory.asBytes((builder as UsageTrackerRemappingClassBuilder).builder)
+    }
+
+    override fun close() {
+      onClassBuilderComplete()
+
+      delegateFactory.close()
+    }
+  }
+
+  /**
+   * Class builder relying on remapper capability to track all external classes used by the class
+   * whose bytecode is being currently generated.
+   */
+  private inner class UsageTrackerRemappingClassBuilder(internal val builder: ClassBuilder) :
+    RemappingClassBuilder(builder, UsageTrackerRemapper()) {
+    override fun defineClass(
+      origin: PsiElement?,
+      version: Int,
+      access: Int,
+      name: String,
+      signature: String?,
+      superName: String,
+      interfaces: Array<out String>
+    ) {
+      moduleClasses.add(name)
+      super.defineClass(origin, version, access, name, signature, superName, interfaces)
+    }
+  }
+
+  /**
+   * Remapper used to track all external classes usage.
+   */
+  private inner class UsageTrackerRemapper : Remapper() {
+    override fun map(typeName: String?): String {
+      typeName?.let { moduleDepClasses.add(it) }
+      return super.map(typeName)
+    }
+
+    override fun mapFieldName(owner: String?, name: String?, desc: String?): String {
+      owner?.let { moduleDepClasses.add(it) }
+      return super.mapFieldName(owner, name, desc)
+    }
+
+    override fun mapMethodName(owner: String?, name: String?, desc: String?): String {
+      owner?.let { moduleDepClasses.add(it) }
+      return super.mapMethodName(owner, name, desc)
+    }
+  }
+}
+

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -82,7 +82,12 @@ class JdepsGenExtension(
       return when (val sourceElement: SourceElement = classDescriptor.source
       ) {
         is JavaSourceElement ->
-          (sourceElement.javaElement as BinaryJavaClass).virtualFile.canonicalPath
+          if (sourceElement.javaElement is BinaryJavaClass) {
+            (sourceElement.javaElement as BinaryJavaClass).virtualFile.canonicalPath
+          } else {
+            // Ignore Java source local to this module.
+            null
+          }
         is KotlinJvmBinarySourceElement ->
           (sourceElement.binaryClass as VirtualFileKotlinClass).file.canonicalPath
         else -> null

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -113,7 +113,6 @@ class JdepsGenExtension(
     // Capture import dependencies
     files.forEach {file ->
       file.importDirectives.forEach {import ->
-        import.importPath?.fqName
         import.importPath?.let {
           moduleDepClasses.add(ClassId.topLevel(it.fqName))
         }

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -123,9 +123,7 @@ message JvmCompilationTask {
       // The full classpath
       repeated string classpath = 1;
       // Direct dependencies of the target.
-      map<string, string> direct_dependencies = 2;
-      // Indirect dependencies of the target.
-      map<string, string> indirect_dependencies = 3;
+      repeated string direct_dependencies = 2;
       // Partitioned from the builder flags and could have been augmented with sources discovered by expanding the
       // source_jars and from annotation processing.
       repeated string kotlin_sources = 4;

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -84,7 +84,7 @@ message CompilationTaskInfo {
 message JvmCompilationTask {
   // Directories used by the builder.
   message Directories {
-    // The directory the compiler should use for class files.
+    // The destination directory the Kotlin compiler should use for class files.
     string classes = 1;
     // The directory to use by annotation processors to produce classes.
     string generated_classes = 2;
@@ -96,13 +96,15 @@ message JvmCompilationTask {
     string generated_stub_classes = 5;
     string abi_classes = 6;
     string generated_java_sources = 7;
+    // The destination directory the Java compiler should use for class files.
+    string java_classes = 8;
   }
 
   // Outputs produced by the builder.
   message Outputs {
     // The path to the primary output jar.
     string jar = 1;
-    // The path to the jdeps file.
+    // The path to the jdeps file from Kotlin compilation.
     string jdeps = 2;
     string srcjar = 3;
     // The path to the abijar
@@ -113,6 +115,8 @@ message JvmCompilationTask {
     string generated_java_stub_jar = 6;
     // The path to the jar containing classes generated from Kotlin annotation processors.
     string generated_class_jar = 7;
+    // The path to the jdeps file from Java compilation.
+    string java_jdeps = 8;
   }
 
   message Inputs {

--- a/src/test/kotlin/io/bazel/kotlin/builder/Deps.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/Deps.java
@@ -97,6 +97,9 @@ public final class Deps {
         @Nullable
         public abstract String jdeps();
 
+        @Nullable
+        public abstract String javaJdeps();
+
         public final String singleCompileJar() {
             Preconditions.checkState(compileJars().size() == 1);
             return compileJars().get(0);
@@ -122,6 +125,8 @@ public final class Deps {
             public abstract Builder sourceJar(String sourceJar);
 
             public abstract Builder jdeps(String jdeps);
+
+            public abstract Builder javaJdeps(String javaJdeps);
 
             public Dep build() {
                 if (!moduleName().isPresent()) {

--- a/src/test/kotlin/io/bazel/kotlin/builder/DirectoryType.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/DirectoryType.java
@@ -10,6 +10,8 @@ import java.util.EnumSet;
 public enum DirectoryType {
     SOURCES("sources", Paths.get("sources")),
     CLASSES("compiled classes", Paths.get("classes")),
+    JAVA_CLASSES("compiled classes", Paths.get("java_classes")),
+    ABI_CLASSES("compiled classes", Paths.get("abi_classes")),
     GENERATED_CLASSES("generated classes", Paths.get("generated_classes")),
     TEMP("temp directory", Paths.get("temp")),
     SOURCE_GEN("generated sources directory", Paths.get("generated_sources")),

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -47,6 +47,8 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
             EnumSet.of(
                     DirectoryType.SOURCES,
                     DirectoryType.CLASSES,
+                    DirectoryType.JAVA_CLASSES,
+                    DirectoryType.ABI_CLASSES,
                     DirectoryType.SOURCE_GEN,
                     DirectoryType.JAVA_SOURCE_GEN,
                     DirectoryType.GENERATED_CLASSES,
@@ -63,6 +65,8 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
         taskBuilder
                 .getDirectoriesBuilder()
                 .setClasses(directory(DirectoryType.CLASSES).toAbsolutePath().toString())
+                .setJavaClasses(directory(DirectoryType.JAVA_CLASSES).toAbsolutePath().toString())
+                .setAbiClasses(directory(DirectoryType.ABI_CLASSES).toAbsolutePath().toString())
                 .setGeneratedSources(directory(DirectoryType.SOURCE_GEN).toAbsolutePath().toString())
                 .setGeneratedJavaSources(directory(DirectoryType.JAVA_SOURCE_GEN).toAbsolutePath().toString())
                 .setGeneratedStubClasses(directory(DirectoryType.GENERATED_STUBS).toAbsolutePath().toString())
@@ -113,6 +117,7 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
                                     outputs.getAbijar().isEmpty() ? outputs.getJar() : outputs.getAbijar()
                             ))
                             .jdeps(outputs.getJdeps())
+                            .javaJdeps(outputs.getJavaJdeps())
                             .runtimeDeps(ImmutableList.copyOf(taskBuilder.getInputs().getClasspathList()))
                             .sourceJar(taskBuilder.getOutputs().getSrcjar())
                             .build();
@@ -183,6 +188,12 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
         public TaskBuilder outputJdeps() {
             taskBuilder.getOutputsBuilder()
                     .setJdeps(instanceRoot().resolve("jdeps_file.jdeps").toAbsolutePath().toString());
+            return this;
+        }
+
+        public TaskBuilder outputJavaJdeps() {
+            taskBuilder.getOutputsBuilder()
+                    .setJavaJdeps(instanceRoot().resolve("java_jdeps_file.jdeps").toAbsolutePath().toString());
             return this;
         }
 

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -112,6 +112,7 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
                             .compileJars(ImmutableList.of(
                                     outputs.getAbijar().isEmpty() ? outputs.getJar() : outputs.getAbijar()
                             ))
+                            .jdeps(outputs.getJdeps())
                             .runtimeDeps(ImmutableList.copyOf(taskBuilder.getInputs().getClasspathList()))
                             .sourceJar(taskBuilder.getOutputs().getSrcjar())
                             .build();

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -55,6 +55,7 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
                     DirectoryType.TEMP);
 
     private TaskBuilder taskBuilderInstance = new TaskBuilder();
+    private KotlinBuilderTestComponent component;
 
     @Override
     void setupForNext(CompilationTaskInfo.Builder taskInfo) {
@@ -82,7 +83,10 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
 
     @SafeVarargs
     public final Dep runCompileTask(Consumer<TaskBuilder>... setup) {
-        return executeTask(component().jvmTaskExecutor()::execute, setup);
+        if (component == null) {
+            component = component();
+        }
+        return executeTask(component.jvmTaskExecutor()::execute, setup);
     }
 
     public static KotlinBuilderTestComponent component() {
@@ -122,6 +126,10 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
                             .sourceJar(taskBuilder.getOutputs().getSrcjar())
                             .build();
                 });
+    }
+
+    public void tearDown() {
+        component = null;
     }
 
     public class TaskBuilder {

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -169,8 +169,10 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
         }
 
         public void addDirectDependencies(Dep... dependencies) {
-            Dep.classpathOf(dependencies)
-                    .forEach((dependency) -> taskBuilder.getInputsBuilder().addClasspath(dependency));
+            Dep.classpathOf(dependencies).forEach(dependency -> {
+                taskBuilder.getInputsBuilder().addClasspath(dependency);
+                taskBuilder.getInputsBuilder().addDirectDependencies(dependency);
+            });
         }
 
         public TaskBuilder outputSrcJar() {

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -46,6 +46,12 @@ kt_rules_test(
 )
 
 kt_rules_test(
+    name = "KotlinBuilderJvmJdepsTest",
+    size = "large",
+    srcs = ["jvm/KotlinBuilderJvmJdepsTest.kt"],
+)
+
+kt_rules_test(
     name = "JdepsMergerTest",
     srcs = ["jvm/JdepsMergerTest.kt"],
 )

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParserTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParserTest.java
@@ -15,15 +15,15 @@
  */
 package io.bazel.kotlin.builder.tasks.jvm;
 
-import com.google.common.truth.Truth;
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.devtools.build.lib.view.proto.Deps;
-import org.junit.Assert;
+import com.google.devtools.build.lib.view.proto.Deps.Dependency.Kind;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.function.Predicate;
@@ -36,8 +36,10 @@ public class JdepsParserTest {
   private static final List<String> JDEPS_OUTPUT_FIXTURE =
           toPlatformPaths(
                   "example-tests.jar -> bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-test-host/1.3.1/ktor-server-test-host-1.3.1.jar",
+                  "example-tests.jar -> bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/javax/inject/javax.inject/1/processed_javax.inject-1.jar",
                   "example-tests.jar -> /Library/Java/JavaVirtualMachines/jdk1.8.0_152.jdk/Contents/Home/jre/lib/rt.jar",
                   "example-tests.jar -> bazel-out/darwin-fastbuild/bin/root/example/main/example-lib.jar",
+                  "example-lib.jar -> bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/javax/inject/javax.inject/1/processed_javax.inject-1.jar",
                   "example-lib.jar -> bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.3.71/kotlin-stdlib-jdk7-1.3.71.jar",
                   "ktor-server-test-host-1.3.1.jar -> bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-host-common/1.3.1/ktor-server-host-common-1.3.1.jar",
                   "ktor-server-test-host-1.3.1.jar -> /Library/Java/JavaVirtualMachines/jdk1.8.0_152.jdk/Contents/Home/jre/lib/rt.jar",
@@ -49,6 +51,7 @@ public class JdepsParserTest {
   private static final List<String> CLASSPATH =
           toPlatformPaths(
                   "bazel-out/darwin-fastbuild/bin/root/example/main/example-lib.jar",
+                  "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/javax/inject/javax.inject/1/processed_javax.inject-1.jar",
                   "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-host-common/1.3.1/ktor-server-host-common-1.3.1.jar",
                   "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-test-host/1.3.1/ktor-server-test-host-1.3.1.jar",
                   "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar",
@@ -73,37 +76,6 @@ public class JdepsParserTest {
                   "kotlin-stdlib-jdk7.jar",
                   "kotlin-stdlib-jdk8.jar");
 
-  private static void testWithFixture(List<String> fixture) throws IOException {
-    Deps.Dependencies result =
-            JdepsParser.Companion.parse(LABEL, CLASS_JAR, CLASSPATH, fixture, IS_KOTLIN_IMPLICIT);
-
-    Assert.assertEquals(LABEL, result.getRuleLabel());
-
-    Truth.assertThat(result
-            .getDependencyList()
-            .stream()
-            .map(Deps.Dependency::getPath)
-            .collect(Collectors.toSet()))
-            .containsExactlyElementsIn(CLASSPATH);
-
-    Assert.assertEquals(13, result.getDependencyCount());
-
-    List<String> unused = depKinds(result, Deps.Dependency.Kind.UNUSED);
-    Assert.assertEquals(6, unused.size());
-
-    List<String> explicit = depKinds(result, Deps.Dependency.Kind.EXPLICIT);
-    Assert.assertEquals(2, explicit.size());
-    Assert.assertTrue(explicit.contains("bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-test-host/1.3.1/ktor-server-test-host-1.3.1.jar"));
-    Assert.assertTrue(explicit.contains("bazel-out/darwin-fastbuild/bin/root/example/main/example-lib.jar"));
-
-    List<String> implicit = depKinds(result, Deps.Dependency.Kind.IMPLICIT);
-    Assert.assertEquals(5, implicit.size());
-    Assert.assertTrue(implicit.contains("bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-host-common/1.3.1/ktor-server-host-common-1.3.1.jar"));
-
-    result.writeTo(System.out);
-    System.out.flush();
-  }
-
   private static List<String> toPlatformPaths(String... lines) {
     return Stream.of(lines).map(JdepsParserTest::toPlatformPath).collect(Collectors.toList());
   }
@@ -113,7 +85,7 @@ public class JdepsParserTest {
     return File.separatorChar != '/' ? it.replace(" /", "c:\\").replace("/", File.separator) : it;
   }
 
-  private static List<String> depKinds(Deps.Dependencies result, Deps.Dependency.Kind kind) {
+  private static List<String> depKinds(Deps.Dependencies result, Kind kind) {
     return result
             .getDependencyList()
             .stream()
@@ -123,7 +95,44 @@ public class JdepsParserTest {
   }
 
   @Test
-  public void parseJdepsResult() throws IOException {
-    testWithFixture(JDEPS_OUTPUT_FIXTURE);
+  public void parseJdepsResult() {
+    Deps.Dependencies result =
+            JdepsParser.Companion.parse(LABEL, CLASS_JAR, CLASSPATH,
+                JDEPS_OUTPUT_FIXTURE, IS_KOTLIN_IMPLICIT);
+
+    assertThat(result.getRuleLabel()).isEqualTo(LABEL);
+
+    assertThat(result
+            .getDependencyList()
+            .stream()
+            .map(Deps.Dependency::getPath)
+            .collect(Collectors.toSet()))
+            .containsExactlyElementsIn(CLASSPATH);
+
+    assertThat(depKinds(result, Kind.UNUSED))
+        .containsExactly(
+  "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk8/1.3.61/kotlin-stdlib-jdk8-1.3.61.jar",
+          "external/com_github_jetbrains_kotlin/lib/annotations-13.0.jar",
+          "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/javax/inject/javax.inject/1/javax.inject-1.jar",
+          "external/com_github_jetbrains_kotlin/lib/kotlin-reflect.jar",
+          "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-common/1.3.72/kotlin-stdlib-common-1.3.72.jar",
+          "external/com_github_jetbrains_kotlin/lib/kotlin-test.jar"
+        );
+
+    assertThat(depKinds(result, Kind.EXPLICIT))
+        .containsExactly(
+          "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-test-host/1.3.1/ktor-server-test-host-1.3.1.jar",
+          "bazel-out/darwin-fastbuild/bin/root/example/main/example-lib.jar",
+          "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/javax/inject/javax.inject/1/processed_javax.inject-1.jar"
+        );
+
+    assertThat(depKinds(result, Kind.IMPLICIT))
+        .containsExactly(
+          "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/io/ktor/ktor-server-host-common/1.3.1/ktor-server-host-common-1.3.1.jar",
+          "bazel-out/darwin-fastbuild/bin/external/maven/v1/https/repo1.maven.org/maven2/org/jetbrains/kotlin/kotlin-stdlib-jdk7/1.3.71/kotlin-stdlib-jdk7-1.3.71.jar",
+          "external/com_github_jetbrains_kotlin/lib/kotlin-stdlib.jar",
+          "external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk7.jar",
+          "external/com_github_jetbrains_kotlin/lib/kotlin-stdlib-jdk8.jar"
+        );
   }
 }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmAbiTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmAbiTest.java
@@ -27,13 +27,6 @@ import org.junit.runners.JUnit4;
 public class KotlinBuilderJvmAbiTest {
   private static final KotlinJvmTestBuilder ctx = new KotlinJvmTestBuilder();
 
-  private static final Consumer<KotlinJvmTestBuilder.TaskBuilder> SETUP_NORMALIZATION_TEST_SOURCES =
-      ctx -> {
-        ctx.addSource("AClass.kt", "package something;\n" + "class AClass{}");
-        ctx.addSource("BClass.kt", "package something;\n" + "class BClass{}");
-        ctx.outputJar();
-      };
-
   @Test
   public void testGeneratesAbiOnly() {
     Deps.Dep d = ctx.runCompileTask(
@@ -41,6 +34,10 @@ public class KotlinBuilderJvmAbiTest {
           c.addSource("AClass.kt", "package something;" + "class AClass{}");
           c.addSource("AnotherClass.java", "package something;", "", "class AnotherClass{}");
           c.outputAbiJar();
+          c.compileJava();
+          c.compileKotlin();
+          c.outputJdeps();
+          c.outputJavaJdeps();
         });
     ctx.runCompileTask(
         c -> {
@@ -49,7 +46,7 @@ public class KotlinBuilderJvmAbiTest {
               "package dep;",
               "import something.AClass",
               "class Dependent{}");
-          c.outputJar().outputJdeps();
+          c.outputJar().outputJdeps().outputJavaJdeps().compileKotlin().compileJava();
         });
   }
 
@@ -59,10 +56,12 @@ public class KotlinBuilderJvmAbiTest {
         c -> {
           c.addSource("AClass.kt", "package something;" + "class AClass{}");
           c.addSource("AnotherClass.java", "package something;", "", "class AnotherClass{}");
-          // declaring outputJdeps also asserts existance after compile.
           c.outputJar();
           c.outputJdeps();
+          c.outputJavaJdeps();
           c.outputAbiJar();
+          c.compileKotlin();
+          c.compileJava();
         });
   }
 }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmAbiTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmAbiTest.java
@@ -36,8 +36,6 @@ public class KotlinBuilderJvmAbiTest {
           c.outputAbiJar();
           c.compileJava();
           c.compileKotlin();
-          c.outputJdeps();
-          c.outputJavaJdeps();
         });
     ctx.runCompileTask(
         c -> {

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBasicTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBasicTest.java
@@ -41,6 +41,7 @@ public class KotlinBuilderJvmBasicTest {
                 ctx.addSource("AClass.kt", "package something;\n" + "class AClass{}");
                 ctx.addSource("BClass.kt", "package something;\n" + "class BClass{}");
                 ctx.outputJar();
+                ctx.outputJdeps();
             };
 
     private static String hashDep(String path) {
@@ -71,6 +72,7 @@ public class KotlinBuilderJvmBasicTest {
               "class AnotherClass{}"
           );
           c.outputJar();
+          c.outputJdeps();
         });
         ctx.assertFilesExist(
                 DirectoryType.CLASSES, "something/AClass.class", "something/AnotherClass.class");
@@ -96,6 +98,7 @@ public class KotlinBuilderJvmBasicTest {
                                     c.compileKotlin();
                                     c.addSource("AClass.kt", "package something;" + "class AClass{");
                                     c.outputJar();
+                                    c.outputJdeps();
                                 }),
                 lines -> assertThat(lines.get(0)).startsWith(ctx.toPlatform("sources/AClass")));
     }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBasicTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmBasicTest.java
@@ -73,9 +73,10 @@ public class KotlinBuilderJvmBasicTest {
           );
           c.outputJar();
           c.outputJdeps();
+          c.outputJavaJdeps();
         });
-        ctx.assertFilesExist(
-                DirectoryType.CLASSES, "something/AClass.class", "something/AnotherClass.class");
+        ctx.assertFilesExist(DirectoryType.CLASSES, "something/AClass.class");
+        ctx.assertFilesExist(DirectoryType.JAVA_CLASSES, "something/AnotherClass.class");
     }
 
     @Test
@@ -85,7 +86,7 @@ public class KotlinBuilderJvmBasicTest {
           c.addSource("AClass.kt", "package something;" + "class AClass{}");
           c.addSource("AnotherClass.java", "package something;", "", "class AnotherClass{}");
           // declaring outputJdeps also asserts existance after compile.
-          c.outputJar().outputJdeps();
+          c.outputJar().outputJdeps().outputJavaJdeps().compileKotlin().compileJava();
         });
   }
 

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJavaTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJavaTest.java
@@ -45,9 +45,13 @@ public class KotlinBuilderJvmJavaTest {
               "class AnotherClass{}"
           );
           c.outputJar();
+          c.outputJdeps();
+          c.outputJavaJdeps();
+          c.compileJava();
+          c.compileKotlin();
         });
-    ctx.assertFilesExist(
-        DirectoryType.CLASSES, "something/AClass.class", "something/AnotherClass.class");
+    ctx.assertFilesExist(DirectoryType.CLASSES, "something/AClass.class");
+    ctx.assertFilesExist(DirectoryType.JAVA_CLASSES, "something/AnotherClass.class");
   }
 
   @Test
@@ -86,8 +90,13 @@ public class KotlinBuilderJvmJavaTest {
               "  val a = AClass()",
               "}");
           ctx.outputJar();
+          ctx.outputJdeps();
+          ctx.outputJavaJdeps();
+          ctx.compileJava();
+          ctx.compileKotlin();
         });
-    ctx.assertFilesExist(DirectoryType.CLASSES, "a/AClass.class", "b/BClass.class");
+    ctx.assertFilesExist(DirectoryType.JAVA_CLASSES, "a/AClass.class");
+    ctx.assertFilesExist(DirectoryType.CLASSES, "b/BClass.class");
   }
 
   @Test

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package io.bazel.kotlin.builder.tasks.jvm;
+
+import com.google.common.truth.Truth.assertThat
+import com.google.devtools.build.lib.view.proto.Deps
+import io.bazel.kotlin.builder.KotlinJvmTestBuilder
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.io.BufferedInputStream
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.function.Consumer
+
+
+@RunWith(JUnit4::class)
+class KotlinBuilderJvmJdepsTest {
+    val ctx = KotlinJvmTestBuilder()
+
+    @Test
+    fun `no dependencies`() {
+
+      val deps = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+        c.addSource("AClass.kt", "package something;" + "class AClass{}")
+        c.outputJar()
+        c.outputJdeps()
+        c.compileKotlin()
+      })
+      val jdeps = depsProto(deps)
+
+      assertThat(jdeps.dependencyCount).isEqualTo(0)
+      assertThat(jdeps.ruleLabel).isEqualTo(deps.label())
+  }
+
+  @Test
+  fun `property dependency`() {
+      val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+        c.addSource("AClass.kt", "package something;" + "class AClass{}")
+        c.outputJar()
+        c.outputJdeps()
+        c.compileKotlin()
+      })
+
+      val dependingTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+        c.addSource("HasPropertyDependency.kt", "package something;" + "val property2 =  AClass()")
+        c.outputJar()
+        c.compileKotlin()
+        c.addDirectDependencies(dependentTarget)
+        c.outputJdeps()
+        c.compileKotlin()
+      })
+      val jdeps = depsProto(dependingTarget)
+
+      assertThat(jdeps.ruleLabel).isEqualTo(dependingTarget.label())
+
+      assertExplicit(jdeps).containsExactly(dependentTarget.singleCompileJar())
+
+      assertImplicit(jdeps).isEmpty()
+      assertUnused(jdeps).isEmpty()
+      assertIncomplete(jdeps).isEmpty()
+  }
+
+  private fun depsProto(mergedJdeps: io.bazel.kotlin.builder.Deps.Dep) =
+    Deps.Dependencies.parseFrom(BufferedInputStream(Files.newInputStream(Paths.get(mergedJdeps.jdeps()!!))))
+
+  private fun assertExplicit(jdeps: Deps.Dependencies) = assertThat(
+    jdeps.dependencyList.filter { it.kind == Deps.Dependency.Kind.EXPLICIT }.map { it.path }
+  )
+
+  private fun assertImplicit(jdeps: Deps.Dependencies) = assertThat(
+    jdeps.dependencyList.filter { it.kind == Deps.Dependency.Kind.IMPLICIT }.map { it.path }
+  )
+
+  private fun assertUnused(jdeps: Deps.Dependencies) = assertThat(
+    jdeps.dependencyList.filter { it.kind == Deps.Dependency.Kind.UNUSED }.map { it.path }
+  )
+
+  private fun assertIncomplete(jdeps: Deps.Dependencies) = assertThat(
+    jdeps.dependencyList.filter { it.kind == Deps.Dependency.Kind.INCOMPLETE }.map { it.path }
+  )
+}

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -19,6 +19,7 @@ package io.bazel.kotlin.builder.tasks.jvm;
 import com.google.common.truth.Truth.assertThat
 import com.google.devtools.build.lib.view.proto.Deps
 import io.bazel.kotlin.builder.KotlinJvmTestBuilder
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -30,6 +31,11 @@ import java.util.function.Consumer
 @RunWith(JUnit4::class)
 class KotlinBuilderJvmJdepsTest {
     val ctx = KotlinJvmTestBuilder()
+
+    @After
+    fun tearDown() {
+      ctx.tearDown()
+    }
 
     @Test
     fun `no dependencies`() {

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
@@ -169,6 +169,7 @@ class KotlinWorkerTest {
             flag(JavaBuilderFlags.OUTPUT, outputJar)
             flag(KotlinBuilderFlags.BUILD_KOTLIN, "true")
             flag(JavaBuilderFlags.BUILD_JAVA, "false")
+            flag(KotlinBuilderFlags.OUTPUT_JDEPS, "out.jdeps")
             source(one)
             source(zero)
             source(imaginary)

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
@@ -115,6 +115,7 @@ class KotlinWorkerTest {
     flag(JavaBuilderFlags.TEMPDIR, "tmp")
     flag(JavaBuilderFlags.SOURCEGEN_DIR, "generated_sources")
     cp(JavaBuilderFlags.CLASSPATH, KotlinJvmTestBuilder.KOTLIN_STDLIB.singleCompileJar())
+    cp(JavaBuilderFlags.DIRECT_DEPENDENCIES, "")
     info.passthroughFlagsList.forEach { pf ->
       flag(KotlinBuilderFlags.PASSTHROUGH_FLAGS, pf)
     }

--- a/src/test/kotlin/io/bazel/kotlin/defs.bzl
+++ b/src/test/kotlin/io/bazel/kotlin/defs.bzl
@@ -32,6 +32,7 @@ def kt_rules_test(name, **kwargs):
     for dep in [
         "//src/main/kotlin/io/bazel/kotlin/compiler",
         "//src/main/kotlin:skip-code-gen",
+        "//src/main/kotlin:jdeps-gen",
         "@com_github_jetbrains_kotlin//:annotations",
         "@com_github_jetbrains_kotlin//:jvm-abi-gen",
         "@com_github_jetbrains_kotlin//:kotlin-stdlib",


### PR DESCRIPTION
* Create Kotlin compiler plugin to generate Bazel Jdeps output.
* Existing dependency analysis (post process output jar file) now only occurs on Java compilation performed in the KotlinBuilder.
* Kotlin Jdeps now merged with Java Jdeps in all cases.
* Direct dependencies instead of full classpath now passed in to both Kotlin and Java Jdeps generators, jdeps files should now be a lot smaller.

Future Work:- Implement Kotlin strict deps inside the compiler plugin, now we can tell if a symbol is loaded from a jar contained in direct dependencies or not.

Fixes: https://github.com/bazelbuild/rules_kotlin/issues/423