### PR TITLE
Move Jacoco to runtime deps

### DIFF
--- a/src/main/kotlin/BUILD.release.bazel
+++ b/src/main/kotlin/BUILD.release.bazel
@@ -45,7 +45,10 @@ java_binary(
     ],
     main_class = "io.bazel.kotlin.builder.cmd.Build",
     visibility = ["//visibility:public"],
-    runtime_deps = [":worker"],
+    runtime_deps = [
+        ":worker",
+        "@bazel_tools//tools/jdk:JacocoCoverage",
+    ],
 )
 
 java_binary(

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -19,6 +19,9 @@ kt_bootstrap_library(
     srcs = glob([
         "**/*.kt",
     ]),
+    neverlink_deps = [
+        "@bazel_tools//tools/jdk:JacocoCoverage",
+    ],
     visibility = ["//src:__subpackages__"],
     deps = [
         "//src/main/kotlin/io/bazel/kotlin/builder/toolchain",
@@ -28,7 +31,6 @@ kt_bootstrap_library(
         "//src/main/protobuf:deps_java_proto",
         "//src/main/protobuf:kotlin_model_java_proto",
         "//src/main/protobuf:worker_protocol_java_proto",
-        "@bazel_tools//tools/jdk:JacocoCoverage",
         "@com_github_jetbrains_kotlin//:kotlin-preloader",
         "@kotlin_rules_maven//:com_google_protobuf_protobuf_java",
         "@kotlin_rules_maven//:com_google_protobuf_protobuf_java_util",

--- a/src/test/kotlin/io/bazel/kotlin/builder/BUILD
+++ b/src/test/kotlin/io/bazel/kotlin/builder/BUILD
@@ -47,6 +47,7 @@ java_library(
         "@kotlin_rules_maven//:com_google_protobuf_protobuf_java",
     ],
     runtime_deps = [
+        "@bazel_tools//tools/jdk:JacocoCoverage",
         "@com_github_jetbrains_kotlin//:kotlin-reflect",
         "@com_github_jetbrains_kotlin//:kotlin-stdlib",
     ],


### PR DESCRIPTION
Because `@bazel_tools//tools/jdk:JacocoCoverage` was a compile-time dependency, the release package depended on the version of Bazel that was used to build it.

Closes #646