### PR TITLE
Fix java.version parsing (#510)

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
@@ -100,9 +100,12 @@ internal class JDepsGenerator @Inject constructor(
  * from reporting the version in the `1.x.y_z` format (e.g. `1.8.0_202`) in favor of `x.y.z` (e.g.
  * `11.0.1`). As a result, this function checks for a major version of "1" and if it's so, use the
  * minor version as the major one. Otherwise, it uses the first term as the major version.
+ *
+ * Also note that the java.version does not include trailing zero elements.
  */
 private fun String.majorJavaVersion(): Int {
-  val (major, minor) = this.trim().split('.')
+  val elements = this.trim().split('.')
+  val major = elements[0]
   val parsedMajor = Integer.parseInt(major)
-  return if (parsedMajor == 1) Integer.parseInt(minor) else parsedMajor
+  return if (parsedMajor == 1) Integer.parseInt(elements[1]) else parsedMajor
 }


### PR DESCRIPTION
Fixes #510

We can't always assume `this.trim().split('.')` to have 3 elements, because `java.version` does not include trailing zero elements. In other words, `java.version` can be a single number like `11` or `15`. This change fixes IndexOutOfBoundsException caused by the wrong assumption.

References:
* [JEP 223: New Version-String Scheme](https://openjdk.java.net/jeps/223)
* [JDK-8231384: java.version system property doesn't contain minor/patch version anymore](https://bugs.openjdk.java.net/browse/JDK-8231384)