### PR TITLE
Fix duplicate worker console output

### DIFF
--- a/src/main/kotlin/io/bazel/worker/IO.kt
+++ b/src/main/kotlin/io/bazel/worker/IO.kt
@@ -23,13 +23,28 @@ import java.io.ByteArrayOutputStream
 import java.io.Closeable
 import java.io.InputStream
 import java.io.PrintStream
+import java.nio.charset.StandardCharsets
 
 class IO(
   val input: InputStream,
   val output: PrintStream,
-  val captured: ByteArrayOutputStream,
+  private val captured: ByteArrayOutputStream,
   private val restore: () -> Unit = {}
 ) : Closeable {
+
+  /**
+   * Reads the captured std out and err as a UTF-8 string and then resets the
+   * captured ByteArrayOutputStream.
+   *
+   * Resetting the ByteArrayOutputStream prevents the worker from returning
+   * the same console output multiple times
+   **/
+  fun readCapturedAsUtf8String(): String {
+    val out = captured.toByteArray().toString(StandardCharsets.UTF_8)
+    captured.reset()
+    return out
+  }
+
   companion object {
     fun capture(): IO {
       val stdErr = System.err

--- a/src/main/kotlin/io/bazel/worker/PersistentWorker.kt
+++ b/src/main/kotlin/io/bazel/worker/PersistentWorker.kt
@@ -102,7 +102,7 @@ class PersistentWorker(
       val response = WorkerProtocol.WorkResponse.newBuilder().apply {
         output = listOf(
           result.log.out.toString(),
-          io.captured.toByteArray().toString(UTF_8)
+          io.readCapturedAsUtf8String()
         ).filter { it.isNotBlank() }.joinToString("\n")
         exitCode = result.status.exit
         requestId = request.requestId

--- a/src/test/kotlin/io/bazel/worker/IOTest.kt
+++ b/src/test/kotlin/io/bazel/worker/IOTest.kt
@@ -58,7 +58,19 @@ class IOTest {
     assertThat(captured.written()).isEmpty()
     IO.capture().use { io ->
       println("foo foo is on the loose")
-      assertThat(io.captured.written()).isEqualTo("foo foo is on the loose\n")
+      assertThat(io.readCapturedAsUtf8String()).isEqualTo("foo foo is on the loose\n")
+    }
+    assertThat(captured.written()).isEmpty()
+  }
+
+  @Test
+  fun captureDoesNotRepeatOutput() {
+    assertThat(captured.written()).isEmpty()
+    IO.capture().use { io ->
+      println("foo foo is on the loose")
+      assertThat(io.readCapturedAsUtf8String()).isEqualTo("foo foo is on the loose\n")
+      println("bar bar is on the loose")
+      assertThat(io.readCapturedAsUtf8String()).isEqualTo("bar bar is on the loose\n")
     }
     assertThat(captured.written()).isEmpty()
   }


### PR DESCRIPTION
The `ByteArrayOutputStream` isn't being reset between worker instances which causes the output to be repeated as workers finish and return their response. This approach has the unfortunate downside of there being the potential for mangled outputs as multiple work requests are running/finishes at the same time. 

A thread safe `ByteArrayOutputStream` would be in order if we want to preserve the logs from being mangled, but it wouldn't prevent cross contamination of outputs between work requests.

Alternatively if we'd like to perfectly preserve the console logs, we'd need to create a `ByteArrayOutputStream` per work request that can be written to instead of relying on `System#out` and `System#err`.