### PR TITLE
Initial support for code coverage.

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -617,8 +617,17 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
         exports = [_java_info(d) for d in getattr(ctx.attr, "exports", [])],
         neverlink = getattr(ctx.attr, "neverlink", False),
     )
+
+    instrumented_files = coverage_common.instrumented_files_info(
+        ctx,
+        source_attributes = ["srcs"],
+        dependency_attributes = ["deps", "exports", "associates", "friends"],
+        extensions = ["kt", "java"],
+    )
+
     return struct(
         java = java_info,
+        instrumented_files = instrumented_files,
         kt = _KtJvmInfo(
             srcs = ctx.files.srcs,
             module_name = associates.module_name,
@@ -891,4 +900,10 @@ def export_only_providers(ctx, actions, attr, outputs):
                 getattr(attr, "exports", []),
             ),
         ),
+        instrumented_files = coverage_common.instrumented_files_info(
+            ctx,
+            source_attributes = ["srcs"],
+            dependency_attributes = ["deps", "exports", "associates", "friends"],
+            extensions = ["kt", "java"],
+        )
     )

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -349,6 +349,9 @@ kt_jvm_test = rule(
             default = "",
         ),
         "main_class": attr.string(default = "com.google.testing.junit.runner.BazelTestRunner"),
+        "_lcov_merger": attr.label(
+            default = Label("@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"),
+        ),
     }),
     executable = True,
     outputs = _common_outputs,

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -91,6 +91,7 @@ def _kotlin_toolchain_impl(ctx):
         kotlinc_options = ctx.attr.kotlinc_options[KotlincOptions] if ctx.attr.kotlinc_options else None,
         empty_jar = ctx.file._empty_jar,
         empty_jdeps = ctx.file._empty_jdeps,
+        jacocorunner = ctx.attr.jacocorunner
     )
 
     return [
@@ -248,6 +249,9 @@ _kt_toolchain = rule(
             cfg = "target",
             default = Label("//third_party:empty.jdeps"),
         ),
+        "jacocorunner": attr.label(
+            default = Label("@bazel_tools//tools/jdk:JacocoCoverage"),
+        ),
     },
     implementation = _kotlin_toolchain_impl,
     provides = [platform_common.ToolchainInfo],
@@ -268,7 +272,8 @@ def define_kt_toolchain(
         experimental_reduce_classpath_mode = None,
         experimental_multiplex_workers = None,
         javac_options = None,
-        kotlinc_options = None):
+        kotlinc_options = None,
+        jacocorunner = None):
     """Define the Kotlin toolchain."""
     impl_name = name + "_impl"
 
@@ -298,6 +303,7 @@ def define_kt_toolchain(
         javac_options = javac_options,
         kotlinc_options = kotlinc_options,
         visibility = ["//visibility:public"],
+        jacocorunner = jacocorunner,
     )
     native.toolchain(
         name = name,


### PR DESCRIPTION
* `kt_jvm_test` supports coverage collection.
* `kt_jvm_library` propagates transitive coverage information.

This provides coverage support of Java code in `java_library` + `android_library` targets through `kt_jvm_test.`

It also provides coverage support of Java code in `kt_jvm_library` when experimental_use_abi_jars is enabled.

TODO: Instrument Kotlin code for coverage.

Partially addresses: https://github.com/bazelbuild/rules_kotlin/issues/300