### PR TITLE
[Jdeps] Fixes for more missing cases discovered during testing

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptorWithSource
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
+import org.jetbrains.kotlin.descriptors.PropertyDescriptor
 import org.jetbrains.kotlin.descriptors.SourceElement
 import org.jetbrains.kotlin.descriptors.findClassAcrossModuleDependencies
 import org.jetbrains.kotlin.diagnostics.DiagnosticSink
@@ -157,6 +158,9 @@ class JdepsGenExtension(
           descriptor.valueParameters.forEach { valueParameter ->
             getClassCanonicalPath(valueParameter.type.constructor.declarationDescriptor as DeclarationDescriptorWithSource)?.let { classesCanonicalPaths.add(it) }
           }
+        }
+        is PropertyDescriptor -> {
+          getClassCanonicalPath(descriptor.type.constructor.declarationDescriptor as DeclarationDescriptorWithSource)?.let { classesCanonicalPaths.add(it) }
         }
       }
     }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -14,6 +14,7 @@ import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.container.StorageComponentContainer
 import org.jetbrains.kotlin.container.useInstance
 import org.jetbrains.kotlin.descriptors.ClassDescriptor
+import org.jetbrains.kotlin.descriptors.DeclarationDescriptor
 import org.jetbrains.kotlin.descriptors.DeclarationDescriptorWithSource
 import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
@@ -30,6 +31,7 @@ import org.jetbrains.kotlin.load.kotlin.VirtualFileKotlinClass
 import org.jetbrains.kotlin.load.kotlin.getContainingKotlinJvmBinaryClass
 import org.jetbrains.kotlin.name.ClassId
 import org.jetbrains.kotlin.platform.TargetPlatform
+import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.BindingTrace
@@ -37,6 +39,8 @@ import org.jetbrains.kotlin.resolve.calls.checkers.CallChecker
 import org.jetbrains.kotlin.resolve.calls.checkers.CallCheckerContext
 import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.resolve.calls.util.FakeCallableDescriptorForObject
+import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
+import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameSafe
 import org.jetbrains.kotlin.resolve.descriptorUtil.getAllSuperclassesWithoutAny
 import org.jetbrains.kotlin.resolve.descriptorUtil.getSuperInterfaces
@@ -123,10 +127,13 @@ class JdepsGenExtension(
     platform: TargetPlatform,
     moduleDescriptor: ModuleDescriptor
   ) {
-    container.useInstance(ClasspathCollectingCallChecker(classesCanonicalPaths))
+    container.useInstance(ClasspathCollectingChecker(classesCanonicalPaths))
   }
 
-  class ClasspathCollectingCallChecker(private val classesCanonicalPaths: HashSet<String>) : CallChecker {
+  class ClasspathCollectingChecker(
+    private val classesCanonicalPaths: HashSet<String>
+  ) : CallChecker, DeclarationChecker {
+
     override fun check(resolvedCall: ResolvedCall<*>, reportOn: PsiElement, context: CallCheckerContext) {
 
       when (resolvedCall.resultingDescriptor) {
@@ -141,6 +148,16 @@ class JdepsGenExtension(
           getClassCanonicalPath(resolvedCall.resultingDescriptor)?.let { classesCanonicalPaths.add(it) }
         }
         else -> return
+      }
+    }
+
+    override fun check(declaration: KtDeclaration, descriptor: DeclarationDescriptor, context: DeclarationCheckerContext) {
+      when (descriptor) {
+        is FunctionDescriptor -> {
+          descriptor.valueParameters.forEach { valueParameter ->
+            getClassCanonicalPath(valueParameter.type.constructor.declarationDescriptor as DeclarationDescriptorWithSource)?.let { classesCanonicalPaths.add(it) }
+          }
+        }
       }
     }
   }

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -55,7 +55,7 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
                     DirectoryType.TEMP);
 
     private TaskBuilder taskBuilderInstance = new TaskBuilder();
