### PR TITLE
Fix JavaPluginInfo in Kotlin Android and Plugin examples.

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -814,7 +814,7 @@ def export_only_providers(ctx, actions, attr, outputs):
     java = JavaInfo(
         output_jar = toolchains.kt.empty_jar,
         compile_jar = toolchains.kt.empty_jar,
-        deps = [_java_info(d) for d in attr.deps + attr.plugins],
+        deps = [_java_info(d) for d in attr.deps + attr.plugins if JavaInfo in d],
         exports = [_java_info(d) for d in getattr(attr, "exports", [])],
         neverlink = getattr(attr, "neverlink", False),
     )

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -372,7 +372,7 @@ def kt_compiler_plugin_impl(ctx):
 
     return [
         DefaultInfo(files = depset(jars)),
-        java_common.merge([]),
+        getattr(java_common, "JavaPluginInfo")(runtime_deps = [info], processor_class = None) if hasattr(java_common, "JavaPluginInfo") else java_common.merge([]),
         _KtCompilerPluginInfo(
             plugin_jars = jars,
             classpath = depset(jars, transitive = [i.transitive_deps for i in compiler_lib_infos]),

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -549,5 +549,5 @@ Supports the following template values:
         ),
     },
     implementation = _kt_compiler_plugin_impl,
-    provides = [JavaInfo, _KtCompilerPluginInfo],
+    provides = [getattr(java_common, "JavaPluginInfo") if hasattr(java_common, "JavaPluginInfo") else JavaInfo, _KtCompilerPluginInfo],
 )


### PR DESCRIPTION
Changes to JavaPlugin handling cause failures with Bazel@HEAD,

https://buildkite.com/bazel/bazel-at-head-plus-downstream/builds/2237#9b9caec9-2b90-4c31-8f38-d3086cc37e73