### PR TITLE
Add Jetpack Compose example to CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -94,6 +94,16 @@ tasks:
     build_targets:
       - //coroutines-helloworld/...
       - //express/...
+  example-jetpack-compose:
+    name: "Example - Jetpack Compose"
+    platform: ubuntu1804
+    shell_commands:
+      - "cd ../.. && bazel build //:rules_kotlin_release && rm -rf /tmp/rules_kotlin_release && mkdir -p /tmp/rules_kotlin_release && tar -C /tmp/rules_kotlin_release -xvf bazel-bin/rules_kotlin_release.tgz"
+    working_directory: examples/jetpack_compose
+    test_flags:
+      - "--override_repository=io_bazel_rules_kotlin=/tmp/rules_kotlin_release"
+    test_targets:
+      - //...
   stardoc:
     name: Stardoc api documentation
     platform: ubuntu1804

--- a/examples/jetpack_compose/.bazelrc
+++ b/examples/jetpack_compose/.bazelrc
@@ -1,0 +1,7 @@
+# Enable d8 merger
+build --define=android_dexmerger_tool=d8_dexmerger
+
+# Flags for the D8 dexer
+build --define=android_incremental_dexing_tool=d8_dexbuilder
+build --define=android_standalone_dexing_tool=d8_compat_dx
+build --nouse_workers_with_dexbuilder

