### PR TITLE
Call System.gc between work requests

### DIFF
--- a/src/main/kotlin/io/bazel/worker/CpuTimeBasedGcScheduler.kt
+++ b/src/main/kotlin/io/bazel/worker/CpuTimeBasedGcScheduler.kt
@@ -1,0 +1,41 @@
+package io.bazel.worker
+
+import com.sun.management.OperatingSystemMXBean
+import java.lang.management.ManagementFactory
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicReference
+
+class CpuTimeBasedGcScheduler(
+  /**
+   * After this much CPU time has elapsed, we may force a GC run. Set to [Duration.ZERO] to
+   * disable.
+   */
+  private val cpuUsageBeforeGc: Duration
+) {
+
+  /** The total process CPU time at the last GC run (or from the start of the worker).  */
+  private val cpuTime: Duration
+    get() = if (cpuUsageBeforeGc.isZero) Duration.ZERO else Duration.ofNanos(bean.processCpuTime)
+  private val cpuTimeAtLastGc: AtomicReference<Duration> = AtomicReference(cpuTime)
+
+  /** Call occasionally to perform a GC if enough CPU time has been used.  */
+  fun maybePerformGc() {
+    if (!cpuUsageBeforeGc.isZero) {
+      val currentCpuTime = cpuTime
+      val lastCpuTime = cpuTimeAtLastGc.get()
+      // Do GC when enough CPU time has been used, but only if nobody else beat us to it.
+      if (currentCpuTime.minus(lastCpuTime).compareTo(cpuUsageBeforeGc) > 0
+        && cpuTimeAtLastGc.compareAndSet(lastCpuTime, currentCpuTime)
+      ) {
+        System.gc()
+        // Avoid counting GC CPU time against CPU time before next GC.
+        cpuTimeAtLastGc.compareAndSet(currentCpuTime, cpuTime)
+      }
+    }
+  }
+
+  companion object {
+    /** Used to get the CPU time used by this process.  */
+    private val bean = ManagementFactory.getOperatingSystemMXBean() as OperatingSystemMXBean
+  }
+}

--- a/src/main/kotlin/io/bazel/worker/CpuTimeBasedGcScheduler.kt
+++ b/src/main/kotlin/io/bazel/worker/CpuTimeBasedGcScheduler.kt
@@ -5,6 +5,7 @@ import java.lang.management.ManagementFactory
 import java.time.Duration
 import java.util.concurrent.atomic.AtomicReference
 
+// This class is intended to mirror https://github.com/Bencodes/bazel/blob/3835d9b21ad524d06873dfbf465ffd2dfb635ba8/src/main/java/com/google/devtools/build/lib/worker/WorkRequestHandler.java#L431-L474
 class CpuTimeBasedGcScheduler(
   /**
    * After this much CPU time has elapsed, we may force a GC run. Set to [Duration.ZERO] to

--- a/src/main/kotlin/io/bazel/worker/PersistentWorker.kt
+++ b/src/main/kotlin/io/bazel/worker/PersistentWorker.kt
@@ -73,6 +73,8 @@ class PersistentWorker(
               .forEach { request ->
                 launch {
                   compileWork(request, io, writeChannel, execute)
+                  //Be a friendly worker by performing a GC between compilation requests
+                  System.gc()
                 }
               }
         }.invokeOnCompletion { writeChannel.close() }

--- a/src/main/kotlin/io/bazel/worker/PersistentWorker.kt
+++ b/src/main/kotlin/io/bazel/worker/PersistentWorker.kt
@@ -41,6 +41,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.io.PrintStream
 import java.nio.charset.StandardCharsets.UTF_8
+import java.time.Duration
 import java.util.concurrent.Executors
 import kotlin.coroutines.CoroutineContext
 
@@ -55,11 +56,11 @@ import kotlin.coroutines.CoroutineContext
  */
 class PersistentWorker(
   private val coroutineContext: CoroutineContext,
-  private val captureIO: () -> IO
+  private val captureIO: () -> IO,
+  private val cpuTimeBasedGcScheduler: CpuTimeBasedGcScheduler,
 ) : Worker {
 
-  constructor() : this(Dispatchers.IO, IO.Companion::capture)
-
+  constructor() : this(Dispatchers.IO, IO.Companion::capture, CpuTimeBasedGcScheduler(Duration.ofSeconds(10)))
 
   @ExperimentalCoroutinesApi
   override fun start(execute: Work) = WorkerContext.run {
@@ -74,7 +75,7 @@ class PersistentWorker(
                 launch {
                   compileWork(request, io, writeChannel, execute)
                   //Be a friendly worker by performing a GC between compilation requests
-                  System.gc()
+                  cpuTimeBasedGcScheduler.maybePerformGc()
                 }
               }
         }.invokeOnCompletion { writeChannel.close() }


### PR DESCRIPTION
These long running Kotlin workers are consuming lots of memory, eventually causing the Linux out-of-memory killer to step in and kill a random java process resulting in this error message:

Example crash output (the out file is empty):
```console
--
  | Server terminated abruptly (error code: 14, error message: 'Socket closed', log file: '/root/.cache/bazel/_bazel_root/7b7747ec045ae606eb720a1222f56098/server/jvm.out')
  |  
```

Calling `System.gc` between these Kotlin work requests has improved stability for us, and it seems to be the standard in Bazel core (seen [here](https://github.com/lyft/bazel/blob/6d1b9725b1e201ca3f25d8ec2a730a20aab62c6e/src/test/java/com/google/devtools/build/lib/worker/ExampleWorkerMultiplexer.java#L148) and [here](https://github.com/bazelbuild/bazel/blob/3835d9b21ad524d06873dfbf465ffd2dfb635ba8/src/main/java/com/google/devtools/build/lib/worker/WorkRequestHandler.java#L468)).

This implementation is intended to closely mirror what Bazel is doing inside it's worker implementation seen [here](https://github.com/Bencodes/bazel/blob/3835d9b21ad524d06873dfbf465ffd2dfb635ba8/src/main/java/com/google/devtools/build/lib/worker/WorkRequestHandler.java#L431-L474).