### PR TITLE
Persistent workers: exit if stdin is closed

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/BazelWorker.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/BazelWorker.kt
@@ -158,7 +158,7 @@ class PersistentWorker(
 
   override fun run(args: List<String>): Int {
     while (true) {
-      val request = WorkRequest.parseDelimitedFrom(io.input) ?: continue
+      val request = WorkRequest.parseDelimitedFrom(io.input) ?: break
 
       val (status, exit) = WorkingDirectoryContext.newContext()
         .runCatching {


### PR DESCRIPTION
Currently, the Kotlin persistent worker goes into an infinite loop when stdin is closed. It keeps trying to parse the input, but nothing is read, so it keeps getting a `null` pointer, and then tries, tries again.