### PR TITLE
Pass reducedClasspathMode to CompilationTaskInfo

### DIFF
--- a/kotlin/internal/js/impl.bzl
+++ b/kotlin/internal/js/impl.bzl
@@ -68,6 +68,7 @@ def kt_js_library_impl(ctx):
     args.add("--kotlin_output_js_jar", ctx.outputs.jar)
     args.add("--kotlin_output_srcjar", ctx.outputs.srcjar)
     args.add("--strict_kotlin_deps", "off")
+    args.add("--reduced_classpath_mode", "NONE")
 
     args.add_all("--kotlin_js_libraries", libraries, omit_if_empty = False)
     args.add_all("--sources", ctx.files.srcs)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -186,6 +186,7 @@ class KotlinBuilder @Inject internal constructor(
       toolchainInfoBuilder.commonBuilder.languageVersion =
         argMap.mandatorySingle(KotlinBuilderFlags.LANGUAGE_VERSION)
       strictKotlinDeps = argMap.mandatorySingle(KotlinBuilderFlags.STRICT_KOTLIN_DEPS)
+      reducedClasspathMode = argMap.mandatorySingle(KotlinBuilderFlags.REDUCED_CLASSPATH_MODE)
       this
     }
 


### PR DESCRIPTION
This allows `compilation_task.kt` to attempt to reduce the classpath given the provided java deps information.

Note for those that enable this: It will likely break your builds until the bugs are worked out.