### PR TITLE
Pass strict_deps flag to java compiler in JavaBuilder flow

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -786,6 +786,7 @@ def _run_kt_java_builder_actions(
             javac_opts = javac_opts,
             host_javabase = toolchains.java_runtime,
             neverlink = getattr(ctx.attr, "neverlink", False),
+            strict_deps = toolchains.kt.experimental_strict_kotlin_deps,
         )
         ap_generated_src_jar = java_info.annotation_processing.source_jar
         compile_jars = compile_jars + [


### PR DESCRIPTION
Currently disabling strict deps in Kotlin toolchain (`experimental_strict_kotlin_deps = "off"`) has no effect when ABI jars compilation is enabled. Targets previously compiling with strict_deps disabled fails to build when ABI jars are enabled. 

This PR fixes it by passing the Kotlin toolchain flag to underlying `java_common.compile` to unify the behavior.