### PR TITLE
Isolate Kotlin compiler instances for Multiplex workers.

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
@@ -163,16 +163,18 @@ class KotlinToolchain private constructor(
     toolchain: KotlinToolchain,
     clazz: String
   ) {
-    private val compiler: Any
     private val execMethod: Method
     private val getCodeMethod: Method
+    private val compilerClass = toolchain.classLoader.loadClass(clazz)
 
     init {
-      val compilerClass = toolchain.classLoader.loadClass(clazz)
+      // Disables disposing of the environment which is required when running parallel builds. This
+      // follows the behavior of the Kotlin compiler daemon.
+      System.setProperty("kotlin.environment.keepalive", "true")
+
       val exitCodeClass =
         toolchain.classLoader.loadClass("org.jetbrains.kotlin.cli.common.ExitCode")
 
-      compiler = compilerClass.getConstructor().newInstance()
       execMethod =
         compilerClass.getMethod("exec", PrintStream::class.java, Array<String>::class.java)
       getCodeMethod = exitCodeClass.getMethod("getCode")
@@ -183,6 +185,7 @@ class KotlinToolchain private constructor(
     // 2 is an internal error
     // 3 is the script execution error
     fun compile(args: Array<String>, out: PrintStream): Int {
+      val compiler = compilerClass.getConstructor().newInstance()
       val exitCodeInstance = execMethod.invoke(compiler, out, args)
       return getCodeMethod.invoke(exitCodeInstance, *NO_ARGS) as Int
     }


### PR DESCRIPTION
Following the Kotlin Compiler Daemon and conversations with Jetbrains it seems
that we need to set the system property `kotlin.environment.keepalive` so that parallel builds do not clobber each other.

In `exec` the environment is registered as a disposable to be torn down, this system property avoids this.

Switching to a new instance of the compiler for each invocation for safety. There is little state in the compiler and this doesn't affect performance.