### PR TITLE
Don't propagate JavaInfo for compiler plugin deshaded libs

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -419,7 +419,6 @@ def kt_compiler_plugin_impl(ctx):
 
     return [
         DefaultInfo(files = classpath),
-        java_common.merge([]),
         _KtCompilerPluginInfo(
             classpath = classpath,
             options = options,

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -419,7 +419,7 @@ def kt_compiler_plugin_impl(ctx):
 
     return [
         DefaultInfo(files = classpath),
-        info,
+        java_common.merge([]),
         _KtCompilerPluginInfo(
             classpath = classpath,
             options = options,

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -226,14 +226,14 @@ _common_attr = utils.add_dicts(
             mandatory = False,
         ),
         "kotlinc_opts": attr.label(
-            doc = """Kotlinc options to be used when compiling this target. These opts if provided 
+            doc = """Kotlinc options to be used when compiling this target. These opts if provided
             will be used instead of the ones provided to the toolchain.""",
             default = None,
             providers = [_KotlincOptions],
             mandatory = False,
         ),
         "javac_opts": attr.label(
-            doc = """Javac options to be used when compiling this target. These opts if provided will 
+            doc = """Javac options to be used when compiling this target. These opts if provided will
             be used instead of the ones provided to the toolchain.""",
             default = None,
             providers = [_JavacOptions],
@@ -560,5 +560,5 @@ Supports the following template values:
         ),
     },
     implementation = _kt_compiler_plugin_impl,
-    provides = [JavaInfo, _KtCompilerPluginInfo],
+    provides = [_KtCompilerPluginInfo],
 )

--- a/kotlin/internal/jvm/plugins.bzl
+++ b/kotlin/internal/jvm/plugins.bzl
@@ -52,7 +52,7 @@ def _targets_to_annotation_processors_java_plugin_info(targets):
     if hasattr(java_common, "JavaPluginInfo"):
         _JavaPluginInfo = getattr(java_common, "JavaPluginInfo")
         return [t[_JavaPluginInfo] for t in targets if _JavaPluginInfo in t]
-    return [t[JavaInfo] for t in targets if KtJvmPluginInfo in t]
+    return [t[JavaInfo] for t in targets if JavaInfo in t]
 
 def _targets_to_transitive_runtime_jars(targets):
     if hasattr(java_common, "JavaPluginInfo"):


### PR DESCRIPTION
If JavaInfo is propagated, compiler plugin libs end up in the set of runtime dependencies of android_binary targets, which makes no sense.
Fixes https://github.com/bazelbuild/rules_kotlin/issues/639
