### PR TITLE
Add experimental stdlib opt-in option

### DIFF
--- a/src/main/starlark/rkt_1_5/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_5/kotlin/opts.bzl
@@ -121,6 +121,16 @@ _KOPTS = {
             True: ["-Xmulti-platform"],
         },
     ),
+    "x_opt_in_experimental_stdlib_api": struct(
+        args = dict(
+            default = False,
+            doc = "Enable experimental standard library features.",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xopt-in=kotlin.ExperimentalStdlibApi"],
+        },
+    ),
 }
 
 KotlincOptions = provider(

--- a/src/main/starlark/rkt_1_6/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_6/kotlin/opts.bzl
@@ -121,6 +121,16 @@ _KOPTS = {
             True: ["-Xmulti-platform"],
         },
     ),
+    "x_opt_in_experimental_stdlib_api": struct(
+        args = dict(
+            default = False,
+            doc = "Enable experimental standard library features.",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xopt-in=kotlin.ExperimentalStdlibApi"],
+        },
+    ),
 }
 
 KotlincOptions = provider(


### PR DESCRIPTION
Since work on the generic opt-in framework seems to be stalled, this adds an explicit option for opting into Kotlin's experimental stdlib.