### PR TITLE
Strict dependency checking and enforcement.

### DIFF
--- a/examples/android/bzl/BUILD.bazel
+++ b/examples/android/bzl/BUILD.bazel
@@ -13,6 +13,7 @@ define_kt_toolchain(
     name = "experimental_toolchain",
     api_version = "1.4",
     experimental_use_abi_jars = True,
+    experimental_strict_kotlin_deps = "warn",
     javac_options = ":default_javac_options",
     kotlinc_options = ":default_kotlinc_options",
     language_version = "1.4",

--- a/kotlin/internal/js/impl.bzl
+++ b/kotlin/internal/js/impl.bzl
@@ -68,6 +68,7 @@ def kt_js_library_impl(ctx):
     args.add("--kotlin_js_dir", out_dir.path)
     args.add("--kotlin_output_js_jar", ctx.outputs.jar)
     args.add("--kotlin_output_srcjar", ctx.outputs.srcjar)
+    args.add("--strict_kotlin_deps", "off")
 
     args.add_all("--kotlin_js_libraries", libraries, omit_if_empty = False)
     args.add_all("--sources", ctx.files.srcs)

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -378,6 +378,7 @@ def _run_kt_builder_action(
     # TODO: Implement Strict Kotlin deps: (https://github.com/bazelbuild/rules_kotlin/issues/419)
     # This flag is currently unused by the builder but required for the unused_deps tool
     args.add_all("--direct_dependencies", _java_infos_to_compile_jars(compile_deps.deps))
+    args.add("--strict_kotlin_deps", toolchains.kt.experimental_strict_kotlin_deps)
     args.add_all("--classpath", compile_deps.compile_jars)
     args.add_all("--sources", srcs.all_srcs, omit_if_empty = True)
     args.add_all("--source_jars", srcs.src_jars + generated_src_jars, omit_if_empty = True)

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -78,6 +78,7 @@ def _kotlin_toolchain_impl(ctx):
         jvm_stdlibs = java_common.merge(compile_time_providers + runtime_providers),
         js_stdlibs = ctx.attr.js_stdlibs,
         experimental_use_abi_jars = ctx.attr.experimental_use_abi_jars,
+        experimental_strict_kotlin_deps = ctx.attr.experimental_strict_kotlin_deps,
         javac_options = ctx.attr.javac_options[JavacOptions] if ctx.attr.javac_options else None,
         kotlinc_options = ctx.attr.kotlinc_options[KotlincOptions] if ctx.attr.kotlinc_options else None,
         empty_jar = ctx.file._empty_jar,
@@ -187,6 +188,15 @@ _kt_toolchain = rule(
             `kt_abi_plugin_incompatible`""",
             default = False,
         ),
+        "experimental_strict_kotlin_deps": attr.string(
+            doc = "Report strict deps violations",
+            default = "off",
+            values = [
+                "off",
+                "warn",
+                "error",
+            ],
+        ),
         "javac_options": attr.label(
             doc = "Compiler options for javac",
             providers = [JavacOptions],
@@ -224,6 +234,7 @@ def define_kt_toolchain(
         api_version = None,
         jvm_target = None,
         experimental_use_abi_jars = False,
+        experimental_strict_kotlin_deps = None,
         javac_options = None,
         kotlinc_options = None):
     """Define the Kotlin toolchain."""
@@ -248,6 +259,7 @@ def define_kt_toolchain(
             absolute_target("//kotlin/internal:noexperimental_use_abi_jars"): False,
             "//conditions:default": experimental_use_abi_jars,
         }),
+        experimental_strict_kotlin_deps = experimental_strict_kotlin_deps,
         javac_options = javac_options,
         kotlinc_options = kotlinc_options,
         visibility = ["//visibility:public"],

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -115,7 +115,8 @@ class KotlinBuilder @Inject internal constructor(
       GENERATED_JAVA_SRC_JAR("--generated_java_srcjar"),
       GENERATED_JAVA_STUB_JAR("--kapt_generated_stub_jar"),
       GENERATED_CLASS_JAR("--kapt_generated_class_jar"),
-      BUILD_KOTLIN("--build_kotlin");
+      BUILD_KOTLIN("--build_kotlin"),
+      STRICT_KOTLIN_DEPS("--strict_kotlin_deps"),
     }
   }
 
@@ -180,6 +181,7 @@ class KotlinBuilder @Inject internal constructor(
         argMap.mandatorySingle(KotlinBuilderFlags.API_VERSION)
       toolchainInfoBuilder.commonBuilder.languageVersion =
         argMap.mandatorySingle(KotlinBuilderFlags.LANGUAGE_VERSION)
+      strictKotlinDeps = argMap.mandatorySingle(KotlinBuilderFlags.STRICT_KOTLIN_DEPS)
       this
     }
 

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -69,6 +69,7 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
                       inputs.directDependenciesList.forEach {
                         flag("direct_dependencies", it)
                       }
+                      flag("strict_kotlin_deps", info.strictKotlinDeps)
                     }
                     .given(outputs.jar).notEmpty {
                       append(codeGenArgs())

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/BUILD.bazel
@@ -11,25 +11,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+load("@rules_java//java:defs.bzl", "java_library")
 load("//src/main/kotlin:bootstrap.bzl", "kt_bootstrap_library")
 
 kt_bootstrap_library(
-    name = "tasks",
+    name = "jars",
     srcs = glob([
+        "*.kt",
         "**/*.kt",
     ]),
     visibility = ["//src:__subpackages__"],
     deps = [
-        "//src/main/kotlin/io/bazel/kotlin/builder/toolchain",
-        "//src/main/kotlin/io/bazel/kotlin/builder/utils",
-        "//src/main/kotlin/io/bazel/kotlin/builder/utils/jars",
         "//src/main/protobuf:deps_java_proto",
-        "//src/main/protobuf:kotlin_model_java_proto",
-        "//src/main/protobuf:worker_protocol_java_proto",
-        "@com_github_jetbrains_kotlin//:kotlin-preloader",
-        "@kotlin_rules_maven//:com_google_protobuf_protobuf_java",
-        "@kotlin_rules_maven//:com_google_protobuf_protobuf_java_util",
-        "@kotlin_rules_maven//:javax_inject_javax_inject",
     ],
 )

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/JarOwner.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/JarOwner.kt
@@ -1,0 +1,28 @@
+package io.bazel.kotlin.builder.utils.jars
+
+import io.bazel.kotlin.builder.utils.jars.JarHelper.Companion.INJECTING_RULE_KIND
+import io.bazel.kotlin.builder.utils.jars.JarHelper.Companion.TARGET_LABEL
+import java.io.IOException
+import java.io.UncheckedIOException
+import java.nio.file.Path
+import java.util.jar.JarFile
+
+data class JarOwner(val jar: Path, val label: String? = null, val aspect: String? = null) {
+  companion object {
+    fun readJarOwnerFromManifest(jarPath: Path): JarOwner {
+      try {
+        JarFile(jarPath.toFile()).use { jarFile ->
+          val manifest = jarFile.manifest ?: return JarOwner(jarPath)
+          val attributes = manifest.mainAttributes
+          val label = attributes[TARGET_LABEL] as String?
+            ?: return JarOwner(jarPath)
+          val injectingRuleKind = attributes[INJECTING_RULE_KIND] as String?
+          return JarOwner(jarPath, label, injectingRuleKind)
+        }
+      } catch (e: IOException) {
+        // This jar file pretty much has to exist.
+        throw UncheckedIOException(e)
+      }
+    }
+  }
+}

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/BUILD.bazel
@@ -21,6 +21,7 @@ kt_bootstrap_library(
     srcs = glob(["*.kt"]),
     visibility = ["//src:__subpackages__"],
     deps = [
+        "//src/main/kotlin/io/bazel/kotlin/builder/utils/jars",
         "//src/main/protobuf:deps_java_proto",
         "@com_github_jetbrains_kotlin//:kotlin-compiler",
         "@kotlin_rules_maven//:com_google_protobuf_protobuf_java",

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
@@ -16,18 +16,21 @@ class JdepsGenCommandLineProcessor : CommandLineProcessor {
       CliOption("target_label", "<String>", "Label of target being analyzed", required = true)
      val DIRECT_DEPENDENCIES_OPTION: CliOption =
       CliOption("direct_dependencies", "<List>", "List of targets direct dependencies", required = false, allowMultipleOccurrences = true)
+    val STRICT_KOTLIN_DEPS_OPTION: CliOption =
+      CliOption("strict_kotlin_deps", "<String>", "Report strict deps violations", required = true)
   }
 
   override val pluginId: String
     get() = COMPILER_PLUGIN_ID
   override val pluginOptions: Collection<AbstractCliOption>
-    get() = listOf(OUTPUT_JDEPS_FILE_OPTION, TARGET_LABEL_OPTION, DIRECT_DEPENDENCIES_OPTION)
+    get() = listOf(OUTPUT_JDEPS_FILE_OPTION, TARGET_LABEL_OPTION, DIRECT_DEPENDENCIES_OPTION, STRICT_KOTLIN_DEPS_OPTION)
 
   override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
     when (option) {
       OUTPUT_JDEPS_FILE_OPTION -> configuration.put(JdepsGenConfigurationKeys.OUTPUT_JDEPS, value)
       TARGET_LABEL_OPTION -> configuration.put(JdepsGenConfigurationKeys.TARGET_LABEL, value)
       DIRECT_DEPENDENCIES_OPTION -> configuration.appendList(JdepsGenConfigurationKeys.DIRECT_DEPENDENCIES, value)
+      STRICT_KOTLIN_DEPS_OPTION -> configuration.put(JdepsGenConfigurationKeys.STRICT_KOTLIN_DEPS, value)
       else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
     }
   }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenConfigurationKeys.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenConfigurationKeys.kt
@@ -16,6 +16,12 @@ object JdepsGenConfigurationKeys {
     CompilerConfigurationKey.create(JdepsGenCommandLineProcessor.TARGET_LABEL_OPTION.description)
 
   /**
+   * Label of the Bazel target being analyzed.
+   */
+  val STRICT_KOTLIN_DEPS: CompilerConfigurationKey<String> =
+    CompilerConfigurationKey.create(JdepsGenCommandLineProcessor.STRICT_KOTLIN_DEPS_OPTION.description)
+
+  /**
    * List of direct dependencies of the target.
    */
   val DIRECT_DEPENDENCIES: CompilerConfigurationKey<List<String>> =

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -78,6 +78,8 @@ message CompilationTaskInfo {
     // trace: enables trace logging.
     // timings: causes timing information to be printed at the of an action.
     repeated string debug = 9;
+    // Enable strict dependency checking for Kotlin
+    string strict_kotlin_deps = 10;
 }
 
 // Mested messages not marked with stable could be refactored.

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -183,6 +183,12 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
             });
         }
 
+        public void addTransitiveDependencies(Dep... dependencies) {
+            Dep.classpathOf(dependencies).forEach(dependency -> {
+                taskBuilder.getInputsBuilder().addClasspath(dependency);
+            });
+        }
+
         public TaskBuilder outputSrcJar() {
             taskBuilder.getOutputsBuilder()
                     .setSrcjar(instanceRoot().resolve("jar_file-sources.jar").toAbsolutePath().toString());
@@ -198,6 +204,11 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
         public TaskBuilder outputJdeps() {
             taskBuilder.getOutputsBuilder()
                     .setJdeps(instanceRoot().resolve("jdeps_file.jdeps").toAbsolutePath().toString());
+            return this;
+        }
+
+        public TaskBuilder kotlinStrictDeps(String level) {
+            taskBuilder.getInfoBuilder().setStrictKotlinDeps(level);
             return this;
         }
 

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -52,6 +52,12 @@ kt_rules_test(
 )
 
 kt_rules_test(
+    name = "KotlinBuilderJvmStrictDepsTest",
+    size = "large",
+    srcs = ["jvm/KotlinBuilderJvmStrictDepsTest.kt"],
+)
+
+kt_rules_test(
     name = "JdepsMergerTest",
     srcs = ["jvm/JdepsMergerTest.kt"],
 )

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmAbiTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmAbiTest.java
@@ -36,6 +36,8 @@ public class KotlinBuilderJvmAbiTest {
           c.outputAbiJar();
           c.compileJava();
           c.compileKotlin();
+          c.outputJdeps();
+          c.outputJavaJdeps();
         });
     ctx.runCompileTask(
         c -> {

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmAbiTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmAbiTest.java
@@ -36,8 +36,6 @@ public class KotlinBuilderJvmAbiTest {
           c.outputAbiJar();
           c.compileJava();
           c.compileKotlin();
-          c.outputJdeps();
-          c.outputJavaJdeps();
         });
     ctx.runCompileTask(
         c -> {

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmStrictDepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmStrictDepsTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package io.bazel.kotlin.builder.tasks.jvm;
+
+import com.google.common.truth.Truth.assertThat
+import io.bazel.kotlin.builder.KotlinJvmTestBuilder
+import org.junit.After
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+import java.util.function.Consumer
+
+@RunWith(JUnit4::class)
+class KotlinBuilderJvmStrictDepsTest {
+  val ctx = KotlinJvmTestBuilder()
+
+  @After
+  fun tearDown() {
+    ctx.tearDown()
+  }
+
+  @Test
+  fun `strict dependency violation error`() {
+    val transitiveDep = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("TransitiveClass.kt",
+        """
+          package something
+          
+          class TransitiveClass{}
+        """)
+      c.outputJar()
+      c.outputJdeps()
+      c.compileKotlin()
+    })
+
+    val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("AClass.kt",
+        """
+          package something
+          
+          class AClass{}
+        """)
+      c.outputJar()
+      c.compileKotlin()
+      c.addDirectDependencies(transitiveDep)
+      c.outputJdeps()
+    })
+
+
+    ctx.runFailingCompileTaskAndValidateOutput(
+      {
+        ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+            c.addSource("HasTransitiveReference.kt",
+              """
+          package something
+          
+          val transitiveReference = TransitiveClass()
+        """)
+            c.outputJar()
+            c.compileKotlin()
+            c.addDirectDependencies(dependentTarget)
+            c.addTransitiveDependencies(transitiveDep)
+            c.outputJdeps()
+            c.kotlinStrictDeps("error")
+          })
+      }
+    ) { lines: List<String?> -> assertThat(lines[0]).contains("Strict Deps Violations - please fix") }
+  }
+
+}

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
@@ -114,6 +114,7 @@ class KotlinWorkerTest {
     flag(KotlinBuilderFlags.GENERATED_CLASSDIR, "generated_classes")
     flag(JavaBuilderFlags.TEMPDIR, "tmp")
     flag(JavaBuilderFlags.SOURCEGEN_DIR, "generated_sources")
+    flag(KotlinBuilderFlags.STRICT_KOTLIN_DEPS, "off")
     cp(JavaBuilderFlags.CLASSPATH, KotlinJvmTestBuilder.KOTLIN_STDLIB.singleCompileJar())
     cp(JavaBuilderFlags.DIRECT_DEPENDENCIES, "")
     info.passthroughFlagsList.forEach { pf ->

--- a/src/test/kotlin/io/bazel/kotlin/builder/utils/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/utils/BUILD.bazel
@@ -19,6 +19,9 @@ load("//kotlin:kotlin.bzl", "kt_jvm_test")
 kt_rules_test(
     name = "SourceJarCreatorTest",
     srcs = ["jars/SourceJarCreatorTest.java"],
+    deps = [
+        "//src/main/kotlin/io/bazel/kotlin/builder/utils/jars",
+    ]
 )
 
 kt_jvm_test(


### PR DESCRIPTION
Add Toolchain parameter:

experimental_strict_kotlin_deps with values "off", "warn", "error"

Provides checking and enforcement if a dependency required for compilation is not explicitly listed in a targets 'deps'