### PR TITLE
Pass annotation processor JavaInfos to java_common.compile(plugins = ..)

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -723,6 +723,7 @@ def _run_kt_java_builder_actions(ctx, rule_kind, toolchains, srcs, generated_src
             output = ctx.actions.declare_file(ctx.label.name + "-java.jar"),
             deps = compile_deps.deps + kt_stubs_for_java,
             java_toolchain = toolchains.java,
+            plugins = _plugin_mappers.targets_to_annotation_processors_java_info(ctx.attr.plugins),
             javac_opts = javac_opts,
             host_javabase = toolchains.java_runtime,
             neverlink = getattr(ctx.attr, "neverlink", False),

--- a/kotlin/internal/jvm/plugins.bzl
+++ b/kotlin/internal/jvm/plugins.bzl
@@ -37,14 +37,15 @@ def _kt_plugin_to_processorpath(processor):
 def _targets_to_annotation_processors(targets):
     return depset(transitive = [t[KtJvmPluginInfo].annotation_processors for t in targets if KtJvmPluginInfo in t])
 
+def _targets_to_annotation_processors_java_info(targets):
+    return [t[JavaInfo] for t in targets if KtJvmPluginInfo in t]
+
 def _targets_to_transitive_runtime_jars(targets):
     return depset(transitive = [t[KtJvmPluginInfo].transitive_runtime_jars for t in targets if KtJvmPluginInfo in t])
 
-def _targets_to_plugins(targets):
-    return depset(transitive = [t[KtJvmPluginInfo].plugins for t in targets if KtJvmPluginInfo in t])
-
 mappers = struct(
     targets_to_annotation_processors = _targets_to_annotation_processors,
+    targets_to_annotation_processors_java_info = _targets_to_annotation_processors_java_info,
     targets_to_transitive_runtime_jars = _targets_to_transitive_runtime_jars,
     kt_plugin_to_processor = _kt_plugin_to_processor,
     kt_plugin_to_processorpath = _kt_plugin_to_processorpath,


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/bazel/issues/12754

When `plugins` attribute is not specified JavaBuilder uses a "direct jars only" optimization for compiling Java headers. Unfortunately for cases that compile Java code generated by annotation processors run externally (i.e: KAPT) its not correct to use that optimization since the annotation processor code may include references to symbols from transitive dependencies.

Specifying plugins uses regular header compilation mode, but since we specify `javac_opts = ["-proc:none"]` the annotation processors themselves are not run (Despite what Bazel emits in the progress message)