--- a/examples/jetpack_compose/WORKSPACE
+++ b/examples/jetpack_compose/WORKSPACE
@@ -22,14 +22,14 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 maven_install(
     artifacts = [
         "org.jetbrains.kotlin:kotlin-stdlib:{}".format(_KOTLIN_COMPILER_VERSION),
-        "androidx.core:core-ktx:1.3.2",
-        "androidx.appcompat:appcompat:1.2.0",
-        "com.google.android.material:material:1.2.1",
-        "androidx.activity:activity-compose:1.3.0-alpha06",
-        "androidx.compose.material:material:1.0.0-beta04",
-        "androidx.compose.ui:ui:1.0.0-beta04",
-        "androidx.compose.ui:ui-tooling:1.0.0-beta04",
-        "androidx.compose.compiler:compiler:1.0.0-beta04",
+        "androidx.core:core-ktx:1.5.0",
+        "androidx.appcompat:appcompat:1.3.0",
+        "com.google.android.material:material:1.3.0",
+        "androidx.activity:activity-compose:1.3.0-alpha08",
+        "androidx.compose.material:material:1.0.0-beta07",
+        "androidx.compose.ui:ui:1.0.0-beta07",
+        "androidx.compose.ui:ui-tooling:1.0.0-beta07",
+        "androidx.compose.compiler:compiler:1.0.0-beta07",
     ],
     repositories = [
         "https://maven.google.com",

--- a/examples/jetpack_compose/WORKSPACE
+++ b/examples/jetpack_compose/WORKSPACE
@@ -1,6 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_KOTLIN_COMPILER_VERSION = "1.4.21"
+_KOTLIN_COMPILER_VERSION = "1.4.32"
 
 ## JVM External
 
@@ -25,10 +25,11 @@ maven_install(
         "androidx.core:core-ktx:1.3.2",
         "androidx.appcompat:appcompat:1.2.0",
         "com.google.android.material:material:1.2.1",
-        "androidx.compose.material:material:1.0.0-alpha09",
-        "androidx.compose.ui:ui:1.0.0-alpha09",
-        "androidx.compose.ui:ui-tooling:1.0.0-alpha09",
-        "androidx.compose.compiler:compiler:1.0.0-alpha09",
+        "androidx.activity:activity-compose:1.3.0-alpha06",
+        "androidx.compose.material:material:1.0.0-beta04",
+        "androidx.compose.ui:ui:1.0.0-beta04",
+        "androidx.compose.ui:ui-tooling:1.0.0-beta04",
+        "androidx.compose.compiler:compiler:1.0.0-beta04",
     ],
     repositories = [
         "https://maven.google.com",
@@ -126,6 +127,7 @@ load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
 android_sdk_repository(
     name = "androidsdk",
     api_level = 29,
+    build_tools_version = "30.0.1",
 )
 
 ## Kotlin
@@ -143,9 +145,9 @@ load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_reg
 
 kotlin_repositories(
     compiler_release = {
-        "sha256": "46720991a716e90bfc0cf3f2c81b2bd735c14f4ea6a5064c488e04fd76e6b6c7",
+        "sha256": "dfef23bb86bd5f36166d4ec1267c8de53b3827c446d54e82322c6b6daad3594c",
         "urls": [
-            "https://github.com/JetBrains/kotlin/releases/download/v1.4.21/kotlin-compiler-1.4.21.zip",
+            "https://github.com/JetBrains/kotlin/releases/download/v1.4.32/kotlin-compiler-1.4.32.zip",
         ],
     },
 )

--- a/examples/jetpack_compose/WORKSPACE
+++ b/examples/jetpack_compose/WORKSPACE
@@ -1,6 +1,10 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+_COMPOSE_VERSION = "1.0.0-beta07"
+
 _KOTLIN_COMPILER_VERSION = "1.4.32"
+
+_KOTLIN_COMPILER_SHA = "dfef23bb86bd5f36166d4ec1267c8de53b3827c446d54e82322c6b6daad3594c"
 
 ## JVM External
 
@@ -26,10 +30,10 @@ maven_install(
         "androidx.appcompat:appcompat:1.3.0",
         "com.google.android.material:material:1.3.0",
         "androidx.activity:activity-compose:1.3.0-alpha08",
-        "androidx.compose.material:material:1.0.0-beta07",
-        "androidx.compose.ui:ui:1.0.0-beta07",
-        "androidx.compose.ui:ui-tooling:1.0.0-beta07",
-        "androidx.compose.compiler:compiler:1.0.0-beta07",
+        "androidx.compose.material:material:{}".format(_COMPOSE_VERSION),
+        "androidx.compose.ui:ui:{}".format(_COMPOSE_VERSION),
+        "androidx.compose.ui:ui-tooling:{}".format(_COMPOSE_VERSION),
+        "androidx.compose.compiler:compiler:{}".format(_COMPOSE_VERSION),
     ],
     repositories = [
         "https://maven.google.com",
@@ -122,6 +126,15 @@ http_archive(
     ],
 )
 
+http_archive(
+    name = "rules_android",
+    sha256 = _RULES_ANDROID_SHA,
+    strip_prefix = "rules_android-{}".format(_RULES_ANDROID_VERSION),
+    urls = [
+        "https://github.com/bazelbuild/rules_android/archive/v{}.zip".format(_RULES_ANDROID_VERSION),
+    ],
+)
+
 load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
 
 android_sdk_repository(
@@ -141,13 +154,13 @@ load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_d
 
 kt_download_local_dev_dependencies()
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories")
 
 kotlin_repositories(
     compiler_release = {
-        "sha256": "dfef23bb86bd5f36166d4ec1267c8de53b3827c446d54e82322c6b6daad3594c",
+        "sha256": _KOTLIN_COMPILER_SHA,
         "urls": [
-            "https://github.com/JetBrains/kotlin/releases/download/v1.4.32/kotlin-compiler-1.4.32.zip",
+            "https://github.com/JetBrains/kotlin/releases/download/v{}/kotlin-compiler-{}.zip".format(_KOTLIN_COMPILER_VERSION, _KOTLIN_COMPILER_VERSION),
         ],
     },
 )

--- a/examples/jetpack_compose/WORKSPACE
+++ b/examples/jetpack_compose/WORKSPACE
@@ -139,8 +139,15 @@ load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_d
 
 kt_download_local_dev_dependencies()
 
-load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories")
+load("@io_bazel_rules_kotlin//kotlin:kotlin.bzl", "kotlin_repositories", "kt_register_toolchains")
 
-kotlin_repositories()
+kotlin_repositories(
+    compiler_release = {
+        "sha256": "46720991a716e90bfc0cf3f2c81b2bd735c14f4ea6a5064c488e04fd76e6b6c7",
+        "urls": [
+            "https://github.com/JetBrains/kotlin/releases/download/v1.4.21/kotlin-compiler-1.4.21.zip",
+        ],
+    },
+)
 
 register_toolchains("//:kotlin_toolchain")

--- a/examples/jetpack_compose/compose-app/BUILD
+++ b/examples/jetpack_compose/compose-app/BUILD
@@ -1,4 +1,5 @@
 load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
 
 # An app that consumes android-kt deps
 android_binary(
@@ -10,5 +11,12 @@ android_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//compose-ui:lib",
+    ],
+)
+
+build_test(
+    name = "force_build_apks_test",
+    targets = [
+        ":compose_example_app",
     ],
 )

--- a/examples/jetpack_compose/compose-ui/BUILD
+++ b/examples/jetpack_compose/compose-ui/BUILD
@@ -8,6 +8,7 @@ kt_android_library(
     plugins = ["//:jetpack_compose_compiler_plugin"],
     visibility = ["//visibility:public"],
     deps = [
+        "@maven//:androidx_activity_activity_compose",
         "@maven//:androidx_appcompat_appcompat",
         "@maven//:androidx_compose_material_material",
         "@maven//:androidx_compose_ui_ui",

--- a/examples/jetpack_compose/compose-ui/MainActivity.kt
+++ b/examples/jetpack_compose/compose-ui/MainActivity.kt
@@ -1,10 +1,10 @@
 package cm.ben.android.bazel.compose.example.ui
 
 import android.os.Bundle
+import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.setContent
 
 class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
This PR shows a few issues with the Jetpack Compose example:
- It's not built on CI
- It actually doesn't build.

But also with the overall example structure. There seem to be a [hook set-up on CI to use a release build of the rules](https://github.com/bazelbuild/rules_kotlin/blob/master/.bazelci/presubmit.yml#L33-L37), which obviously doesn't work when building locally. The problem is, when using the parent repo, specifying a `compiler_release` in `kotlin_repositories` doesn't seem to work (not entirely sure why).

While this _might_ end up building on CI (edit: it doesn't) with the few changes here, it definitely does not build locally as Compose 1.0.0-alpha09 requires kotlinc 1.4.21, which there's no way to force with the current set-up locally - the default version is 1.4.20.