### PR TITLE
Remove jcenter references

### DIFF
--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -29,7 +29,6 @@ maven_install(
         "com.google.auto.value:auto-value-annotations:1.6.5",
     ],
     repositories = [
-        "https://jcenter.bintray.com/",
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],

--- a/examples/anvil/WORKSPACE
+++ b/examples/anvil/WORKSPACE
@@ -65,7 +65,6 @@ maven_install(
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7",
     ],
     repositories = [
-        "https://jcenter.bintray.com/",
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],

--- a/examples/jetpack_compose/WORKSPACE
+++ b/examples/jetpack_compose/WORKSPACE
@@ -31,7 +31,6 @@ maven_install(
         "androidx.compose.compiler:compiler:1.0.0-alpha09",
     ],
     repositories = [
-        "https://jcenter.bintray.com/",
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],

--- a/examples/node/WORKSPACE
+++ b/examples/node/WORKSPACE
@@ -22,7 +22,7 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
     artifacts = [
-        "org.jetbrains.kotlinx:atomicfu-js:0.13.1",
+        "org.jetbrains.kotlinx:atomicfu-js:0.15.2",
         "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:1.3.2",
     ],
     repositories = [

--- a/kotlin/internal/repositories/setup.bzl
+++ b/kotlin/internal/repositories/setup.bzl
@@ -49,7 +49,6 @@ def kt_configure():
         ],
         repositories = [
             "https://maven-central.storage.googleapis.com/repos/central/data/",
-            "https://jcenter.bintray.com/",
             "https://repo1.maven.org/maven2",
         ],
     )

--- a/kotlin/internal/repositories/setup.bzl
+++ b/kotlin/internal/repositories/setup.bzl
@@ -40,7 +40,7 @@ def kt_configure():
             "javax.annotation:javax.annotation-api:1.3.2",
             "javax.inject:javax.inject:1",
             "org.pantsbuild:jarjar:1.7.2",
-            "org.jetbrains.kotlinx:atomicfu-js:0.14.0",
+            "org.jetbrains.kotlinx:atomicfu-js:0.15.2",
             "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2",
             "org.jetbrains.kotlinx:kotlinx-coroutines-core-js:1.4.2",
             "org.jetbrains.kotlinx:kotlinx-coroutines-test:1.4.2",


### PR DESCRIPTION
Jcenter is being deprecated and removed

https://github.com/bazelbuild/rules_jvm_external/issues/517