### PR TITLE
Support srcjars in mixed Java/Kotlin sources when ABI jars are enabled

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -768,7 +768,7 @@ def _run_kt_java_builder_actions(
     # Build Java
     # If there is Java source or KAPT generated Java source compile that Java and fold it into
     # the final ABI jar. Otherwise just use the KT ABI jar as final ABI jar.
-    if srcs.java or generated_src_jars:
+    if srcs.java or generated_src_jars or srcs.src_jars:
         javac_opts = _javac_options_provider_to_flags(toolchains.kt.javac_options)
 
         # Kotlin takes care of annotation processing. Note that JavaBuilder "discovers"
@@ -778,7 +778,7 @@ def _run_kt_java_builder_actions(
         java_info = java_common.compile(
             ctx,
             source_files = srcs.java,
-            source_jars = generated_src_jars,
+            source_jars = generated_src_jars + srcs.src_jars,
             output = ctx.actions.declare_file(ctx.label.name + "-java.jar"),
             deps = compile_deps.deps + kt_stubs_for_java,
             java_toolchain = toolchains.java,


### PR DESCRIPTION
When srcjars are used in a mixed Java/Kotlin target, build fails since `srcjars` are not propagated to `Java` compiler in the JavaBuilder flow. The error only surfaces when any `*.java` file in target contains references to sources inside said `srcjar`.

Fixed by passing srcjars to Java compiler.


