### PR TITLE
fix typo in jvm/impl.bzl error message

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -225,7 +225,7 @@ def kt_jvm_library_impl(ctx):
 
     if not ctx.attr.srcs and len(ctx.attr.deps) > 0:
         fail(
-            "deps without srcs in invalid." +
+            "deps without srcs is invalid." +
             "\nTo add runtime dependencies use runtime_deps." +
             "\nTo export libraries use exports.",
             attr = "deps",


### PR DESCRIPTION
This line gets triggered if you create a package that has dependencies but no sources added. The error is reported on the command line as:

```
ERROR: SOMEPATH/BUILD.bazel:6:12: in kt_jvm_library rule //SOMEPATH: 
Traceback (most recent call last):
	File "/private/var/tmp/_bazel_petter/4666252dfbdfc8dffb8973ffc6fead20/external/io_bazel_rules_kotlin/kotlin/internal/jvm/impl.bzl", line 227, column 13, in kt_jvm_library_impl
		fail(
Error in fail: attribute deps: deps without srcs in invalid.
To add runtime dependencies use runtime_deps.
To export libraries use exports.
```

The line `Error in fail: attribute deps: deps without srcs in invalid` confused me - it could be improved further, but I'm pretty sure it's meant to say that 'dependencies without sources *is* invalid', not that it 'found dependencies without sources in something called "invalid"'. 