### PR TITLE
Fix missing dependency on jvm-abi-gen.jar in release artifacts

### DIFF
--- a/src/main/kotlin/BUILD.release.bazel
+++ b/src/main/kotlin/BUILD.release.bazel
@@ -40,6 +40,7 @@ java_binary(
         ":jdeps-gen",
         ":skip-code-gen",
         "//src/main/kotlin/io/bazel/kotlin/compiler",
+        "@com_github_jetbrains_kotlin//:lib/jvm-abi-gen.jar",
         "@com_github_jetbrains_kotlin//:lib/kotlin-compiler.jar",
     ],
     main_class = "io.bazel.kotlin.builder.cmd.Build",


### PR DESCRIPTION
Fixes #492 also for the released artifacts.