### PR TITLE
Add x_explicit_api_mode to remaining kotlinc_options

### DIFF
--- a/src/main/starlark/rkt_1_5/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_5/kotlin/opts.bzl
@@ -88,6 +88,19 @@ _KOPTS = {
             True: ["-Xno-optimized-callable-reference"],
         },
     ),
+    "x_explicit_api_mode": struct(
+        args = dict(
+            default = "off",
+            doc = "Enable explicit API mode for Kotlin libraries.",
+            values = ["off", "warning", "strict"],
+        ),
+        type = attr.string,
+        value_to_flag = {
+            "off": None,
+            "warning": ["-Xexplicit-api=warning"],
+            "strict": ["-Xexplicit-api=strict"],
+        },
+    ),
     "java_parameters": struct(
         args = dict(
             default = False,


### PR DESCRIPTION
See https://github.com/Kotlin/KEEP/blob/master/proposals/explicit-api-mode.md for more about the switch itself. 

I'm not sure how to test this - the best test would be to have some test code with default access modifiers and explicit-api=strict set, and then run a compilation and verify that it fails. That seems complex, and like it would require a fair amount of tooling, which I'm not sure if it's available. Please advice if so.