### PR TITLE
Implement (experimental) unused dependency checking feature.

### DIFF
--- a/examples/android/bzl/BUILD.bazel
+++ b/examples/android/bzl/BUILD.bazel
@@ -14,6 +14,7 @@ define_kt_toolchain(
     api_version = "1.4",
     experimental_use_abi_jars = True,
     experimental_strict_kotlin_deps = "warn",
+    experimental_report_unused_deps = "warn",
     javac_options = ":default_javac_options",
     kotlinc_options = ":default_kotlinc_options",
     language_version = "1.4",

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -81,6 +81,7 @@ def _kotlin_toolchain_impl(ctx):
         js_stdlibs = ctx.attr.js_stdlibs,
         experimental_use_abi_jars = ctx.attr.experimental_use_abi_jars,
         experimental_strict_kotlin_deps = ctx.attr.experimental_strict_kotlin_deps,
+        experimental_report_unused_deps = ctx.attr.experimental_report_unused_deps,
         javac_options = ctx.attr.javac_options[JavacOptions] if ctx.attr.javac_options else None,
         kotlinc_options = ctx.attr.kotlinc_options[KotlincOptions] if ctx.attr.kotlinc_options else None,
         empty_jar = ctx.file._empty_jar,
@@ -199,6 +200,15 @@ _kt_toolchain = rule(
                 "error",
             ],
         ),
+        "experimental_report_unused_deps": attr.string(
+            doc = "Report unused dependencies",
+            default = "off",
+            values = [
+                "off",
+                "warn",
+                "error",
+            ],
+        ),
         "javac_options": attr.label(
             doc = "Compiler options for javac",
             providers = [JavacOptions],
@@ -237,6 +247,7 @@ def define_kt_toolchain(
         jvm_target = None,
         experimental_use_abi_jars = False,
         experimental_strict_kotlin_deps = None,
+        experimental_report_unused_deps = None,
         javac_options = None,
         kotlinc_options = None):
     """Define the Kotlin toolchain."""
@@ -262,6 +273,7 @@ def define_kt_toolchain(
             "//conditions:default": experimental_use_abi_jars,
         }),
         experimental_strict_kotlin_deps = experimental_strict_kotlin_deps,
