### PR TITLE
source jars passed as rule srcs attributes were being included twice

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -601,7 +601,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
         ctx.actions,
         output_jar = output_jar,
         output_source_jar = ctx.outputs.srcjar,
-        sources = ctx.files.srcs,
+        sources = srcs.kt + srcs.java,
         source_jars = srcs.src_jars + generated_src_jars,
         java_toolchain = toolchains.java,
         host_javabase = toolchains.java_runtime,


### PR DESCRIPTION
Once via the java_common.pack_sources#source_jars attribute which is correct as it extracts the contents and includes those in the final source.jar

Additionally via java_common.pack_sources.sources attribute. as a nested jar within the final source.jar

Exclude source jars from java_common.pack_sources.sources and only pass srcs.kt + srcs.java here.