### PR TITLE
Pass compilation args using the official way

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationArgs.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationArgs.kt
@@ -18,12 +18,9 @@
 package io.bazel.kotlin.builder.tasks.jvm
 
 import io.bazel.kotlin.builder.toolchain.KotlinToolchain
-import java.io.ByteArrayOutputStream
-import java.io.ObjectOutputStream
 import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 import java.nio.file.Path
-import java.util.Base64
 
 /**
  * CompilationArgs collects the arguments for executing the Kotlin compiler.
@@ -172,28 +169,18 @@ class CompilationArgs(
     return this
   }
 
-  fun list(): List<String> = args.toList()
-
-  fun base64Encode(
+  fun flagRepeated(
     flag: String,
     vararg values: Pair<String, List<String>>,
-    transform: (String) -> String = { it }
+    transform: (option: String, value: String) -> String
   ): CompilationArgs {
-    val os = ByteArrayOutputStream()
-    val oos = ObjectOutputStream(os)
-
-    oos.writeInt(values.size)
-    for ((k, vs) in values) {
-      oos.writeUTF(k)
-
-      oos.writeInt(vs.size)
-      for (v in vs) {
-        oos.writeUTF(v)
+    values.forEach { (option, values) ->
+      values.forEach {
+        flag(flag, transform(option, it))
       }
     }
-
-    oos.flush()
-    flag(flag, transform(Base64.getEncoder().encodeToString(os.toByteArray())))
     return this
   }
+
+  fun list(): List<String> = args.toList()
 }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -140,7 +140,7 @@ internal fun JvmCompilationTask.kaptArgs(
   )
   return CompilationArgs()
     .xFlag("plugin", plugins.kapt.jarPath)
-    .base64Encode(
+    .flagRepeated(
       "-P",
       "sources" to listOf(directories.generatedJavaSources),
       "classes" to listOf(directories.generatedClasses),
@@ -149,10 +149,12 @@ internal fun JvmCompilationTask.kaptArgs(
       "javacArguments" to listOf(javacArgs.let(::encodeMap)),
       "correctErrorTypes" to listOf("false"),
       "verbose" to listOf(context.whenTracing { "true" } ?: "false"),
-      "processors" to listOf(inputs.processorsList.joinToString(",")),
+      "processors" to inputs.processorsList.toList(),
       "apclasspath" to inputs.processorpathsList,
-      "aptMode" to listOf(aptMode)
-    ) { enc -> "plugin:${plugins.kapt.id}:configuration=$enc" }
+      "aptMode" to listOf(aptMode),
+    ) { option, value ->
+      "plugin:${plugins.kapt.id}:$option=$value"
+    }
 }
 
 internal fun JvmCompilationTask.runPlugins(

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -143,33 +143,28 @@ internal fun JvmCompilationTask.kaptArgs(
   return CompilationArgs().apply {
     xFlag("plugin", plugins.kapt.jarPath)
 
+    val values = arrayOf(
+      "sources" to listOf(directories.generatedJavaSources),
+      "classes" to listOf(directories.generatedClasses),
+      "stubs" to listOf(directories.stubs),
+      "incrementalData" to listOf(directories.incrementalData),
+      "javacArguments" to listOf(javacArgs.let(::encodeMap)),
+      "correctErrorTypes" to listOf("false"),
+      "verbose" to listOf(context.whenTracing { "true" } ?: "false"),
+      "processors" to listOf(inputs.processorsList.joinToString(",")),
+      "apclasspath" to inputs.processorpathsList,
+      "aptMode" to listOf(aptMode)
+    )
+
     val version = info.toolchainInfo.common.apiVersion.toFloat()
     when {
       version < 1.5 -> base64Encode(
         "-P",
-        "sources" to listOf(directories.generatedJavaSources),
-        "classes" to listOf(directories.generatedClasses),
-        "stubs" to listOf(directories.stubs),
-        "incrementalData" to listOf(directories.incrementalData),
-        "javacArguments" to listOf(javacArgs.let(::encodeMap)),
-        "correctErrorTypes" to listOf("false"),
-        "verbose" to listOf(context.whenTracing { "true" } ?: "false"),
-        "processors" to listOf(inputs.processorsList.joinToString(",")),
-        "apclasspath" to inputs.processorpathsList,
-        "aptMode" to listOf(aptMode)
+        *values
       ) { enc -> "plugin:${plugins.kapt.id}:configuration=$enc" }
       else -> repeatFlag(
         "-P",
-        "sources" to listOf(directories.generatedJavaSources),
-        "classes" to listOf(directories.generatedClasses),
-        "stubs" to listOf(directories.stubs),
-        "incrementalData" to listOf(directories.incrementalData),
-        "javacArguments" to listOf(javacArgs.let(::encodeMap)),
-        "correctErrorTypes" to listOf("false"),
-        "verbose" to listOf(context.whenTracing { "true" } ?: "false"),
-        "processors" to inputs.processorsList.toList(),
-        "apclasspath" to inputs.processorpathsList,
-        "aptMode" to listOf(aptMode),
+        *values
       ) { option, value ->
         "plugin:${plugins.kapt.id}:$option=$value"
       }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/compilation_task.kt
@@ -110,7 +110,9 @@ internal fun JvmCompilationTask.plugins(
     }
   }
 
-internal fun JvmCompilationTask.preProcessingSteps(context: CompilationTaskContext): JvmCompilationTask {
+internal fun JvmCompilationTask.preProcessingSteps(
+  context: CompilationTaskContext
+): JvmCompilationTask {
   return context.execute("expand sources") { expandWithSourceJarSources() }
 }
 
@@ -138,23 +140,41 @@ internal fun JvmCompilationTask.kaptArgs(
     "-target" to info.toolchainInfo.jvm.jvmTarget,
     "-source" to info.toolchainInfo.jvm.jvmTarget
   )
-  return CompilationArgs()
-    .xFlag("plugin", plugins.kapt.jarPath)
-    .flagRepeated(
-      "-P",
-      "sources" to listOf(directories.generatedJavaSources),
-      "classes" to listOf(directories.generatedClasses),
-      "stubs" to listOf(directories.stubs),
-      "incrementalData" to listOf(directories.incrementalData),
-      "javacArguments" to listOf(javacArgs.let(::encodeMap)),
-      "correctErrorTypes" to listOf("false"),
-      "verbose" to listOf(context.whenTracing { "true" } ?: "false"),
-      "processors" to inputs.processorsList.toList(),
-      "apclasspath" to inputs.processorpathsList,
-      "aptMode" to listOf(aptMode),
-    ) { option, value ->
-      "plugin:${plugins.kapt.id}:$option=$value"
+  return CompilationArgs().apply {
+    xFlag("plugin", plugins.kapt.jarPath)
+
+    val version = info.toolchainInfo.common.apiVersion.toFloat()
+    when {
+      version < 1.5 -> base64Encode(
+        "-P",
+        "sources" to listOf(directories.generatedJavaSources),
+        "classes" to listOf(directories.generatedClasses),
+        "stubs" to listOf(directories.stubs),
+        "incrementalData" to listOf(directories.incrementalData),
+        "javacArguments" to listOf(javacArgs.let(::encodeMap)),
+        "correctErrorTypes" to listOf("false"),
+        "verbose" to listOf(context.whenTracing { "true" } ?: "false"),
+        "processors" to listOf(inputs.processorsList.joinToString(",")),
+        "apclasspath" to inputs.processorpathsList,
+        "aptMode" to listOf(aptMode)
+      ) { enc -> "plugin:${plugins.kapt.id}:configuration=$enc" }
+      else -> repeatFlag(
+        "-P",
+        "sources" to listOf(directories.generatedJavaSources),
+        "classes" to listOf(directories.generatedClasses),
+        "stubs" to listOf(directories.stubs),
+        "incrementalData" to listOf(directories.incrementalData),
+        "javacArguments" to listOf(javacArgs.let(::encodeMap)),
+        "correctErrorTypes" to listOf("false"),
+        "verbose" to listOf(context.whenTracing { "true" } ?: "false"),
+        "processors" to inputs.processorsList.toList(),
+        "apclasspath" to inputs.processorpathsList,
+        "aptMode" to listOf(aptMode),
+      ) { option, value ->
+        "plugin:${plugins.kapt.id}:$option=$value"
+      }
     }
+  }
 }
 
 internal fun JvmCompilationTask.runPlugins(
@@ -162,7 +182,12 @@ internal fun JvmCompilationTask.runPlugins(
   plugins: InternalCompilerPlugins,
   compiler: KotlinToolchain.KotlincInvoker
 ): JvmCompilationTask {
-  if ((inputs.processorsList.isEmpty() && inputs.stubsPluginsList.isEmpty()) || inputs.kotlinSourcesList.isEmpty()) {
+  if ((
+    inputs.processorsList.isEmpty() &&
+      inputs.stubsPluginsList.isEmpty()
+    ) ||
+    inputs.kotlinSourcesList.isEmpty()
+  ) {
     return this
   } else {
     return context.execute("kapt (${inputs.processorsList.joinToString(", ")})") {
@@ -177,14 +202,15 @@ internal fun JvmCompilationTask.runPlugins(
           .plus(
             kaptArgs(context, plugins, "stubsAndApt")
           )
-      )
+        )
         .flag("-d", directories.generatedClasses)
         .values(inputs.kotlinSourcesList)
         .values(inputs.javaSourcesList).list().let { args ->
           context.executeCompilerTask(
             args,
             compiler::compile,
-            printOnSuccess = context.whenTracing { false } ?: true)
+            printOnSuccess = context.whenTracing { false } ?: true
+          )
         }.let { outputLines ->
           // if tracing is enabled the output should be formatted in a special way, if we aren't
           // tracing then any compiler output would make it's way to the console as is.
@@ -217,16 +243,16 @@ internal fun JvmCompilationTask.createOutputJar() =
  * Produce the primary output jar.
  */
 internal fun JvmCompilationTask.createAbiJar() =
