### PR TITLE
Fix test class checking to break when it finds a match.

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -214,6 +214,7 @@ def kt_jvm_junit_test_impl(ctx):
                     elements = file.short_path.split(splitter, 1)
                     if len(elements) == 2:
                         test_class = elements[1].split(".")[0].replace("/", ".")
+                        break
 
     _write_launcher_action(
         ctx,


### PR DESCRIPTION
The present logic fails to break the loop when it finds a match, so just assumes the last match. However, the matchers are ordered, because the later ones are more general, and so a given path may match more than one (e.g. `test/` and `src/test/kotlin/` will both match `foo/bar/src/test/kotlin/my/package/SomeTest.kt`).

a.k.a. oops.