### PR TITLE
Add support for javac KAPT arguments

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -452,6 +452,13 @@ def _run_kt_builder_action(
         omit_if_empty = True,
     )
 
+    # Add KAPT javac arguments. This is only defined on the toolchain for now, but could be added to rules if need be
+    args.add_all(
+        "--javac_arguments",
+        ["%s:%s" % (k, v) for k, v in toolchains.kt.kapt_javac_arguments.items()],
+        omit_if_empty = True,
+    )
+
     args.add_all(
         "--compiler_plugin",
         [j for p in compiler_compiler_plugins for j in p.plugin_jars],

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -84,6 +84,7 @@ def _kotlin_toolchain_impl(ctx):
         experimental_report_unused_deps = ctx.attr.experimental_report_unused_deps,
         experimental_reduce_classpath_mode = ctx.attr.experimental_reduce_classpath_mode,
         javac_options = ctx.attr.javac_options[JavacOptions] if ctx.attr.javac_options else None,
+        kapt_javac_arguments = ctx.attr.kapt_javac_arguments if ctx.attr.kapt_javac_arguments else None,
         kotlinc_options = ctx.attr.kotlinc_options[KotlincOptions] if ctx.attr.kotlinc_options else None,
         empty_jar = ctx.file._empty_jar,
         empty_jdeps = ctx.file._empty_jdeps,
@@ -223,6 +224,10 @@ _kt_toolchain = rule(
             providers = [JavacOptions],
             default = Label("//kotlin/internal:default_javac_options"),
         ),
+        "kapt_javac_arguments": attr.string_dict(
+            doc = """javac arguments to be supplied to KAPT""",
+            mandatory = False,
+        ),
         "_empty_jar": attr.label(
             doc = """Empty jar for exporting JavaInfos.""",
             allow_single_file = True,
@@ -259,6 +264,7 @@ def define_kt_toolchain(
         experimental_report_unused_deps = None,
         experimental_reduce_classpath_mode = None,
         javac_options = None,
+        kapt_javac_arguments = None,
         kotlinc_options = None):
     """Define the Kotlin toolchain."""
     impl_name = name + "_impl"
@@ -286,6 +292,7 @@ def define_kt_toolchain(
         experimental_report_unused_deps = experimental_report_unused_deps,
         experimental_reduce_classpath_mode = experimental_reduce_classpath_mode,
         javac_options = javac_options,
+        kapt_javac_arguments = kapt_javac_arguments,
         kotlinc_options = kotlinc_options,
         visibility = ["//visibility:public"],
     )

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -156,6 +156,8 @@ message JvmCompilationTask {
       repeated string javac_flags = 15;
       // JDeps dependency artifacts
       repeated string deps_artifacts = 16;
+      // Annotation processor javac arguments
+      map<string, string> javac_arguments = 17;
   }
 
   CompilationTaskInfo info = 1;


### PR DESCRIPTION
**Background**
Internally, we needed to support javac arguments in kotlin rules to pass through dagger options to KAPT such as fastInit and disable format generated sources. 

This is our own implementation to satisfy our requirements, but I suspect this is not the desirable approach for this based on this issue: https://github.com/bazelbuild/rules_kotlin/issues/403. However, it may be helpful for getting us closer to the right APIs here.

**Change**
* Add a `kapt_javac_arguments` attribute to the kotlin toolchain rule
* Pass through `kapt_javac_arguments` to the KotlinWorker through a `javac_arguments` field in the kotlin model proto.

To encode the key/value pairs through to the kotlin worker we use a `:` delimiter. This can cause issues if the key used for an annotation processor's option includes a `:` which I'm not sure is possible or not.