### PR TITLE
Use current java_stub_template

### DIFF
--- a/kotlin/internal/repositories/release_repositories.bzl
+++ b/kotlin/internal/repositories/release_repositories.bzl
@@ -51,7 +51,7 @@ def kotlin_repositories(
                  versions.BAZEL_JAVA_LAUNCHER_VERSION +
                  "/src/main/java/com/google/devtools/build/lib/bazel/rules/java/" +
                  "java_stub_template.txt")],
-        sha256 = "a618e746e743f3119a9939e60645a02de40149aae9d63201c3cd05706010f6eb",
+        sha256 = "ab1370fd990a8bff61a83c7bd94746a3401a6d5d2299e54b1b6bc02db4f87f68",
     )
 
     maybe(

--- a/kotlin/internal/repositories/versions.bzl
+++ b/kotlin/internal/repositories/versions.bzl
@@ -16,7 +16,7 @@ versions = struct(
     RULES_PROTO_SHA = "4d421d51f9ecfe9bf96ab23b55c6f2b809cbaf0eea24952683e397decfbd0dd0",
     IO_BAZEL_STARDOC_VERSION = "0.4.0",
     IO_BAZEL_STARDOC_SHA = "6d07d18c15abb0f6d393adbd6075cd661a2219faab56a9517741f0fc755f6f3c",
-    BAZEL_JAVA_LAUNCHER_VERSION = "3.7.0",
+    BAZEL_JAVA_LAUNCHER_VERSION = "5.0.0-pre.20210510.2",
     KOTLIN_CURRENT_COMPILER_RELEASE = {
         "urls": [
             "https://github.com/JetBrains/kotlin/releases/download/v1.4.20/kotlin-compiler-1.4.20.zip",


### PR DESCRIPTION
Pulling in the updated version of the java launcher template that has some important fixes for a subtle test classpath bug.

Associated PRs:
- https://github.com/bazelbuild/bazel/pull/12969
- https://github.com/bazelbuild/bazel/issues/10620
- https://github.com/bazelbuild/bazel/pull/12946