### PR TITLE
Support optional source_jar

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -129,12 +129,16 @@ def kt_jvm_import_impl(ctx):
             jars = [artifact],
         ),
     )
+
     return struct(
         kt = kt_info,
         providers = [
             DefaultInfo(
                 files = depset(direct = [artifact.class_jar]),
-                runfiles = ctx.runfiles(files = [artifact.class_jar, artifact.source_jar]),
+                runfiles = ctx.runfiles(
+                    # Append class jar with the optional sources jar
+                    files = [artifact.class_jar] + [artifact.source_jar] if artifact.source_jar else []
+                ),
             ),
             JavaInfo(
                 output_jar = artifact.class_jar,


### PR DESCRIPTION
Creating a `kt_jvm_import` target without source jars crashes.

```
Traceback (most recent call last):
        File "/private/var/tmp/_bazel_blee/499a001013731d09bffd82f8601a3161/external/io_bazel_rules_kotlin/kotlin/internal/jvm/impl.bzl", line 141, column 40, in kt_jvm_import_impl
                runfiles = ctx.runfiles(files = [artifact.class_jar, artifact.source_jar]),
Error in runfiles: at index 0 of files, got element of type NoneType, want File
```