### PR TITLE
Support explicit API mode

### DIFF
--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -407,6 +407,7 @@ kt_kotlinc_options(<a href="#kt_kotlinc_options-name">name</a>, <a href="#kt_kot
 |<a id="kt_kotlinc_options-x_skip_prerelease_check"></a>x_skip_prerelease_check |  Suppress errors thrown when using pre-release classes.   | Boolean | optional | False |
 |<a id="kt_kotlinc_options-x_use_experimental"></a>x_use_experimental |  Allow the experimental language features.   | Boolean | optional | True |
 |<a id="kt_kotlinc_options-x_use_ir"></a>x_use_ir |  Enable or disable the experimental IR backend.   | Boolean | optional | False |
+|<a id="kt_kotlinc_options-x_explicit_api_mode"></a>x_explicit_api_mode |  Enable or disable Kotlin explicit API mode for library developers.   | String | optional | "off" |
 
 
 <a name="#define_kt_toolchain"></a>

--- a/src/main/starlark/legacy/kotlin/opts.bzl
+++ b/src/main/starlark/legacy/kotlin/opts.bzl
@@ -108,6 +108,19 @@ _KOPTS = {
             True: ["-Xmulti-platform"],
         },
     ),
+    "x_explicit_api_mode": struct(
+        args = dict(
+            default = "off",
+            doc = "Enable explicit API mode for Kotlin libraries.",
+            values = ["off", "warning", "strict"],
+        ),
+        type = attr.string,
+        value_to_flag = {
+            "off": None,
+            "warning": ["-Xexplicit-api=warning"],
+            "strict": ["-Xexplicit-api=strict"],
+        },
+    ),
 }
 
 KotlincOptions = provider(

--- a/src/main/starlark/rkt_1_4/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_4/kotlin/opts.bzl
@@ -128,6 +128,19 @@ _KOPTS = {
             True: ["-Xallow-jvm-ir-dependencies"],
         },
     ),
+    "x_explicit_api_mode": struct(
+        args = dict(
+            default = "off",
+            doc = "Enable explicit API mode for Kotlin libraries.",
+            values = ["off", "warning", "strict"],
+        ),
+        type = attr.string,
+        value_to_flag = {
+            "off": None,
+            "warning": ["-Xexplicit-api=warning"],
+            "strict": ["-Xexplicit-api=strict"],
+        },
+    ),
 }
 
 KotlincOptions = provider(

--- a/src/main/starlark/rkt_1_5/jvm/opts.bzl
+++ b/src/main/starlark/rkt_1_5/jvm/opts.bzl
@@ -44,6 +44,19 @@ _JOPTS = {
             True: ["-XDsuppressNotes"],
         },
     ),
+    "x_explicit_api_mode": struct(
+        args = dict(
+            default = "off",
+            doc = "Enable explicit API mode for Kotlin libraries.",
+            values = ["off", "warning", "strict"],
+        ),
+        type = attr.string,
+        value_to_flag = {
+            "off": None,
+            "warning": ["-Xexplicit-api=warning"],
+            "strict": ["-Xexplicit-api=strict"],
+        },
+    ),
 }
 
 def _javac_options_impl(ctx):


### PR DESCRIPTION
Support for explicit API mode which was added in Kotlin 1.4.x.

https://github.com/Kotlin/KEEP/blob/master/proposals/explicit-api-mode.md

Example usage:

```python
# Custom kotlinc options that can be provided at the target level 
# to override what is being set globally by `define_kt_toolchain`
kt_kotlinc_options(
    name = "kt_kotlinc_library_options",
    # ...
    x_explicit_api_mode = "strict",
)

kt_jvm_library(
    name = "foo_library",
    # ...
    kotlinc_opts = ":kt_kotlinc_library_options",
    srcs = glob(["*.kt"]),
    deps = [
        # ...
    ],
)
```