### PR TITLE
Reduced classpath - experimental feature

### DIFF
--- a/examples/android/bzl/BUILD.bazel
+++ b/examples/android/bzl/BUILD.bazel
@@ -15,6 +15,7 @@ define_kt_toolchain(
     experimental_use_abi_jars = True,
     experimental_strict_kotlin_deps = "warn",
     experimental_report_unused_deps = "warn",
+    experimental_reduce_classpath_mode = "KOTLINBUILDER_REDUCED",
     javac_options = ":default_javac_options",
     kotlinc_options = ":default_kotlinc_options",
     language_version = "1.4",

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -391,6 +391,7 @@ def _run_kt_builder_action(
     args.add_all("--direct_dependencies", _java_infos_to_compile_jars(compile_deps.deps))
     args.add("--strict_kotlin_deps", toolchains.kt.experimental_strict_kotlin_deps)
     args.add_all("--classpath", compile_deps.compile_jars)
+    args.add("--reduced_classpath_mode", toolchains.kt.experimental_reduce_classpath_mode)
     args.add_all("--sources", srcs.all_srcs, omit_if_empty = True)
     args.add_all("--source_jars", srcs.src_jars + generated_src_jars, omit_if_empty = True)
     args.add_all("--deps_artifacts", deps_artifacts, omit_if_empty = True)

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -82,6 +82,7 @@ def _kotlin_toolchain_impl(ctx):
         experimental_use_abi_jars = ctx.attr.experimental_use_abi_jars,
         experimental_strict_kotlin_deps = ctx.attr.experimental_strict_kotlin_deps,
         experimental_report_unused_deps = ctx.attr.experimental_report_unused_deps,
+        experimental_reduce_classpath_mode = ctx.attr.experimental_reduce_classpath_mode,
         javac_options = ctx.attr.javac_options[JavacOptions] if ctx.attr.javac_options else None,
         kotlinc_options = ctx.attr.kotlinc_options[KotlincOptions] if ctx.attr.kotlinc_options else None,
         empty_jar = ctx.file._empty_jar,
@@ -209,6 +210,14 @@ _kt_toolchain = rule(
                 "error",
             ],
         ),
+        "experimental_reduce_classpath_mode": attr.string(
+            doc = "Removes unneeded dependencies from the classpath",
+            default = "NONE",
+            values = [
+                "NONE",
+                "KOTLINBUILDER_REDUCED",
+            ],
+        ),
         "javac_options": attr.label(
             doc = "Compiler options for javac",
             providers = [JavacOptions],
@@ -248,6 +257,7 @@ def define_kt_toolchain(
         experimental_use_abi_jars = False,
         experimental_strict_kotlin_deps = None,
         experimental_report_unused_deps = None,
+        experimental_reduce_classpath_mode = None,
         javac_options = None,
         kotlinc_options = None):
     """Define the Kotlin toolchain."""
@@ -274,6 +284,7 @@ def define_kt_toolchain(
         }),
         experimental_strict_kotlin_deps = experimental_strict_kotlin_deps,
         experimental_report_unused_deps = experimental_report_unused_deps,
+        experimental_reduce_classpath_mode = experimental_reduce_classpath_mode,
         javac_options = javac_options,
         kotlinc_options = kotlinc_options,
         visibility = ["//visibility:public"],

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -117,6 +117,7 @@ class KotlinBuilder @Inject internal constructor(
       GENERATED_CLASS_JAR("--kapt_generated_class_jar"),
       BUILD_KOTLIN("--build_kotlin"),
       STRICT_KOTLIN_DEPS("--strict_kotlin_deps"),
+      REDUCED_CLASSPATH_MODE("--reduced_classpath_mode"),
     }
   }
 
@@ -274,6 +275,9 @@ class KotlinBuilder @Inject internal constructor(
 
       with(root.inputsBuilder) {
         addAllClasspath(argMap.mandatory(JavaBuilderFlags.CLASSPATH))
+        addAllDepsArtifacts(
+          argMap.optional(JavaBuilderFlags.DEPS_ARTIFACTS) ?: emptyList()
+        )
         addAllDirectDependencies(argMap.mandatory(JavaBuilderFlags.DIRECT_DEPENDENCIES))
 
         addAllProcessors(argMap.optional(JavaBuilderFlags.PROCESSORS) ?: emptyList())

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -80,6 +80,8 @@ message CompilationTaskInfo {
     repeated string debug = 9;
     // Enable strict dependency checking for Kotlin
     string strict_kotlin_deps = 10;
+    // Optimize classpath by removing dependencies not required for compilation
+    string reduced_classpath_mode = 11;
 }
 
 // Mested messages not marked with stable could be refactored.
@@ -152,6 +154,8 @@ message JvmCompilationTask {
       repeated string compiler_plugin_classpath = 14;
       // Java opts to be passed to java compiler
       repeated string javac_flags = 15;
+      // JDeps dependency artifacts
+      repeated string deps_artifacts = 16;
   }
 
   CompilationTaskInfo info = 1;


### PR DESCRIPTION
Use dependency targets jdeps files to trim down the transitive dependencies on the compilation classpath. 