### PR TITLE
Trim worker output before emitting it

### DIFF
--- a/src/main/kotlin/io/bazel/worker/PersistentWorker.kt
+++ b/src/main/kotlin/io/bazel/worker/PersistentWorker.kt
@@ -102,7 +102,7 @@ class PersistentWorker(
       output = listOf(
         result.log.out.toString(),
         cap
-      ).joinToString("\n")
+      ).joinToString("\n").trim()
       exitCode = result.status.exit
       requestId = request.requestId
     }.build()


### PR DESCRIPTION
This prevents spurious outputs empty outputs reported in #580.