### PR TITLE
Bump default kotlinc version to the latest

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -57,6 +57,16 @@ tasks:
     #  - "--override_repository=io_bazel_rules_kotlin=/tmp/rules_kotlin_release"
     test_targets:
       - //...
+  example-jetpack-compose:
+    name: "Example - Jetpack Compose"
+    platform: ubuntu1804
+    shell_commands:
+      - "cd ../.. && bazel build //:rules_kotlin_release && rm -rf /tmp/rules_kotlin_release && mkdir -p /tmp/rules_kotlin_release && tar -C /tmp/rules_kotlin_release -xvf bazel-bin/rules_kotlin_release.tgz"
+    working_directory: examples/jetpack_compose
+    test_flags:
+      - "--override_repository=io_bazel_rules_kotlin=/tmp/rules_kotlin_release"
+    test_targets:
+      - //...
   examples-trivial:
     name: "Example - Trivial"
     platform: ubuntu1804

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -53,8 +53,8 @@ tasks:
     shell_commands:
       - "cd ../.. && bazel build //:rules_kotlin_release && rm -rf /tmp/rules_kotlin_release && mkdir -p /tmp/rules_kotlin_release && tar -C /tmp/rules_kotlin_release -xvf bazel-bin/rules_kotlin_release.tgz"
     working_directory: examples/anvil
-    #test_flags:
-    #  - "--override_repository=io_bazel_rules_kotlin=/tmp/rules_kotlin_release"
+    test_flags:
+      - "--override_repository=io_bazel_rules_kotlin=/tmp/rules_kotlin_release"
     test_targets:
       - //...
   example-jetpack-compose:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -63,9 +63,9 @@ tasks:
     shell_commands:
       - "cd ../.. && bazel build //:rules_kotlin_release && rm -rf /tmp/rules_kotlin_release && mkdir -p /tmp/rules_kotlin_release && tar -C /tmp/rules_kotlin_release -xvf bazel-bin/rules_kotlin_release.tgz"
     working_directory: examples/jetpack_compose
-    test_flags:
+    build_flags:
       - "--override_repository=io_bazel_rules_kotlin=/tmp/rules_kotlin_release"
-    test_targets:
+    build_targets:
       - //...
   examples-trivial:
     name: "Example - Trivial"

--- a/kotlin/internal/repositories/release_repositories.bzl
+++ b/kotlin/internal/repositories/release_repositories.bzl
@@ -29,9 +29,9 @@ BAZEL_JAVA_LAUNCHER_VERSION = "3.7.0"
 
 KOTLIN_CURRENT_COMPILER_RELEASE = {
     "urls": [
-        "https://github.com/JetBrains/kotlin/releases/download/v1.4.20/kotlin-compiler-1.4.20.zip",
+        "https://github.com/JetBrains/kotlin/releases/download/v1.4.21/kotlin-compiler-1.4.21.zip",
     ],
-    "sha256": "11db93a4d6789e3406c7f60b9f267eba26d6483dcd771eff9f85bb7e9837011f",
+    "sha256": "46720991a716e90bfc0cf3f2c81b2bd735c14f4ea6a5064c488e04fd76e6b6c7",
 }
 
 KOTLIN_RULES = absolute_target("//kotlin:kotlin.bzl")


### PR DESCRIPTION
Satisfies the dependency of the jetpack compose example (and to be consistent). Also add JPC to the CI system.