### PR TITLE
Generic -Xopt-in support

### DIFF
--- a/src/main/starlark/rkt_1_5/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_5/kotlin/opts.bzl
@@ -121,6 +121,16 @@ _KOPTS = {
             True: ["-Xmulti-platform"],
         },
     ),
+    "x_opt_in_experimental_stdlib_api": struct(
+        args = dict(
+            default = False,
+            doc = "Enable experimental standard library features.",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xopt-in=kotlin.ExperimentalStdlibApi"],
+        },
+    ),
 }
 
 KotlincOptions = provider(

--- a/src/main/starlark/rkt_1_5/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_5/kotlin/opts.bzl
@@ -1,3 +1,6 @@
+def _map_optin_class_to_flag(values):
+    return ["-Xopt-in=%s" % v for v in values]
+
 _KOPTS = {
     "warn": struct(
         args = dict(
@@ -121,15 +124,14 @@ _KOPTS = {
             True: ["-Xmulti-platform"],
         },
     ),
-    "x_opt_in_experimental_stdlib_api": struct(
+    "x_optin": struct(
         args = dict(
-            default = False,
-            doc = "Enable experimental standard library features.",
+            default = [],
+            doc = "Define APIs to opt-in to.",
         ),
-        type = attr.bool,
-        value_to_flag = {
-            True: ["-Xopt-in=kotlin.ExperimentalStdlibApi"],
-        },
+        type = attr.string_list,
+        value_to_flag = None,
+        map_value_to_flag = _map_optin_class_to_flag,
     ),
 }
 
@@ -171,7 +173,7 @@ def kotlinc_options_to_flags(kotlinc_options):
     flags = []
     for n, o in _KOPTS.items():
         value = getattr(kotlinc_options, n, None)
-        flag = o.value_to_flag.get(value, None)
+        flag = o.value_to_flag.get(value, None) if o.value_to_flag else o.map_value_to_flag(value)
         if flag:
             flags.extend(flag)
     return flags

--- a/src/main/starlark/rkt_1_6/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_6/kotlin/opts.bzl
@@ -121,6 +121,16 @@ _KOPTS = {
             True: ["-Xmulti-platform"],
         },
     ),
+    "x_opt_in_experimental_stdlib_api": struct(
+        args = dict(
+            default = False,
+            doc = "Enable experimental standard library features.",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xopt-in=kotlin.ExperimentalStdlibApi"],
+        },
+    ),
 }
 
 KotlincOptions = provider(

--- a/src/main/starlark/rkt_1_6/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_6/kotlin/opts.bzl
@@ -1,3 +1,6 @@
+def _map_optin_class_to_flag(values):
+    return ["-opt-in=%s" % v for v in values]
+
 _KOPTS = {
     "warn": struct(
         args = dict(
@@ -121,15 +124,14 @@ _KOPTS = {
             True: ["-Xmulti-platform"],
         },
     ),
-    "x_opt_in_experimental_stdlib_api": struct(
+    "x_optin": struct(
         args = dict(
-            default = False,
-            doc = "Enable experimental standard library features.",
+            default = [],
+            doc = "Define APIs to opt-in to.",
         ),
-        type = attr.bool,
-        value_to_flag = {
-            True: ["-Xopt-in=kotlin.ExperimentalStdlibApi"],
-        },
+        type = attr.string_list,
+        value_to_flag = None,
+        map_value_to_flag = _map_optin_class_to_flag,
     ),
 }
 
@@ -171,7 +173,7 @@ def kotlinc_options_to_flags(kotlinc_options):
     flags = []
     for n, o in _KOPTS.items():
         value = getattr(kotlinc_options, n, None)
-        flag = o.value_to_flag.get(value, None)
+        flag = o.value_to_flag.get(value, None) if o.value_to_flag else o.map_value_to_flag(value)
         if flag:
             flags.extend(flag)
     return flags


### PR DESCRIPTION
Inspired from conversation on #653 to solve for #603.

I'm only opening this PR because this is a feature I needed today and haven't seen any movement on #653 in almost a month. Feel free to disregard if this PR is redundant pending work from #653. 

If necessary, I can add to some of the other `opts.bzl` files, but it wasn't clear to me the resolution of this comment since the PR was approved afterwards:
https://github.com/bazelbuild/rules_kotlin/pull/653#issuecomment-1010326401