### PR TITLE
Don't propagate plugins through deps

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -808,7 +808,7 @@ def export_only_providers(ctx, actions, attr, outputs):
     java = JavaInfo(
         output_jar = toolchains.kt.empty_jar,
         compile_jar = toolchains.kt.empty_jar,
-        deps = [_java_info(d) for d in attr.deps + attr.plugins],
+        deps = [_java_info(d) for d in attr.deps],
         exports = [_java_info(d) for d in getattr(attr, "exports", [])],
         neverlink = getattr(attr, "neverlink", False),
     )

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -810,6 +810,7 @@ def export_only_providers(ctx, actions, attr, outputs):
         compile_jar = toolchains.kt.empty_jar,
         deps = [_java_info(d) for d in attr.deps],
         exports = [_java_info(d) for d in getattr(attr, "exports", [])],
+        plugins = attr.plugins,
         neverlink = getattr(attr, "neverlink", False),
     )
 

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -810,7 +810,6 @@ def export_only_providers(ctx, actions, attr, outputs):
         compile_jar = toolchains.kt.empty_jar,
         deps = [_java_info(d) for d in attr.deps],
         exports = [_java_info(d) for d in getattr(attr, "exports", [])],
-        plugins = attr.plugins,
         neverlink = getattr(attr, "neverlink", False),
     )
 


### PR DESCRIPTION
Plugins are not a target dependency. They are a host dep.
If propagated they will cause the build to break at the android_binary
level.
---
 fixes https://github.com/bazelbuild/rules_kotlin/issues/665