### PR TITLE
Make the underlying _kt library public.

### DIFF
--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -50,6 +50,7 @@ maven_install(
         "com.google.dagger:dagger-producers:2.35.1",
         "com.google.auto.value:auto-value:1.6.5",
         "com.google.auto.value:auto-value-annotations:1.6.5",
+        "org.robolectric:robolectric:4.7.3",
     ],
     repositories = [
         "https://maven.google.com",
@@ -85,7 +86,9 @@ android_sdk_repository(
 android_ndk_repository(name = "androidndk")  # Required. Name *must* be "androidndk".
 
 http_archive(
-    name = "rules_pkg",
-    sha256 = "4ba8f4ab0ff85f2484287ab06c0d871dcb31cc54d439457d28fd4ae14b18450a",
-    url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.2.4/rules_pkg-0.2.4.tar.gz",
+    name = "robolectric",
+    urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.7.3.tar.gz"],
+    strip_prefix = "robolectric-bazel-4.7.3",
 )
+load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
+robolectric_repositories()

--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -87,8 +87,10 @@ android_ndk_repository(name = "androidndk")  # Required. Name *must* be "android
 
 http_archive(
     name = "robolectric",
-    urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.7.3.tar.gz"],
     strip_prefix = "robolectric-bazel-4.7.3",
+    urls = ["https://github.com/robolectric/robolectric-bazel/archive/4.7.3.tar.gz"],
 )
+
 load("@robolectric//bazel:robolectric.bzl", "robolectric_repositories")
+
 robolectric_repositories()

--- a/examples/android/libKtAndroid/BUILD.bazel
+++ b/examples/android/libKtAndroid/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_compiler_plugin")
 load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
+
 load("@rules_java//java:defs.bzl", "java_plugin")
 
 kt_compiler_plugin(

--- a/examples/android/libKtAndroid/BUILD.bazel
+++ b/examples/android/libKtAndroid/BUILD.bazel
@@ -1,6 +1,5 @@
 load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_compiler_plugin")
 load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
-
 load("@rules_java//java:defs.bzl", "java_plugin")
 
 kt_compiler_plugin(

--- a/examples/android/libKtAndroid/src/main/java/examples/android/lib/MainActivity.kt
+++ b/examples/android/libKtAndroid/src/main/java/examples/android/lib/MainActivity.kt
@@ -22,6 +22,8 @@ class MainActivity : AppCompatActivity() {
     // Ensure Serialization plugin has run and generated code correctly.
     Data.serializer()
 
-    AutoValue_TestKtValue.Builder().setName("Auto Value Test").build()
+    TestKtValue.create {
+      setName("Auto Value Test") // can't use property syntax, because autovalue builder's codegen
+    }
   }
 }

--- a/examples/android/libKtAndroid/src/main/java/examples/android/lib/TestKtValue.kt
+++ b/examples/android/libKtAndroid/src/main/java/examples/android/lib/TestKtValue.kt
@@ -5,11 +5,17 @@ import com.google.auto.value.AutoValue
 @AutoValue
 abstract class TestKtValue {
   abstract fun name(): String
-  fun builder(): Builder = AutoValue_TestKtValue.Builder()
+  internal fun nameInternal() = "${name()}_internal"
 
   @AutoValue.Builder
   abstract class Builder {
     abstract fun setName(name: String): Builder
     abstract fun build(): TestKtValue
   }
+  companion object {
+    fun create(builderFunction: Builder.() -> Unit) = AutoValue_TestKtValue.Builder().also {
+        builderFunction.invoke(it)
+      }.build()
+  }
+
 }

--- a/examples/android/libKtAndroid/src/test/java/examples/android/lib/AndroidManifest.xml
+++ b/examples/android/libKtAndroid/src/test/java/examples/android/lib/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest package="examples.android.lib"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-sdk
+        android:minSdkVersion="23"
+        android:targetSdkVersion="23"
+        android:maxSdkVersion="29" />
+</manifest>

--- a/examples/android/libKtAndroid/src/test/java/examples/android/lib/BUILD.bazel
+++ b/examples/android/libKtAndroid/src/test/java/examples/android/lib/BUILD.bazel
@@ -3,8 +3,8 @@ load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_local_test")
 kt_android_local_test(
     name = "SomeTest",
     srcs = ["SomeTest.kt"],
+    associates = ["//libKtAndroid:my_kt_kt"],
     custom_package = "examples.android.lib",
-    associates = [ "//libKtAndroid:my_kt_kt" ],
     manifest = "AndroidManifest.xml",
     deps = [
         "@maven//:junit_junit",

--- a/examples/android/libKtAndroid/src/test/java/examples/android/lib/BUILD.bazel
+++ b/examples/android/libKtAndroid/src/test/java/examples/android/lib/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_local_test")
+
+kt_android_local_test(
+    name = "SomeTest",
+    srcs = ["SomeTest.kt"],
+    custom_package = "examples.android.lib",
+    associates = [ "//libKtAndroid:my_kt_kt" ],
+    manifest = "AndroidManifest.xml",
+    deps = [
+        "@maven//:junit_junit",
+        "@robolectric//bazel:android-all",
+    ],
+)

--- a/examples/android/libKtAndroid/src/test/java/examples/android/lib/SomeTest.kt
+++ b/examples/android/libKtAndroid/src/test/java/examples/android/lib/SomeTest.kt
@@ -1,0 +1,15 @@
+package examples.android.lib
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SomeTest {
+
+  @Test
+  fun someTest() {
+    val value = TestKtValue.create {
+      setName("foo")
+    }
+    assertEquals("foo_internal", value.nameInternal())
+  }
+}

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -58,7 +58,7 @@ def _kt_android_artifact(
         friends = friends,
         associates = associates,
         testonly = kwargs.get("testonly", default = False),
-        visibility = ["//visibility:private"],
+        visibility = ["//visibility:public"],
         kotlinc_opts = kotlinc_opts,
         javac_opts = javac_opts,
         tags = tags,


### PR DESCRIPTION
Android kotlin libraries are a macro wrapper, and the underlying kotlin library (for target //foo:bar -> //foo:bar_kt) is marked private. Since the associates= (friendly) internal feature of kotlin requires access to a kotlin library, one is forced to often link test targets to the underlying android _kt backing target, which breaks if you're not in hte same package.

This PR makes it public (which sucks, but kind of is necessary until we can eliminate teh macro-based 'android-sandwich' thing we presently do, so that the associates= feature can work at all in kt_android_* targest.

Also adds an example (which fails without the change) to the android example.

Fixes #540