-    private KotlinBuilderTestComponent component;
+    private static KotlinBuilderTestComponent component;
 
     @Override
     void setupForNext(CompilationTaskInfo.Builder taskInfo) {
@@ -83,16 +83,16 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
 
     @SafeVarargs
     public final Dep runCompileTask(Consumer<TaskBuilder>... setup) {
-        if (component == null) {
-            component = component();
-        }
-        return executeTask(component.jvmTaskExecutor()::execute, setup);
+        return executeTask(component().jvmTaskExecutor()::execute, setup);
     }
 
-    public static KotlinBuilderTestComponent component() {
-        return DaggerKotlinBuilderTestComponent.builder()
+    private static KotlinBuilderTestComponent component() {
+        if (component == null) {
+            component = DaggerKotlinBuilderTestComponent.builder()
                 .toolchain(KotlinToolchain.createToolchain())
                 .build();
+        }
+        return component;
     }
 
     private Dep executeTask(

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -32,11 +32,6 @@ import java.util.function.Consumer
 class KotlinBuilderJvmJdepsTest {
     val ctx = KotlinJvmTestBuilder()
 
-    @After
-    fun tearDown() {
-      ctx.tearDown()
-    }
-
     @Test
     fun `no dependencies`() {
 

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -304,6 +304,49 @@ class KotlinBuilderJvmJdepsTest {
   }
 
   @Test
+  fun `kotlin property definition`() {
+      val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+        c.addSource("JavaClass.java",
+          """
+            package something;
+   
+            public class JavaClass {
+              public interface InnerJavaClass {
+  
+              }          
+            }
+          """)
+        c.outputJar()
+        c.outputJavaJdeps()
+        c.compileJava()
+      })
+
+      val dependingTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+        c.addSource("HasPropertyDefinition.kt",
+          """
+            package something
+            
+            interface HasPropertyDefinition {
+
+                val callFactory: JavaClass.InnerJavaClass
+            }
+          """)
+        c.outputJar()
+        c.compileKotlin()
+        c.addDirectDependencies(dependentTarget)
+        c.outputJdeps()
+      })
+      val jdeps = depsProto(dependingTarget)
+
+      assertThat(jdeps.ruleLabel).isEqualTo(dependingTarget.label())
+
+      assertExplicit(jdeps).containsExactly(dependentTarget.singleCompileJar())
+      assertImplicit(jdeps).isEmpty()
+      assertUnused(jdeps).isEmpty()
+      assertIncomplete(jdeps).isEmpty()
+  }
+
+  @Test
   fun `kotlin generic type reference`() {
       val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
         c.addSource("AClass.kt",

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -58,7 +58,7 @@ class KotlinBuilderJvmJdepsTest {
   }
 
   @Test
-  fun `java dependencies`() {
+  fun `java class reference`() {
 
     val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
       c.addSource("AClass.kt",
@@ -97,7 +97,7 @@ class KotlinBuilderJvmJdepsTest {
   }
 
   @Test
-  fun `java constant`() {
+  fun `java constant reference`() {
 
     val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
       c.addSource("Constants.java",
@@ -122,6 +122,53 @@ class KotlinBuilderJvmJdepsTest {
           
           class AnotherClass {
             val ref = Constants.HELLO_CONSTANT
+          }
+        """)
+      c.outputJar()
+      c.compileKotlin()
+      c.outputJdeps()
+      c.addDirectDependencies(dependentTarget)
+    })
+    val jdeps = depsProto(dependingTarget)
+
+    assertThat(jdeps.ruleLabel).isEqualTo(dependingTarget.label())
+
+    assertExplicit(jdeps).containsExactly(dependentTarget.singleCompileJar())
+    assertImplicit(jdeps).isEmpty()
+    assertUnused(jdeps).isEmpty()
+    assertIncomplete(jdeps).isEmpty()
+  }
+
+  @Test
+  fun `java annotation reference`() {
+
+    val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("JavaAnnotation.java",
+        """
+          package something;
+          
+          import java.lang.annotation.Retention;
+          import java.lang.annotation.RetentionPolicy;
+          
+          @Retention(RetentionPolicy.RUNTIME)          
+          public @interface JavaAnnotation {
+          }
+        """)
+      c.outputJar()
+      c.outputJavaJdeps()
+      c.compileJava()
+    })
+
+    val dependingTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("AnotherClass.kt",
+        """
+          package something.other
+          
+          import something.JavaAnnotation
+ 
+          abstract class AnotherClass {
+            @JavaAnnotation
+            internal abstract fun hasAnnotation()
           }
         """)
       c.outputJar()
@@ -221,7 +268,7 @@ class KotlinBuilderJvmJdepsTest {
   }
 
   @Test
-  fun `property dependency`() {
+  fun `kotlin property reference`() {
       val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
         c.addSource("AClass.kt",
           """
@@ -257,6 +304,42 @@ class KotlinBuilderJvmJdepsTest {
   }
 
   @Test
+  fun `kotlin generic type reference`() {
+      val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+        c.addSource("AClass.kt",
+          """
+            package something
+
+            class AClass{}
+            """)
+        c.outputJar()
+        c.outputJdeps()
+        c.compileKotlin()
+      })
+
+      val dependingTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+        c.addSource("HasGenericTypeDependency.kt",
+          """
+            package something
+            
+            val property2 =  listOf<AClass>()
+          """)
+        c.outputJar()
+        c.compileKotlin()
+        c.addDirectDependencies(dependentTarget)
+        c.outputJdeps()
+      })
+      val jdeps = depsProto(dependingTarget)
+
+      assertThat(jdeps.ruleLabel).isEqualTo(dependingTarget.label())
+
+      assertExplicit(jdeps).contains(dependentTarget.singleCompileJar())
+      assertImplicit(jdeps).isEmpty()
+      assertUnused(jdeps).isEmpty()
+      assertIncomplete(jdeps).isEmpty()
+  }
+
+  @Test
   fun `inlined constant dependency recorded`() {
     val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
       c.addSource("ContainsConstant.kt",
@@ -278,6 +361,48 @@ class KotlinBuilderJvmJdepsTest {
             package something
             import dependency.ConstHolder
             val property2 = ConstHolder.CONSTANT_VAL
+          """)
+      c.outputJar()
+      c.compileKotlin()
+      c.addDirectDependencies(dependentTarget)
+      c.outputJdeps()
+    })
+    val jdeps = depsProto(dependingTarget)
+
+    assertThat(jdeps.ruleLabel).isEqualTo(dependingTarget.label())
+
+    assertExplicit(jdeps).containsExactly(dependentTarget.singleCompileJar())
+    assertImplicit(jdeps).isEmpty()
+    assertUnused(jdeps).isEmpty()
+    assertIncomplete(jdeps).isEmpty()
+  }
+
+  @Test
+  fun `constructor param inner class recorded`() {
+    val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("JavaClass.java",
+        """
+          package something;
+ 
+          public class JavaClass {
+            public interface InnerJavaClass {
+
+            }          
+          }
+        """)
+      c.outputJar()
+      c.outputJavaJdeps()
+      c.compileJava()
+    })
+
+    val dependingTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("HasConstructorDependency.kt",
+        """
+            package something.otherthan
+            
+            import something.JavaClass
+            
+            class HasConstructorDependency constructor(javaClass: JavaClass.InnerJavaClass) {}
           """)
       c.outputJar()
       c.compileKotlin()

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmStrictDepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmStrictDepsTest.kt
@@ -28,11 +28,6 @@ import java.util.function.Consumer
 class KotlinBuilderJvmStrictDepsTest {
   val ctx = KotlinJvmTestBuilder()
 
-  @After
-  fun tearDown() {
-    ctx.tearDown()
-  }
-
   @Test
   fun `strict dependency violation error`() {
     val transitiveDep = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinWorkerTest.kt
@@ -18,11 +18,13 @@
 package io.bazel.kotlin.builder.tasks.jvm
 
 import com.google.common.truth.Truth.assertThat
+import io.bazel.kotlin.builder.DaggerKotlinBuilderTestComponent
 import io.bazel.kotlin.builder.KotlinJvmTestBuilder
 import io.bazel.kotlin.builder.tasks.InvocationWorker
 import io.bazel.kotlin.builder.tasks.KotlinBuilder.Companion.JavaBuilderFlags
 import io.bazel.kotlin.builder.tasks.KotlinBuilder.Companion.KotlinBuilderFlags
 import io.bazel.kotlin.builder.tasks.WorkerIO
+import io.bazel.kotlin.builder.toolchain.KotlinToolchain.Companion.createToolchain
 import io.bazel.kotlin.builder.utils.Flag
 import io.bazel.kotlin.model.CompilationTaskInfo
 import io.bazel.kotlin.model.Platform
@@ -129,7 +131,9 @@ class KotlinWorkerTest {
   @Test
   fun `abi generation`() {
 
-    val builder = KotlinJvmTestBuilder.component().kotlinBuilder()
+    val builder = DaggerKotlinBuilderTestComponent.builder()
+      .toolchain(createToolchain())
+      .build().kotlinBuilder()
 
     val one = src("One.kt") {
       l("package harry.nilsson")
@@ -197,7 +201,9 @@ class KotlinWorkerTest {
   @Test
   fun `output directories are different for invocations`() {
 
-    val builder = KotlinJvmTestBuilder.component().kotlinBuilder()
+    val builder = DaggerKotlinBuilderTestComponent.builder()
+      .toolchain(createToolchain())
+      .build().kotlinBuilder()
 
     val one = src("One.kt") {
       l("package harry.nilsson")


### PR DESCRIPTION
Add DeclarationChecker to capture declared function (and constructor) value parameter type references.

Add more test coverage.