### PR TITLE
Filter on jars inside of createDepsMap

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -265,7 +265,10 @@ class JdepsGenExtension(
     val jarsToClasses = mutableMapOf<String, MutableList<String>>()
     classes.forEach {
       val parts = it.split("!/")
-      jarsToClasses.computeIfAbsent(parts[0]) { ArrayList() }.add(parts[1])
+      val jarPath = parts[0]
+      if (jarPath.endsWith(".jar")) {
+        jarsToClasses.computeIfAbsent(jarPath) { ArrayList() }.add(parts[1])
+      }
     }
     return jarsToClasses
   }


### PR DESCRIPTION
This prevents crashes when `createDepsMap` attempts to resolve dependencies coming from a local java repository.

https://github.com/bazelbuild/rules_kotlin/issues/591