### PR TITLE
Fix duplicate testonly attributes being passed to kt_android_local_test

### DIFF
--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -89,6 +89,7 @@ def kt_android_local_test(
         flaky = False,
         shard_count = None,
         visibility = None,
+        testonly = True,
         **kwargs):
     """Creates a testable Android sandwich library.
 
@@ -98,7 +99,7 @@ def kt_android_local_test(
     """
     android_local_test(
         name = name,
-        deps = kwargs.get("deps", []) + _kt_android_artifact(name = name, testonly = True, **kwargs),
+        deps = kwargs.get("deps", []) + _kt_android_artifact(name = name, testonly = testonly, **kwargs),
         jvm_flags = jvm_flags,
         test_class = test_class,
         visibility = visibility,
@@ -110,5 +111,5 @@ def kt_android_local_test(
         manifest = manifest,
         manifest_values = manifest_values,
         tags = kwargs.get("tags", default = None),
-        testonly = kwargs.get("testonly", default = True),
+        testonly = testonly,
     )


### PR DESCRIPTION
Passing `testonly = True/False` into a `kt_android_local_test` target causes the kwargs that get passed into `_kt_android_artifact` to have duplicate `testonly` entries.