### PR TITLE
remove kotlin repository alias, as it must be called before kotlin.bzl can be loaded.

### DIFF
--- a/kotlin/kotlin.bzl
+++ b/kotlin/kotlin.bzl
@@ -39,6 +39,7 @@ load(
     ":core.bzl",
     _define_kt_toolchain = "define_kt_toolchain",
     _kt_compiler_plugin = "kt_compiler_plugin",
+    _kt_register_toolchains = "kt_register_toolchains",
 )
 
 define_kt_toolchain = _define_kt_toolchain

--- a/kotlin/kotlin.bzl
+++ b/kotlin/kotlin.bzl
@@ -13,10 +13,6 @@
 # limitations under the License.
 
 load(
-    ":repositories.bzl",
-    _kotlin_repositories = "kotlin_repositories",
-)
-load(
     ":jvm.bzl",
     _kt_jvm_binary = "kt_jvm_binary",
     _kt_jvm_import = "kt_jvm_import",
@@ -43,18 +39,7 @@ load(
     ":core.bzl",
     _define_kt_toolchain = "define_kt_toolchain",
     _kt_compiler_plugin = "kt_compiler_plugin",
-    _kt_register_toolchains = "kt_register_toolchains",
 )
-
-def kotlin_repositories(**kwargs):
-    """
-    Forwarding macro for _kotlin_repositories
-
-    Deprecated:
-        _kotlin_repositories should be loaded from //kotlin:repositories.bzl
-    """
-    print("_kotlin_repositories should be loaded from //kotlin:repositories.bzl")
-    _kotlin_repositories(**kwargs)
 
 define_kt_toolchain = _define_kt_toolchain
 kt_register_toolchains = _kt_register_toolchains


### PR DESCRIPTION
Fixes: https://github.com/bazelbuild/rules_kotlin/issues/602