### PR TITLE
Fix breakage due to no jdeps produced when no KT source.

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
@@ -44,10 +44,7 @@ internal class JDepsGenerator @Inject constructor(
   fun generateJDeps(command: JvmCompilationTask) {
     val jdepsContent =
       if (command.inputs.classpathList.isEmpty()) {
-        Deps.Dependencies.newBuilder().let {
-          it.ruleLabel = command.info.label
-          it.build()
-        }
+        emptyJdeps(command.info.label)
       } else {
         ByteArrayOutputStream().use { out ->
           PrintWriter(out).use { writer ->
@@ -76,9 +73,22 @@ internal class JDepsGenerator @Inject constructor(
           }
         }
       }
-    Paths.get(command.outputs.javaJdeps).also {
-      Files.deleteIfExists(it)
-      FileOutputStream(Files.createFile(it).toFile()).use(jdepsContent::writeTo)
+    writeJdeps(command.outputs.javaJdeps, jdepsContent)
+  }
+
+  companion object {
+    internal fun writeJdeps(path: String, jdepsContent: Deps.Dependencies) {
+      Paths.get(path).also {
+        Files.deleteIfExists(it)
+        FileOutputStream(Files.createFile(it).toFile()).use(jdepsContent::writeTo)
+      }
+    }
+
+    internal fun emptyJdeps(label: String): Deps.Dependencies {
+      return Deps.Dependencies.newBuilder().let {
+        it.ruleLabel = label
+        it.build()
+      }
     }
   }
 }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -19,6 +19,8 @@
 package io.bazel.kotlin.builder.tasks.jvm
 
 import com.google.devtools.build.lib.view.proto.Deps
+import io.bazel.kotlin.builder.tasks.jvm.JDepsGenerator.Companion.emptyJdeps
+import io.bazel.kotlin.builder.tasks.jvm.JDepsGenerator.Companion.writeJdeps
 import io.bazel.kotlin.builder.toolchain.CompilationTaskContext
 import io.bazel.kotlin.builder.toolchain.KotlinToolchain
 import io.bazel.kotlin.builder.utils.IS_JVM_SOURCE_FILE
@@ -279,6 +281,7 @@ fun JvmCompilationTask.compileKotlin(
   printOnFail: Boolean = true
 ): List<String> {
   if (inputs.kotlinSourcesList.isEmpty()) {
+    writeJdeps(outputs.jdeps, emptyJdeps(info.label))
     return emptyList()
   } else {
     return (args + plugins(

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -30,26 +30,49 @@ import java.util.function.Consumer
 
 @RunWith(JUnit4::class)
 class KotlinBuilderJvmJdepsTest {
-    val ctx = KotlinJvmTestBuilder()
+  val ctx = KotlinJvmTestBuilder()
 
-    @Test
-    fun `no dependencies`() {
+  @Test
+  fun `no kotlin source produces empty jdeps`() {
 
-      val deps = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
-        c.addSource("AClass.kt",
-          """
+    val deps = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("AnotherClass.java",
+        """
+          package something;
+          
+          class AnotherClass {
+          }
+        """)
+      c.outputJar()
+      c.outputJdeps()
+      c.compileKotlin()
+      c.compileJava()
+      c.outputJavaJdeps()
+    })
+    val jdeps = depsProto(deps)
+
+    assertThat(jdeps.dependencyCount).isEqualTo(0)
+    assertThat(jdeps.ruleLabel).isEqualTo(deps.label())
+  }
+
+  @Test
+  fun `no dependencies`() {
+
+    val deps = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("AClass.kt",
+        """
             package something
             
             class AClass{}
           """)
-        c.outputJar()
-        c.outputJdeps()
-        c.compileKotlin()
-      })
-      val jdeps = depsProto(deps)
+      c.outputJar()
+      c.outputJdeps()
+      c.compileKotlin()
+    })
+    val jdeps = depsProto(deps)
 
-      assertThat(jdeps.dependencyCount).isEqualTo(0)
-      assertThat(jdeps.ruleLabel).isEqualTo(deps.label())
+    assertThat(jdeps.dependencyCount).isEqualTo(0)
+    assertThat(jdeps.ruleLabel).isEqualTo(deps.label())
   }
 
   @Test
@@ -264,45 +287,45 @@ class KotlinBuilderJvmJdepsTest {
 
   @Test
   fun `kotlin property reference`() {
-      val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
-        c.addSource("AClass.kt",
-          """
+    val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("AClass.kt",
+        """
             package something
 
             class AClass{}
             """)
-        c.outputJar()
-        c.outputJdeps()
-        c.compileKotlin()
-      })
+      c.outputJar()
+      c.outputJdeps()
+      c.compileKotlin()
+    })
 
-      val dependingTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
-        c.addSource("HasPropertyDependency.kt",
-          """
+    val dependingTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("HasPropertyDependency.kt",
+        """
             package something
             
             val property2 =  AClass()
           """)
-        c.outputJar()
-        c.compileKotlin()
-        c.addDirectDependencies(dependentTarget)
-        c.outputJdeps()
-      })
-      val jdeps = depsProto(dependingTarget)
+      c.outputJar()
+      c.compileKotlin()
+      c.addDirectDependencies(dependentTarget)
+      c.outputJdeps()
+    })
+    val jdeps = depsProto(dependingTarget)
 
-      assertThat(jdeps.ruleLabel).isEqualTo(dependingTarget.label())
+    assertThat(jdeps.ruleLabel).isEqualTo(dependingTarget.label())
 
-      assertExplicit(jdeps).containsExactly(dependentTarget.singleCompileJar())
-      assertImplicit(jdeps).isEmpty()
-      assertUnused(jdeps).isEmpty()
-      assertIncomplete(jdeps).isEmpty()
+    assertExplicit(jdeps).containsExactly(dependentTarget.singleCompileJar())
+    assertImplicit(jdeps).isEmpty()
+    assertUnused(jdeps).isEmpty()
+    assertIncomplete(jdeps).isEmpty()
   }
 
   @Test
   fun `kotlin property definition`() {
-      val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
-        c.addSource("JavaClass.java",
-          """
+    val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("JavaClass.java",
+        """
             package something;
    
             public class JavaClass {
@@ -311,14 +334,14 @@ class KotlinBuilderJvmJdepsTest {
               }          
             }
           """)
-        c.outputJar()
-        c.outputJavaJdeps()
-        c.compileJava()
-      })
+      c.outputJar()
+      c.outputJavaJdeps()
+      c.compileJava()
+    })
 
-      val dependingTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
-        c.addSource("HasPropertyDefinition.kt",
-          """
+    val dependingTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("HasPropertyDefinition.kt",
+        """
             package something
             
             interface HasPropertyDefinition {
@@ -326,55 +349,55 @@ class KotlinBuilderJvmJdepsTest {
                 val callFactory: JavaClass.InnerJavaClass
             }
           """)
-        c.outputJar()
-        c.compileKotlin()
-        c.addDirectDependencies(dependentTarget)
-        c.outputJdeps()
-      })
-      val jdeps = depsProto(dependingTarget)
+      c.outputJar()
+      c.compileKotlin()
+      c.addDirectDependencies(dependentTarget)
+      c.outputJdeps()
+    })
+    val jdeps = depsProto(dependingTarget)
 
-      assertThat(jdeps.ruleLabel).isEqualTo(dependingTarget.label())
+    assertThat(jdeps.ruleLabel).isEqualTo(dependingTarget.label())
 
-      assertExplicit(jdeps).containsExactly(dependentTarget.singleCompileJar())
-      assertImplicit(jdeps).isEmpty()
-      assertUnused(jdeps).isEmpty()
-      assertIncomplete(jdeps).isEmpty()
+    assertExplicit(jdeps).containsExactly(dependentTarget.singleCompileJar())
+    assertImplicit(jdeps).isEmpty()
+    assertUnused(jdeps).isEmpty()
+    assertIncomplete(jdeps).isEmpty()
   }
 
   @Test
   fun `kotlin generic type reference`() {
-      val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
-        c.addSource("AClass.kt",
-          """
+    val dependentTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("AClass.kt",
+        """
             package something
 
             class AClass{}
             """)
-        c.outputJar()
-        c.outputJdeps()
-        c.compileKotlin()
-      })
+      c.outputJar()
+      c.outputJdeps()
+      c.compileKotlin()
+    })
 
-      val dependingTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
-        c.addSource("HasGenericTypeDependency.kt",
-          """
+    val dependingTarget = ctx.runCompileTask(Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource("HasGenericTypeDependency.kt",
+        """
             package something
             
             val property2 =  listOf<AClass>()
           """)
-        c.outputJar()
-        c.compileKotlin()
-        c.addDirectDependencies(dependentTarget)
-        c.outputJdeps()
-      })
-      val jdeps = depsProto(dependingTarget)
+      c.outputJar()
+      c.compileKotlin()
+      c.addDirectDependencies(dependentTarget)
+      c.outputJdeps()
+    })
+    val jdeps = depsProto(dependingTarget)
 
-      assertThat(jdeps.ruleLabel).isEqualTo(dependingTarget.label())
+    assertThat(jdeps.ruleLabel).isEqualTo(dependingTarget.label())
 
-      assertExplicit(jdeps).contains(dependentTarget.singleCompileJar())
-      assertImplicit(jdeps).isEmpty()
-      assertUnused(jdeps).isEmpty()
-      assertIncomplete(jdeps).isEmpty()
+    assertExplicit(jdeps).contains(dependentTarget.singleCompileJar())
+    assertImplicit(jdeps).isEmpty()
+    assertUnused(jdeps).isEmpty()
+    assertIncomplete(jdeps).isEmpty()
   }
 
   @Test


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/rules_kotlin/issues/440