### PR TITLE
Fix annotation processing when no kotlin sources are passed

### DIFF
--- a/src/test/data/jvm/kapt/BUILD
+++ b/src/test/data/jvm/kapt/BUILD
@@ -139,10 +139,22 @@ kt_jvm_library(
     ],
 )
 
+kt_jvm_library(
+    name = "ap_only_java",
+    srcs = [
+        "java/TestAutoValue.java",
+    ],
+    plugins = [":autovalue"],
+    deps = [
+        "@kotlin_rules_maven//:com_google_auto_value_auto_value_annotations",
+    ],
+)
+
 filegroup(
     name = "kapt",
     srcs = [
         ":ap_kotlin.jar",
+        ":ap_only_java.jar",
         ":ap_kotlin_mixed",
         ":ap_kotlin_mixed_inherit_plugin_via_exported_deps",
         ":ap_kotlin_mixed_multiple_plugins",

--- a/src/test/kotlin/io/bazel/kotlin/KotlinJvmKaptAssertionTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/KotlinJvmKaptAssertionTest.kt
@@ -41,6 +41,13 @@ class KotlinJvmKaptAssertionTest : KotlinAssertionTestCase("src/test/data/jvm/ka
   }
 
   @Test
+  fun testJavaOnlyAnnotationProcessing() {
+    jarTestCase("ap_only_java.jar", description = "annotation processing should work when only java sources are specified") {
+      assertContainsEntries("tests/smoke/kapt/java/AutoValue_TestAutoValue.class")
+    }
+  }
+
+  @Test
   fun testMixedModeAnnotationProcessing() {
     jarTestCase(
       "ap_kotlin_mixed.jar",


### PR DESCRIPTION
The rules assume the kotlin compiler will take care of annotation
processing, but kotlinc does not run if not kotlin sources are
specified. This commit forces annotation processing with java
if no kotlin sources are passed.
