### PR TITLE
Fix release default options visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,15 @@
 # Bazel Kotlin Rules
 
 Current release: ***`legacy-1.3.0`***<br />
-Release candidate: ***`1.5.0-alpha-1`***<br />
+Release candidate: ***`1.5.0-alpha-2`***<br />
 Main branch: `master`
 
 # News!
+* <b>Dec 30, 2020.</b> Released version [1.5.0-alpha-2](https://github.com/bazelbuild/rules_kotlin/releases/tag/v1.5.0-alpha-2). Includes:
+  - Expanded kotlinc options
+  - New optimized compilation path (using JavaBuilder) `--define=experimental_use_abi_jars=1`.
+    - *Caveat*: compilation may fail due to https://youtrack.jetbrains.com/issue/KT-40133, https://youtrack.jetbrains.com/issue/KT-40340, https://youtrack.jetbrains.com/issue/KT-41381
+    - *Workaround*: add `tags=['kt_abi_plugin_incompatible']`
 * <b>Dec 3, 2020.</b> Released version [1.5.0-alpha-1](https://github.com/bazelbuild/rules_kotlin/releases/tag/v1.5.0-alpha-1). Includes:
   - Kotlin 1.4 support
   - Lots of different fixes, especially to kotlinc plugins, `exported_compiler_plugins`, etc.

--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -64,7 +64,7 @@ load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_d
 
 kt_download_local_dev_dependencies()
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories")
 
 kotlin_repositories()
 

--- a/kotlin/internal/BUILD
+++ b/kotlin/internal/BUILD
@@ -11,24 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-load("//kotlin/internal:opts.bzl", "kt_javac_options", "kt_kotlinc_options")
 load("//kotlin/internal:toolchains.bzl", "kt_configure_toolchains")
 load("//kotlin/internal/utils:packager.bzl", "release_archive")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-
-kt_kotlinc_options(
-    name = "default_kotlinc_options",
-    # Used internally as the rule default. This should be
-    # considered an implementation detail and not used externally
-    visibility = ["//visibility:public"],
-)
-
-kt_javac_options(
-    name = "default_javac_options",
-    # Used internally as the rule default. This should be
-    # considered an implementation detail and not used externally
-    visibility = ["//visibility:public"],
-)
 
 # Configures the toolchains
 kt_configure_toolchains()

--- a/kotlin/internal/BUILD.release.bazel
+++ b/kotlin/internal/BUILD.release.bazel
@@ -16,11 +16,3 @@ load("//kotlin/internal:opts.bzl", "kt_javac_options", "kt_kotlinc_options")
 load("//kotlin/internal:toolchains.bzl", "kt_configure_toolchains")
 
 kt_configure_toolchains()
-
-kt_kotlinc_options(
-    name = "default_kotlinc_options",
-)
-
-kt_javac_options(
-    name = "default_javac_options",
-)

--- a/kotlin/internal/BUILD.release.bazel
+++ b/kotlin/internal/BUILD.release.bazel
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("//kotlin/internal:opts.bzl", "kt_javac_options", "kt_kotlinc_options")
 load("//kotlin/internal:toolchains.bzl", "kt_configure_toolchains")
 
 kt_configure_toolchains()

--- a/kotlin/internal/jvm/BUILD.release.bazel
+++ b/kotlin/internal/jvm/BUILD.release.bazel
@@ -11,8 +11,4 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-load("//kotlin/internal:toolchains.bzl", "kt_configure_toolchains")
-
-kt_configure_toolchains()
-
 exports_files(["jetbrains-deshade.jarjar"])

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -268,7 +268,7 @@ def kt_configure_toolchains():
     Must be called in kotlin/internal/BUILD.bazel
     """
     if native.package_name() != "kotlin/internal":
-        fail("kt_configure_toolchains must be called in kotlin/internal to define well known targets.")
+        fail("kt_configure_toolchains must be called in kotlin/internal not %s" % native.package_name())
 
     kt_kotlinc_options(
         name = "default_kotlinc_options",

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -15,6 +15,8 @@ load(
     "//kotlin/internal:opts.bzl",
     "JavacOptions",
     "KotlincOptions",
+    "kt_javac_options",
+    "kt_kotlinc_options",
 )
 load(
     "//kotlin/internal:defs.bzl",
@@ -262,7 +264,22 @@ def define_kt_toolchain(
 def kt_configure_toolchains():
     """
     Defines the toolchain_type and default toolchain for kotlin compilation.
+
+    Must be called in kotlin/internal/BUILD.bazel
     """
+    if native.package_name() != "kotlin/internal":
+        fail("kt_configure_toolchains must be called in kotlin/internal to define well known targets.")
+
+    kt_kotlinc_options(
+        name = "default_kotlinc_options",
+        visibility = ["//visibility:public"],
+    )
+
+    kt_javac_options(
+        name = "default_javac_options",
+        visibility = ["//visibility:public"],
+    )
+
     native.config_setting(
         name = "experimental_use_abi_jars",
         values = {"define": "experimental_use_abi_jars=1"},


### PR DESCRIPTION
Default options in release tar do not have the correct visibility. This fixes that by moving them to kt_configure_toolchains().

Unsure why the release script and the ci missed the error.