### PR TITLE
bump all 1.5.1 refs to 1.5.2

### DIFF
--- a/examples/jetpack_compose/BUILD
+++ b/examples/jetpack_compose/BUILD
@@ -46,8 +46,8 @@ kt_compiler_plugin(
 # Used in 'override_targets' by referencing @//:kotlinx_coroutines_core_jvm
 kt_jvm_import(
     name = "kotlinx_coroutines_core_jvm",
-    jars = ["@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.1/kotlinx-coroutines-core-jvm-1.5.1.jar"],
-    srcjar = "@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.1/kotlinx-coroutines-core-jvm-1.5.1-sources.jar",
+    jars = ["@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.2/kotlinx-coroutines-core-jvm-1.5.2.jar"],
+    srcjar = "@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.5.2/kotlinx-coroutines-core-jvm-1.5.2-sources.jar",
     visibility = ["//visibility:public"],
     deps = [
         "//stub:sun_misc",


### PR DESCRIPTION
Fixes CI.

Github showed green for https://github.com/bazelbuild/rules_kotlin/pull/657, I merged, then was informed the branch had changed... but it merged it anyway.

Moral: always refresh.