### PR TITLE
[jdeps] Support tracking IMPLICIT dependencies

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenComponentRegistrar.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenComponentRegistrar.kt
@@ -18,7 +18,6 @@ class JdepsGenComponentRegistrar : ComponentRegistrar {
     // they were loaded from
     val extension = JdepsGenExtension(project, configuration)
     AnalysisHandlerExtension.registerExtension(project, extension)
-    ClassBuilderInterceptorExtension.registerExtension(project, extension)
     StorageComponentContainerContributor.registerExtension(project, extension)
   }
 }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmAbiTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmAbiTest.java
@@ -36,6 +36,8 @@ public class KotlinBuilderJvmAbiTest {
           c.outputAbiJar();
           c.compileJava();
           c.compileKotlin();
+          c.outputJdeps();
+          c.outputJavaJdeps();
         });
     ctx.runCompileTask(
         c -> {


### PR DESCRIPTION
Support tracking super types of type and of generic type declarations that are not explicitly referenced as IMPLICIT dependencies.

This case only manifests when there are NO explicit type references to
any types in that given dependency, just that types are indirectly
loaded via being a super type of an explicit dependency.

Add tests for this cases as well as lambda references + return types.