### PR TITLE
Add support for kt_android_local_test

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -90,6 +90,9 @@ def _compiler_toolchains(ctx):
 def _compiler_friends(ctx, friends):
     """Creates a struct of friends meta data"""
 
+    if len(friends) > 0 and ctx.attr.testonly == False:
+        fail("only testonly targets can have friends associated with them")
+
     # TODO extract and move this into common. Need to make it generic first.
     if len(friends) == 0:
         return struct(

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -198,6 +198,12 @@ _common_attr = utils.add_dicts(
         [Attributes common to all build rules](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).""",
             allow_files = True,
         ),
+        "friends": attr.label_list(
+            doc = """A single Kotlin dep which allows Kotlin code in other modules access to internal members. Currently uses the output
+            jar of the module -- i.e., exported deps won't be included.""",
+            default = [],
+            providers = [JavaInfo, _KtJvmInfo],
+        ),
         "plugins": attr.label_list(
             default = [],
             aspects = [_kt_jvm_plugin_aspect],
@@ -329,12 +335,6 @@ kt_jvm_test = rule(
         "_bazel_test_runner": attr.label(
             default = Label("@bazel_tools//tools/jdk:TestRunner_deploy.jar"),
             allow_files = True,
-        ),
-        "friends": attr.label_list(
-            doc = """A single Kotlin dep which allows the test code access to internal members. Currently uses the output
-            jar of the module -- i.e., exported deps won't be included.""",
-            default = [],
-            providers = [JavaInfo, _KtJvmInfo],
         ),
         "test_class": attr.string(
             doc = "The Java class to be loaded by the test runner.",

--- a/kotlin/kotlin.bzl
+++ b/kotlin/kotlin.bzl
@@ -20,6 +20,7 @@ load(
     "//kotlin:rules.bzl",
     _define_kt_toolchain = "define_kt_toolchain",
     _kt_android_library = "kt_android_library",
+    _kt_android_local_test = "kt_android_local_test",
     _kt_compiler_plugin = "kt_compiler_plugin",
     _kt_javac_options = "kt_javac_options",
     _kt_js_import = "kt_js_import",
@@ -44,4 +45,5 @@ kt_jvm_import = _kt_jvm_import
 kt_jvm_library = _kt_jvm_library
 kt_jvm_test = _kt_jvm_test
 kt_android_library = _kt_android_library
+kt_android_local_test = _kt_android_local_test
 kt_compiler_plugin = _kt_compiler_plugin

--- a/kotlin/rules.bzl
+++ b/kotlin/rules.bzl
@@ -35,6 +35,7 @@ load(
 load(
     "//kotlin/internal/jvm:android.bzl",
     _kt_android_library = "kt_android_library",
+    _kt_android_local_test = "kt_android_local_test",
 )
 load(
     "//kotlin/internal/js:js.bzl",
@@ -53,4 +54,5 @@ kt_jvm_import = _kt_jvm_import
 kt_jvm_library = _kt_jvm_library
 kt_jvm_test = _kt_jvm_test
 kt_android_library = _kt_android_library
+kt_android_local_test = _kt_android_local_test
 kt_compiler_plugin = _kt_compiler_plugin


### PR DESCRIPTION
Adding support for Kotlin and `android_local_test`. Things that changed in this PR:
- The `friends` attr has been moved from the `kt_jvm_test` group to the common group. This is to support creating `kt_jvm_library` bundles that can be packaged up us a dependency in a test target.
- `compile.bzl` was updated to enforce that `testonly` targets have `friends` associated with them. This was to keep compatibility with the old behavior.