### PR TITLE
Make all the child workspaces share the same .bazelversion.

### DIFF
--- a/examples/android/.bazelversion
+++ b/examples/android/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/examples/anvil/.bazelversion
+++ b/examples/anvil/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/examples/jetpack_compose/.bazelversion
+++ b/examples/jetpack_compose/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/examples/node/.bazelversion
+++ b/examples/node/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion

--- a/examples/trivial/.bazelversion
+++ b/examples/trivial/.bazelversion
@@ -1,0 +1,1 @@
+../../.bazelversion


### PR DESCRIPTION
Add in symlinks to make sure we're not running different versions of bazel (by default) on different example workspaces.