### PR TITLE
Implement better test class inference.

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -281,7 +281,8 @@ def kt_jvm_junit_test_impl(ctx):
     # If no test_class, do a best-effort attempt to infer one.
     if not bool(ctx.attr.test_class):
         for file in ctx.files.srcs:
-            if file.basename.split(".")[0] == ctx.attr.name:
+            package_relative_path = file.path.replace(ctx.label.package + "/", "")
+            if package_relative_path.split(".")[0] == ctx.attr.name:
                 for splitter in _SPLIT_STRINGS:
                     elements = file.short_path.split(splitter, 1)
                     if len(elements) == 2:


### PR DESCRIPTION
Currently supported:-

//foo/bar:BazTest

Now additionally support paths within packages that are often generated by test suite macros.

//foo:bar/BazTest