### PR TITLE
Reduce illegal reflective operation warnings when compiling code

### DIFF
--- a/src/main/kotlin/bootstrap.bzl
+++ b/src/main/kotlin/bootstrap.bzl
@@ -63,6 +63,7 @@ CP="%s"
 ARGS="%s"
 
 CMD="$(JAVA) -Xmx256M -Xms32M -noverify \
+      --add-opens java.base/java.util=ALL-UNNAMED \
       -cp $(location @com_github_jetbrains_kotlin//:kotlin-preloader) org.jetbrains.kotlin.preloading.Preloader \
       -cp $(location @com_github_jetbrains_kotlin//:kotlin-compiler) org.jetbrains.kotlin.cli.jvm.K2JVMCompiler \
       $$CP -d $(@D)/$${NAME}_temp.jar $${ARGS} $(SRCS)"


### PR DESCRIPTION
Without opening the util package, the following is seen when compiling
Kotlin code:

```
INFO: From Executing genrule //src/main/kotlin/io/bazel/kotlin/plugin/jdeps:jdeps-gen-lib_jar [for host]:
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by com.intellij.util.ReflectionUtil to method java.util.ResourceBundle.setParent(java.util.ResourceBundle)
WARNING: Please consider reporting this to the maintainers of com.intellij.util.ReflectionUtil
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```

This is a known issue in kotlin, for some versions of kotlin on some
versions of the JDK: https://youtrack.jetbrains.com/issue/KT-43704

The downside with the flag is that it's Java 9+ only, but since Bazel
requires Java 11 to run, this seems like a reasonable assertion to
make.