### PR TITLE
More jdeps fixes

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -156,8 +156,13 @@ class JdepsGenExtension(
           getClassCanonicalPath(resultingDescriptor)?.let { explicitClassesCanonicalPaths.add(it) }
         }
         is PropertyDescriptor -> {
-          val virtualFileClass = (resultingDescriptor).getContainingKotlinJvmBinaryClass() as? VirtualFileKotlinClass ?: return
-          explicitClassesCanonicalPaths.add(virtualFileClass.file.path)
+          when (resultingDescriptor.containingDeclaration) {
+            is ClassDescriptor -> collectTypeReferences((resultingDescriptor.containingDeclaration as ClassDescriptor).defaultType)
+            else -> {
+              val virtualFileClass = (resultingDescriptor).getContainingKotlinJvmBinaryClass() as? VirtualFileKotlinClass ?: return
+              explicitClassesCanonicalPaths.add(virtualFileClass.file.path)
+            }
+          }
         }
         else -> return
       }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -227,9 +227,14 @@ class JdepsGenExtension(
         }
       }
 
+      collectTypeArguments(kotlinType)
+    }
+
+    fun collectTypeArguments(kotlinType: KotlinType) {
       kotlinType.arguments.map { it.type }.forEach { typeArgument ->
         addExplicitDep(typeArgument)
         typeArgument.supertypes().forEach { addImplicitDep(it) }
+        collectTypeArguments(typeArgument)
       }
     }
   }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -143,7 +143,7 @@ class JdepsGenExtension(
           getClassCanonicalPath(resultingDescriptor)?.let { explicitClassesCanonicalPaths.add(it) }
         }
         is FakeCallableDescriptorForObject -> {
-          getClassCanonicalPath(resultingDescriptor)?.let { explicitClassesCanonicalPaths.add(it) }
+          collectTypeReferences(resultingDescriptor.type)
         }
         is JavaPropertyDescriptor -> {
           getClassCanonicalPath(resultingDescriptor)?.let { explicitClassesCanonicalPaths.add(it) }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -32,6 +32,7 @@ import org.jetbrains.kotlin.platform.TargetPlatform
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtFile
 import org.jetbrains.kotlin.resolve.BindingTrace
+import org.jetbrains.kotlin.resolve.FunctionImportedFromObject
 import org.jetbrains.kotlin.resolve.PropertyImportedFromObject
 import org.jetbrains.kotlin.resolve.calls.checkers.CallChecker
 import org.jetbrains.kotlin.resolve.calls.checkers.CallCheckerContext
@@ -127,6 +128,12 @@ class JdepsGenExtension(
       context: CallCheckerContext
     ) {
       when (val resultingDescriptor = resolvedCall.resultingDescriptor) {
+        is FunctionImportedFromObject -> {
+          collectTypeReferences((resolvedCall.resultingDescriptor as FunctionImportedFromObject).containingObject.defaultType)
+        }
+        is PropertyImportedFromObject -> {
+          collectTypeReferences((resolvedCall.resultingDescriptor as PropertyImportedFromObject).containingObject.defaultType)
+        }
         is JavaMethodDescriptor -> {
           getClassCanonicalPath((resultingDescriptor.containingDeclaration as ClassDescriptor).typeConstructor)?.let { explicitClassesCanonicalPaths.add(it) }
         }
@@ -147,9 +154,6 @@ class JdepsGenExtension(
         }
         is JavaPropertyDescriptor -> {
           getClassCanonicalPath(resultingDescriptor)?.let { explicitClassesCanonicalPaths.add(it) }
-        }
-        is PropertyImportedFromObject -> {
-          collectTypeReferences((resolvedCall.resultingDescriptor as PropertyImportedFromObject).containingObject.defaultType)
         }
         is PropertyDescriptor -> {
           val virtualFileClass = (resultingDescriptor).getContainingKotlinJvmBinaryClass() as? VirtualFileKotlinClass ?: return

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -193,6 +193,9 @@ class JdepsGenExtension(
           descriptor.annotations.forEach { annotation ->
             collectTypeReferences(annotation.type)
           }
+          descriptor.backingField?.annotations?.forEach { annotation ->
+            collectTypeReferences(annotation.type)
+          }
         }
         is LocalVariableDescriptor -> {
           collectTypeReferences(descriptor.type)

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -181,6 +181,9 @@ class JdepsGenExtension(
         }
         is PropertyDescriptor -> {
           collectTypeReferences(descriptor.type)
+          descriptor.annotations.forEach { annotation ->
+            collectTypeReferences(annotation.type)
+          }
         }
         is LocalVariableDescriptor -> {
           collectTypeReferences(descriptor.type)

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -163,6 +163,7 @@ class JdepsGenExtension(
               explicitClassesCanonicalPaths.add(virtualFileClass.file.path)
             }
           }
+          addImplicitDep(resultingDescriptor.type)
         }
         else -> return
       }


### PR DESCRIPTION
- Support nested type parameters
- Support property annotations
- Property reference to class with super type should collect super references.
- Support functions imported from objects.
- Support enum property references
- Support annotations with target = FIELD are located on backing field.
- Support indirect property references