-    JarCreator(
-        path = Paths.get(outputs.abijar),
-        normalize = true,
-        verbose = false
-    ).also {
-      it.addDirectory(Paths.get(directories.abiClasses))
-      it.addDirectory(Paths.get(directories.generatedClasses))
-      it.setJarOwner(info.label, info.bazelRuleKind)
-      it.execute()
-    }
+  JarCreator(
+    path = Paths.get(outputs.abijar),
+    normalize = true,
+    verbose = false
+  ).also {
+    it.addDirectory(Paths.get(directories.abiClasses))
+    it.addDirectory(Paths.get(directories.generatedClasses))
+    it.setJarOwner(info.label, info.bazelRuleKind)
+    it.execute()
+  }
 
 /**
  * Produce a jar of sources generated by KAPT.
@@ -286,10 +312,12 @@ fun JvmCompilationTask.compileKotlin(
     writeJdeps(outputs.jdeps, emptyJdeps(info.label))
     return emptyList()
   } else {
-    return (args + plugins(
-      options = inputs.compilerPluginOptionsList,
-      classpath = inputs.compilerPluginClasspathList
-    ))
+    return (
+      args + plugins(
+        options = inputs.compilerPluginOptionsList,
+        classpath = inputs.compilerPluginClasspathList
+      )
+      )
       .values(inputs.javaSourcesList)
       .values(inputs.kotlinSourcesList)
       .flag("-d", directories.classes)
@@ -314,7 +342,8 @@ fun JvmCompilationTask.compileKotlin(
                   .flatMap { walk(it) }
                   .filter { !isDirectory(it) }
                   .map { it.toString() }
-                  .collect(toList()))
+                  .collect(toList())
+              )
             }
           }
       }
@@ -370,7 +399,8 @@ private fun JvmCompilationTask.expandWithSources(sources: Iterator<String>): Jvm
   updateBuilder { builder ->
     sources.filterOutNonCompilableSources().partitionJvmSources(
       { builder.inputsBuilder.addKotlinSources(it) },
-      { builder.inputsBuilder.addJavaSources(it) })
+      { builder.inputsBuilder.addJavaSources(it) }
+    )
   }
 
 private fun JvmCompilationTask.updateBuilder(
@@ -385,9 +415,9 @@ private fun JvmCompilationTask.updateBuilder(
  * Only keep java and kotlin files for the iterator. Filter our all other non-compilable files.
  */
 private fun Iterator<String>.filterOutNonCompilableSources(): Iterator<String> {
-   val result = mutableListOf<String>()
-   this.forEach {
-     if (it.endsWith(".kt") or it.endsWith(".java")) result.add(it)
-   }
+  val result = mutableListOf<String>()
+  this.forEach {
+    if (it.endsWith(".kt") or it.endsWith(".java")) result.add(it)
+  }
   return result.iterator()
 }


### PR DESCRIPTION
Pulling this portion of the Kotlin 1.5.30 support out of the original PR. We should be able to merge this independently so that people can use Kotlin 1.5.30 without rules_kotlin having it as the default.

Original PR here: https://github.com/bazelbuild/rules_kotlin/pull/588