### PR TITLE
Add --exclude_build_data arguement to singlejar invocation

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -234,6 +234,7 @@ def _fold_jars_action(ctx, rule_kind, toolchains, output_jar, input_jars, action
     args.add_all([
         "--normalize",
         "--compression",
+        "--exclude_build_data",
     ])
     args.add_all([
         "--deploy_manifest_lines",


### PR DESCRIPTION
Adding --exclude_build_data so that the build-data.properties won't be created.

This file contains contains information about the build host and will therefore break cacheing
for users that are not on the same platform as platform that built the cached artefact.

build-data.properties is not present in java artefacts since this flag is already applied so with this change, kotlin artefacts will have the same behaviour as java artifacts.