+        experimental_report_unused_deps = experimental_report_unused_deps,
         javac_options = javac_options,
         kotlinc_options = kotlinc_options,
         visibility = ["//visibility:public"],

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -60,6 +60,9 @@ kt_rules_test(
 kt_rules_test(
     name = "JdepsMergerTest",
     srcs = ["jvm/JdepsMergerTest.kt"],
+    deps = [
+        "//src/main/kotlin/io/bazel/kotlin/builder/utils/jars",
+    ],
 )
 
 kt_jvm_test(

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMergerTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMergerTest.kt
@@ -6,12 +6,13 @@ import com.google.devtools.build.lib.view.proto.Deps.Dependency
 import io.bazel.kotlin.builder.DaggerJdepsMergerTestComponent
 import io.bazel.kotlin.builder.tasks.InvocationWorker
 import io.bazel.kotlin.builder.tasks.WorkerIO
+import io.bazel.kotlin.builder.tasks.jvm.JdepsMerger.Companion.JdepsMergerFlags
 import io.bazel.kotlin.builder.utils.Flag
+import io.bazel.kotlin.builder.utils.jars.JarCreator
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
-import java.io.BufferedInputStream
-import java.io.BufferedOutputStream
+import java.io.*
 import java.nio.file.Files
 import java.nio.file.Path
 
@@ -32,6 +33,19 @@ class JdepsMergerTest {
 
   private fun out(name: String): Path {
     return Files.createDirectories(wrkDir.resolve("out")).resolve(name)
+  }
+
+  fun ktJvmLibrary(label: String): String {
+    val path = Files.createDirectories(wrkDir.resolve("out")).resolve("lib${label}.jar")
+    JarCreator(
+      path = path,
+      normalize = true,
+      verbose = false
+    ).also {
+      it.setJarOwner(label, "kt_jvm_library")
+      it.execute()
+    }
+    return path.toString()
   }
 
   @Test
@@ -59,10 +73,11 @@ class JdepsMergerTest {
     WorkerIO.open().use { io ->
       val worker = InvocationWorker(io, merger)
       assertThat(worker.run(args {
-        flag(JdepsMerger.Companion.JdepsMergerFlags.TARGET_LABEL, "//foo/bar:baz")
+        flag(JdepsMergerFlags.TARGET_LABEL, "//foo/bar:baz")
         input(kotlinJdeps)
         input(javaJdeps)
-        flag(JdepsMerger.Companion.JdepsMergerFlags.OUTPUT, mergedJdeps)
+        flag(JdepsMergerFlags.OUTPUT, mergedJdeps)
+        flag(JdepsMergerFlags.REPORT_UNUSED_DEPS, "off")
       })).isEqualTo(0)
     }
 
@@ -96,10 +111,11 @@ class JdepsMergerTest {
     WorkerIO.open().use { io ->
       val worker = InvocationWorker(io, merger)
       assertThat(worker.run(args {
-        flag(JdepsMerger.Companion.JdepsMergerFlags.TARGET_LABEL, "//foo/bar:baz")
+        flag(JdepsMergerFlags.TARGET_LABEL, "//foo/bar:baz")
         input(kotlinJdeps)
         input(javaJdeps)
-        flag(JdepsMerger.Companion.JdepsMergerFlags.OUTPUT, mergedJdeps)
+        flag(JdepsMergerFlags.OUTPUT, mergedJdeps)
+        flag(JdepsMergerFlags.REPORT_UNUSED_DEPS, "off")
       })).isEqualTo(0)
     }
 
@@ -108,6 +124,93 @@ class JdepsMergerTest {
     assertThat(depsProto.dependencyList.map { it.kind }).containsExactly(Dependency.Kind.EXPLICIT)
   }
 
+  @Test
+  fun `unused deps report warning`() {
+    val merger = DaggerJdepsMergerTestComponent.builder().build().jdepsMerger()
+
+    val unusedKotlinDep = ktJvmLibrary("kotlin_dep")
+    val kotlinJdeps = jdeps("kt.jdeps") {
+      addDependency(with(Dependency.newBuilder()) {
+        kind = Dependency.Kind.UNUSED
+        path = unusedKotlinDep
+        build()
+      })
+    }
+
+    val javaJdeps = jdeps("java.jdeps") {
+      addDependency(with(Dependency.newBuilder()) {
+        kind = Dependency.Kind.EXPLICIT
+        path = ktJvmLibrary("java_dep")
+        build()
+      })
+    }
+
+    val mergedJdeps = out("merged.jdeps")
+
+    val out = ByteArrayOutputStream()
+    val printStream = PrintStream(out)
+    System.setOut(printStream)
+    WorkerIO(ByteArrayInputStream(ByteArray(10)), printStream, ByteArrayOutputStream(), {}).use { io ->
+      val worker = InvocationWorker(io, merger)
+      assertThat(worker.run(args {
+        input(kotlinJdeps)
+        input(javaJdeps)
+        flag(JdepsMergerFlags.TARGET_LABEL, "//foo/bar:baz")
+        flag(JdepsMergerFlags.OUTPUT, mergedJdeps)
+        flag(JdepsMergerFlags.REPORT_UNUSED_DEPS, "warn")
+      })).isEqualTo(0)
+    }
+    assertThat(out.toString()).contains("'remove deps kotlin_dep' //foo/bar:baz")
+
+    val depsProto = depsProto(mergedJdeps)
+    assertThat(depsProto.dependencyList
+      .filter { it.kind == Dependency.Kind.UNUSED }
+      .map { it.path }).containsExactly(unusedKotlinDep)
+  }
+
+  @Test
+  fun `unused deps report error`() {
+    val merger = DaggerJdepsMergerTestComponent.builder().build().jdepsMerger()
+
+    val unusedKotlinDep = ktJvmLibrary("kotlin_dep")
+    val kotlinJdeps = jdeps("kt.jdeps") {
+      addDependency(with(Dependency.newBuilder()) {
+        kind = Dependency.Kind.UNUSED
+        path = unusedKotlinDep
+        build()
+      })
+    }
+
+    val javaJdeps = jdeps("java.jdeps") {
+      addDependency(with(Dependency.newBuilder()) {
+        kind = Dependency.Kind.EXPLICIT
+        path = ktJvmLibrary("java_dep")
+        build()
+      })
+    }
+
+    val mergedJdeps = out("merged.jdeps")
+
+    val out = ByteArrayOutputStream()
+    val printStream = PrintStream(out)
+    System.setOut(printStream)
+    WorkerIO(ByteArrayInputStream(ByteArray(10)), printStream, ByteArrayOutputStream(), {}).use { io ->
+      val worker = InvocationWorker(io, merger)
+      assertThat(worker.run(args {
+        input(kotlinJdeps)
+        input(javaJdeps)
+        flag(JdepsMergerFlags.TARGET_LABEL, "//foo/bar:baz")
+        flag(JdepsMergerFlags.OUTPUT, mergedJdeps)
+        flag(JdepsMergerFlags.REPORT_UNUSED_DEPS, "error")
+      })).isEqualTo(1)
+    }
+    assertThat(out.toString()).contains("'remove deps kotlin_dep' //foo/bar:baz")
+
+    val depsProto = depsProto(mergedJdeps)
+    assertThat(depsProto.dependencyList
+      .filter { it.kind == Dependency.Kind.UNUSED }
+      .map { it.path }).containsExactly(unusedKotlinDep)
+  }
 
   private fun depsProto(mergedJdeps: Path) =
     Deps.Dependencies.parseFrom(BufferedInputStream(Files.newInputStream(mergedJdeps)))
@@ -129,7 +232,7 @@ class JdepsMergerTest {
     }
 
     fun input(src: Path) {
-      flag(JdepsMerger.Companion.JdepsMergerFlags.INPUTS, src.toString())
+      flag(JdepsMergerFlags.INPUTS, src.toString())
     }
 
     fun list(): List<String> {

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
@@ -231,11 +231,6 @@ class KotlinWorkerTest {
         flag(JavaBuilderFlags.BUILD_JAVA, "false")
       })).isEqualTo(0)
 
-      System.err.println(ZipFile(jarOne.toFile())
-                           .stream()
-                           .map(ZipEntry::getName)
-                           .toList())
-
       assertThat(
         ZipFile(jarOne.toFile())
           .stream()


### PR DESCRIPTION
- Add a tristate (off/warn/error) experimental_report_unused_deps attribute to the toolchain.
- Implement unused dependency checking in `JDepsMerger` tool.
- Collect jdeps dependency artifacts if experimental_report_unused_deps is enabled (warn/error) and pass to KotlinBuilder. Passing these inputs triggers `JDepsMerge` action for each target causing the unused deps checking logic to be executed. Currently these inputs are not used by the `KotlinBuilder` but will be required for future work implementing a reduced classpath feature.
- Add tests for experimental_report_unused_deps off/warn/error
- Enable experimental_report_unused_deps as "warn" for examples/android