### PR TITLE
Ignore jetpack compose example from within the parent project.

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -2,6 +2,7 @@
 # we don't break trying to build separate workspaces using wildcards like //...
 # examples/dagger doesn't have its own workspace, so don't do all of examples.
 examples/android
+examples/jetpack_compose
 examples/node
 examples/trivial
 examples/anvil


### PR DESCRIPTION
Ignore the jetpack compose example project from the main.  This avoids //... activating a completely different workspace. 