### PR TITLE
Add java_parameters kt_kotlinc_option

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -203,6 +203,8 @@ def _kotlinc_options_provider_to_flags(opts, language_version):
         flags.append("-Xjvm-default=compatibility")
     if opts.x_no_optimized_callable_references:
         flags.append("-Xno-optimized-callable-references")
+    if opts.java_parameters:
+        flags.append("-java-parameters")
     return flags
 
 def _validate_kotlinc_options(opts, language_version):

--- a/kotlin/internal/opts.bzl
+++ b/kotlin/internal/opts.bzl
@@ -86,6 +86,13 @@ _KOPTS = {
         ),
         type = attr.bool,
     ),
+    "java_parameters": struct(
+        args = dict(
+            default = False,
+            doc = "Generate metadata for Java 1.8 reflection on method parameters.",
+        ),
+        type = attr.bool,
+    ),
 }
 
 KotlincOptions = provider(

--- a/kotlin/internal/opts.bzl
+++ b/kotlin/internal/opts.bzl
@@ -89,7 +89,7 @@ _KOPTS = {
     "java_parameters": struct(
         args = dict(
             default = False,
-            doc = "Generate metadata for Java 1.8 reflection on method parameters.",
+            doc = "Generate metadata for Java 1.8+ reflection on method parameters.",
         ),
         type = attr.bool,
     ),


### PR DESCRIPTION
This option makes method parameter names visible to the java 1.8+ reflection API.

https://kotlinlang.org/docs/reference/compiler-reference.html#-java-parameters