### PR TITLE
Use canonical repo name for android rules: build_bazel_rules_android

### DIFF
--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -59,14 +59,14 @@ maven_install(
 )
 
 http_archive(
-    name = "rules_android",
+    name = "build_bazel_rules_android",
     sha256 = versions.ANDROID.SHA,
     strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
     urls = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % versions.ANDROID.VERSION],
 )
 
 load(
-    "@rules_android//android:rules.bzl",
+    "@build_bazel_rules_android//android:rules.bzl",
     "android_ndk_repository",
     "android_sdk_repository",
 )

--- a/examples/android/app/BUILD.bazel
+++ b/examples/android/app/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_android//android:rules.bzl", "android_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
 
 # An app that consumes android-kt deps
 android_binary(

--- a/examples/android/libAndroid/BUILD.bazel
+++ b/examples/android/libAndroid/BUILD.bazel
@@ -1,5 +1,5 @@
+load("@build_bazel_rules_android//android:rules.bzl", "android_library")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
-load("@rules_android//android:rules.bzl", "android_library")
 
 android_library(
     name = "my_android",

--- a/examples/associates/WORKSPACE
+++ b/examples/associates/WORKSPACE
@@ -20,13 +20,6 @@ kt_register_toolchains()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "rules_android",
-    sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-    strip_prefix = "rules_android-0.1.1",
-    urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
-)
-
-http_archive(
     name = "build_bazel_rules_android",
     sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
     strip_prefix = "rules_android-0.1.1",

--- a/examples/jetpack_compose/WORKSPACE
+++ b/examples/jetpack_compose/WORKSPACE
@@ -86,13 +86,13 @@ http_archive(
 ## Android
 
 http_archive(
-    name = "rules_android",
+    name = "build_bazel_rules_android",
     sha256 = versions.ANDROID.SHA,
     strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
     urls = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % versions.ANDROID.VERSION],
 )
 
-load("@rules_android//android:rules.bzl", "android_sdk_repository")
+load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
 
 android_sdk_repository(
     name = "androidsdk",

--- a/examples/jetpack_compose/app/BUILD
+++ b/examples/jetpack_compose/app/BUILD
@@ -1,5 +1,5 @@
-load("@rules_android//android:rules.bzl", "android_binary")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
 
 # An app that consumes android-kt deps
 android_binary(

--- a/examples/plugin/WORKSPACE
+++ b/examples/plugin/WORKSPACE
@@ -38,7 +38,7 @@ maven_install(
     ],
 )
 
-load("@rules_android//android:rules.bzl", "android_sdk_repository")
+load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
 
 android_sdk_repository(
     name = "androidsdk",

--- a/kotlin/internal/jvm/BUILD
+++ b/kotlin/internal/jvm/BUILD
@@ -30,6 +30,6 @@ bzl_library(
     visibility = ["//kotlin:__subpackages__"],
     deps = [
         "//third_party:bzl",
-        "@rules_android//android",
+        "@build_bazel_rules_android//android",
     ],
 )

--- a/src/main/starlark/core/repositories/download.bzl
+++ b/src/main/starlark/core/repositories/download.bzl
@@ -89,7 +89,7 @@ def kt_download_local_dev_dependencies():
     )
 
     rules_stardoc_repository(
-        name = "rules_android",
+        name = "build_bazel_rules_android",
         sha256 = versions.ANDROID.SHA,
         strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
         urls = versions.ANDROID.URLS,

--- a/src/main/starlark/core/repositories/initialize.release.bzl
+++ b/src/main/starlark/core/repositories/initialize.release.bzl
@@ -68,7 +68,7 @@ def kotlin_repositories(
 
     maybe(
         http_archive,
-        name = "rules_android",
+        name = "build_bazel_rules_android",
         sha256 = versions.ANDROID.SHA,
         strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
         urls = versions.ANDROID.URLS,

--- a/src/main/starlark/core/repositories/setup.bzl
+++ b/src/main/starlark/core/repositories/setup.bzl
@@ -16,7 +16,7 @@ load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-load("@rules_android//android:rules.bzl", "android_sdk_repository")
+load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
 load("//src/main/starlark/core/repositories:versions.bzl", "versions")
 
 def kt_configure():


### PR DESCRIPTION
The [canonical](https://github.com/bazelbuild/rules_android/blob/e8fbc49f913101e846235b9c9a31b3aa9788364a/WORKSPACE#L1) repo name for the [android rules repo](https://github.com/bazelbuild/rules_android) appears to be `build_bazel_rules_android`, not `rules_android`. Our project already had the former, so integrating this ruleset led to us having two copies of the android ruleset in our project which felt a little redundant and unnecessary.

Perhaps there's a perfectly good or historical reason for using `rules_android` in here that I'm not aware of. If this complicates things in any way, feel free to close this PR.