### PR TITLE
pass the multiple platform flag to kotlin compiler

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -203,6 +203,8 @@ def _kotlinc_options_provider_to_flags(opts, language_version):
         flags.append("-Xjvm-default=compatibility")
     if opts.x_no_optimized_callable_references:
         flags.append("-Xno-optimized-callable-references")
+    if opts.x_multi_platform:
+            flags.append("-Xmulti-platform")
     if opts.java_parameters:
         flags.append("-java-parameters")
     return flags

--- a/kotlin/internal/opts.bzl
+++ b/kotlin/internal/opts.bzl
@@ -93,6 +93,13 @@ _KOPTS = {
         ),
         type = attr.bool,
     ),
+    "x_multi_platform": struct(
+        args = dict(
+            default = False,
+            doc = "Enable experimental language support for multi-platform projects",
+        ),
+        type = attr.bool,
+    ),
 }
 
 KotlincOptions = provider(


### PR DESCRIPTION
We are building Kotlin multiple platform project, which need bazel to support building kotlin code with KMP features. `-Xmulti-platform` flag is needed to be passed to kotlinc compiler to avoid the compile errors. 

Based on the statue of this [issue](https://github.com/bazelbuild/rules_kotlin/issues/23) there is no generic way of passing kotlinc compiler arguements. This PR add the arg to the `kt_kotlinc_options` so it can be enabled or disabled. 

Test:
Tested with local `local_repository`, kmp code compile successful.
Before got error:
` error: the feature "multi platform projects" is experimental and should be enabled explicitly