### PR TITLE
[WIP] shade kotlin jars used by the toolchain

### DIFF
--- a/examples/anvil/third_party/BUILD.bazel
+++ b/examples/anvil/third_party/BUILD.bazel
@@ -32,15 +32,20 @@ kt_jvm_library(
 )
 
 kt_compiler_plugin(
-    name = "anvil_plugin",
-    compile_phase = True,
-    id = "com.squareup.anvil.compiler",
-    options = {
-        "src-gen-dir": "{generatedClasses}",
-    },
-    stubs_phase = True,
-    target_embedded_compiler = True,
+  name = "anvil_plugin",
+  compile_phase = True,
+  visibility = [
+	"//visibility:public"
+  ],
+  id = "com.squareup.anvil.compiler",
+  options = {
+    "src-gen-dir": "{generatedSources}",
+    "generate-dagger-factories": "true"
+  },
+  stubs_phase = True,
+  target_embedded_compiler = False,
     deps = [
         "@maven//:com_squareup_anvil_compiler",
     ],
 )
+

--- a/src/main/kotlin/BUILD.release.bazel
+++ b/src/main/kotlin/BUILD.release.bazel
@@ -42,6 +42,8 @@ java_binary(
         "//src/main/kotlin/io/bazel/kotlin/compiler",
         "@com_github_jetbrains_kotlin//:lib/jvm-abi-gen.jar",
         "@com_github_jetbrains_kotlin//:lib/kotlin-compiler.jar",
+        "@com_github_jetbrains_kotlin//:kotlin-compiler_shaded",
+        "@com_github_jetbrains_kotlin//:shaded_home",
     ],
     main_class = "io.bazel.kotlin.builder.cmd.Build",
     visibility = ["//visibility:public"],

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
@@ -111,13 +111,22 @@ class KotlinToolchain private constructor(
       val kotlinCompilerJar = BazelRunFiles.resolveVerified(
         "external", "com_github_jetbrains_kotlin", "lib", "kotlin-compiler.jar")
 
+      // The embeddable compiler. Note that paths and naming conventions are not modified
+      // since the classloader expects jars to be placed next to each other.
+      // In particular the following artifacts are declared in kotlin-compiler MANIFEST file
+      // annotations-13.0.jar kotlin-stdlib.jar kotlin-reflect.jar kotlin-script-runtime.jar trove4j.jar
+      // which are preloaded by the classloader when loading kotlin-compiler and need to live next to
+      // kotlin-compiler.
+      val kotlinEmbeddableCompilerJar = BazelRunFiles.resolveVerified(
+        "com_github_jetbrains_kotlin", "lib", "kotlin-compiler.jar")
+
       val jvmAbiGenFile = jvmAbiGenPath.verified()
       return KotlinToolchain(
-        kotlinCompilerJar.toPath().parent.parent,
+        kotlinEmbeddableCompilerJar.toPath().parent.parent,
         createClassLoader(
           javaHome,
           listOf(
-            kotlinCompilerJar,
+            kotlinEmbeddableCompilerJar,
             COMPILER.verified().absoluteFile,
             // plugins *must* be preloaded. Not doing so causes class conflicts
             // (and a NoClassDef err) in the compiler extension interfaces.

--- a/src/main/kotlin/shade.jarjar
+++ b/src/main/kotlin/shade.jarjar
@@ -1,1 +1,13 @@
 rule dagger.** io.bazel.kotlin.builder.dagger.@1
+rule com.intellij.** org.jetbrains.kotlin.com.intellij.@1
+rule com.google.** org.jetbrains.kotlin.com.google.@1
+rule com.sampullara.** org.jetbrains.kotlin.com.sampullara.@1
+rule org.apache.** org.jetbrains.kotlin.org.apache.@1
+rule org.jdom.** org.jetbrains.kotlin.org.jdom.@1
+rule org.picocontainer.** org.jetbrains.kotlin.org.picocontainer.@1
+rule org.jline.** org.jetbrains.kotlin.org.jline.@1
+rule org.fusesource.** org.jetbrains.kotlin.org.fusesource.@1
+rule net.jpountz.** org.jetbrains.kotlin.net.jpountz.@1
+rule one.util.streamex.** org.jetbrains.kotlin.one.util.streamex.@1
+rule it.unimi.dsi.fastutil.** org.jetbrains.kotlin.it.unimi.dsi.fastutil.@1
+rule kotlinx.collections.immutable.** org.jetbrains.kotlin.kotlinx.collections.immutable.@1

--- a/src/main/starlark/core/repositories/BUILD.com_github_jetbrains_kotlin.bazel
+++ b/src/main/starlark/core/repositories/BUILD.com_github_jetbrains_kotlin.bazel
@@ -14,15 +14,88 @@
 # dev_io_bazel_rules_kotlin
 load("@{{.KotlinRulesRepository}}//kotlin:jvm.bzl", "kt_jvm_import")
 load("@{{.KotlinRulesRepository}}//kotlin:js.bzl", "kt_js_import")
+load("@{{.KotlinRulesRepository}}//third_party:jarjar.bzl", "jar_jar_dir")
 load("@rules_java//java:defs.bzl", "java_import")
 
 package(default_visibility = ["//visibility:public"])
+
+
+ALL_JARS = [
+	"allopen-compiler-plugin",
+	"android-extensions-compiler",
+	"android-extensions-runtime",
+	"annotations-13.0",
+	"js.engines",
+	"jvm-abi-gen",
+	"kotlin-annotation-processing-cli",
+	"kotlin-annotation-processing-runtime",
+	"kotlin-annotation-processing",
+	"kotlin-annotations-jvm-sources",
+	"kotlin-annotations-jvm",
+	"kotlin-ant",
+	"kotlin-compiler",
+	"kotlin-daemon-client",
+	"kotlin-daemon",
+	"kotlin-imports-dumper-compiler-plugin",
+	"kotlin-main-kts",
+	"kotlin-preloader",
+	"kotlin-reflect-sources",
+	"kotlin-reflect",
+	"kotlin-runner",
+	"kotlin-script-runtime-sources",
+	"kotlin-script-runtime",
+	"kotlin-scripting-common",
+	"kotlin-scripting-compiler-impl",
+	"kotlin-scripting-compiler",
+	"kotlin-scripting-js",
+	"kotlin-scripting-jvm",
+	"kotlin-stdlib-jdk7-sources",
+	"kotlin-stdlib-jdk7",
+	"kotlin-stdlib-jdk8-sources",
+	"kotlin-stdlib-jdk8",
+	"kotlin-stdlib-js-sources",
+	"kotlin-stdlib-js",
+	"kotlin-stdlib-sources",
+	"kotlin-stdlib",
+	"kotlin-test-js-sources",
+	"kotlin-test-js",
+	"kotlin-test-junit-sources",
+	"kotlin-test-junit",
+	"kotlin-test-junit5-sources",
+	"kotlin-test-junit5",
+	"kotlin-test-sources",
+	"kotlin-test-testng-sources",
+	"kotlin-test-testng",
+	"kotlin-test",
+	"kotlinx-coroutines-core",
+	"kotlinx-serialization-compiler-plugin",
+	"mutability-annotations-compat",
+	"noarg-compiler-plugin",
+	"parcelize-compiler",
+	"parcelize-runtime",
+	"sam-with-receiver-compiler-plugin",
+	"trove4j",
+]
 
 # Kotlin home filegroup containing everything that is needed.
 filegroup(
     name = "home",
     srcs = glob(["**"]),
 )
+
+filegroup(
+    name = "shaded_home",
+    srcs = [":%s_shaded" % art for art in ALL_JARS],
+)
+
+[
+    jar_jar_dir(
+        name = "%s_shaded" % art,
+		output_dir = "lib",
+        input_jars = ["lib/%s.jar" % art],
+        rules = "compiler_shade.jarjar")
+    for art in ALL_JARS
+]
 
 kt_jvm_import(
     name = "annotations",

--- a/src/main/starlark/core/repositories/compiler.bzl
+++ b/src/main/starlark/core/repositories/compiler.bzl
@@ -10,6 +10,22 @@ def _kotlin_compiler_impl(repository_ctx):
         "WORKSPACE",
         content = """workspace(name = "%s")""" % attr.name,
     )
+    repository_ctx.file(
+        "compiler_shade.jarjar",
+        content = """rule dagger.** io.bazel.kotlin.builder.dagger.@1
+rule com.intellij.** org.jetbrains.kotlin.com.intellij.@1
+rule com.google.** org.jetbrains.kotlin.com.google.@1
+rule com.sampullara.** org.jetbrains.kotlin.com.sampullara.@1
+rule org.apache.** org.jetbrains.kotlin.org.apache.@1
+rule org.jdom.** org.jetbrains.kotlin.org.jdom.@1
+rule org.picocontainer.** org.jetbrains.kotlin.org.picocontainer.@1
+rule org.jline.** org.jetbrains.kotlin.org.jline.@1
+rule org.fusesource.** org.jetbrains.kotlin.org.fusesource.@1
+rule net.jpountz.** org.jetbrains.kotlin.net.jpountz.@1
+rule one.util.streamex.** org.jetbrains.kotlin.one.util.streamex.@1
+rule it.unimi.dsi.fastutil.** org.jetbrains.kotlin.it.unimi.dsi.fastutil.@1
+rule kotlinx.collections.immutable.** org.jetbrains.kotlin.kotlinx.collections.immutable.@1"""
+    )
     repository_ctx.template(
         "BUILD.bazel",
         attr._template,

--- a/third_party/jarjar.bzl
+++ b/third_party/jarjar.bzl
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+JAR_JAR_COMMON_ATTRS = {
+    "rules": attr.label(allow_single_file = True),
+    "jarjar_runner": attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("//third_party:jarjar_runner"),
+        ),
+}
+
 def jarjar_action(actions, label, rules, input, output, jarjar):
     actions.run(
         inputs = [rules, input],
@@ -42,19 +51,52 @@ def _jar_jar_impl(ctx):
         ),
     ]
 
+def _jar_jar_dir_impl(ctx):
+    output_dir =  ctx.attr.output_dir
+    shaded_jars = []
+    for jars in ctx.attr.input_jars:
+        for jar in jars.files.to_list():
+            output_jar  = ctx.actions.declare_file(output_dir + "/" + jar.basename)
+            shaded_jars.append(
+                jarjar_action(
+                    actions = ctx.actions,
+                    label = ctx.label,
+                    rules = ctx.file.rules,
+                    input = jar,
+                    output = output_jar,
+                    jarjar = ctx.executable.jarjar_runner
+            ))
+    return [
+        DefaultInfo(
+            files = depset(shaded_jars),
+            runfiles = ctx.runfiles(files = shaded_jars),
+        ),
+    ]
+
+
+JAR_JAR_ATTRS = {
+        "input_jar": attr.label(allow_single_file = True),
+}
+JAR_JAR_ATTRS.update(JAR_JAR_COMMON_ATTRS)
+
 jar_jar = rule(
     implementation = _jar_jar_impl,
-    attrs = {
-        "input_jar": attr.label(allow_single_file = True),
-        "rules": attr.label(allow_single_file = True),
-        "jarjar_runner": attr.label(
-            executable = True,
-            cfg = "host",
-            default = Label("//third_party:jarjar_runner"),
-        ),
-    },
+    attrs = JAR_JAR_ATTRS,
     outputs = {
         "jar": "%{name}.jar",
     },
     provides = [JavaInfo],
 )
+
+
+JAR_JAR_DIR_ATTRS = {
+        "input_jars": attr.label_list(allow_files = True),
+        "output_dir": attr.string(mandatory = True),
+}
+JAR_JAR_DIR_ATTRS.update(JAR_JAR_COMMON_ATTRS)
+
+jar_jar_dir = rule(
+    implementation = _jar_jar_dir_impl,
+    attrs = JAR_JAR_DIR_ATTRS,
+)
+


### PR DESCRIPTION
[POC] Shade toolchain jars used to compile kotlin libraries.

The shaded compiler is loaded into the classpath which allows to use plugins compiled against the embeddable compiler (namely those used by gradle).

ATM this code is shading all jars under lib/. I'm sure some of those dont need to be shaded but this was the easiest way to get all jars to be placed next to each other which is required since the kotlin-compiler declares them in the classpath and the classloader expects them to be there when preloading classes (in particular annotations-13.0.jar kotlin-stdlib.jar kotlin-reflect.jar kotlin-script-runtime.jar trove4j.jar although didnt bother to check if there can be recursive deps).

Also all other plugins generated need to be shaded (src/main/kotlin/shade.jarjar wsa updated to reflect this).