### PR TITLE
Set the compile jar to be the same as the output jar

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -609,7 +609,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
 
     java_info = JavaInfo(
         output_jar = output_jar,
-        compile_jar = compile_jar,
+        compile_jar = output_jar,
         source_jar = source_jar,
         jdeps = ctx.outputs.jdeps,
         deps = compile_deps.deps,
@@ -633,7 +633,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
                 jdeps = ctx.outputs.jdeps,
                 jars = [struct(
                     class_jar = output_jar,
-                    ijar = compile_jar,
+                    ijar = output_jar,
                     source_jars = [source_jar],
                 )],
             ),


### PR DESCRIPTION
When kt_jvm_library is used to create a library that contains auxiliary files (lie .proto files) it does so correctly.  However, when referred to via deps in the build of another module, bazel creates the -hjar file that strips these needed components from the .jar file used to link against.

This PR sets the compile / ijar resource to be the same as the created .jar file, thus eliminating this intermediate hjar creation.  This is the same as a previous PR (#341)