### PR TITLE
Don't hardcode -Xuse-experimental

### DIFF
--- a/kotlin/internal/utils/utils.bzl
+++ b/kotlin/internal/utils/utils.bzl
@@ -34,7 +34,6 @@ def _init_builder_args(ctx, rule_kind, module_name):
     args.add("--kotlin_jvm_target", toolchain.jvm_target)
     args.add("--kotlin_api_version", toolchain.api_version)
     args.add("--kotlin_language_version", toolchain.language_version)
-    args.add("--kotlin_passthrough_flags", "-Xuse-experimental=kotlin.Experimental")
 
     debug = toolchain.debug
     for tag in ctx.attr.tags:


### PR DESCRIPTION
There is a compiler option [here][1] enabled by default that is passed in via [here][2].

[1]: https://github.com/bazelbuild/rules_kotlin/blob/e11db717e218624fff2c036ad63c0b9b6b750158/src/main/starlark/rkt_1_5/kotlin/opts.bzl#L28-L37
[2]: https://github.com/bazelbuild/rules_kotlin/blob/686f0f1cf3e1cc8c750688bb082316b3eadb3cb6/kotlin/internal/jvm/compile.bzl#L303