### PR TITLE
Add kotlin opts for disabling `invokedynamic`

### DIFF
--- a/src/main/starlark/rkt_1_5/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_5/kotlin/opts.bzl
@@ -121,6 +121,30 @@ _KOPTS = {
             True: ["-Xmulti-platform"],
         },
     ),
+    "x_sam_conversions": struct(
+        args = dict(
+            default = "class",
+            doc = "Change codegen behavior of SAM/functional interfaces",
+            values = ["class", "indy"],
+        ),
+        type = attr.string,
+        value_to_flag = {
+            "class": ["-Xsam-conversions=class"],
+            "indy": ["-Xsam-conversions=indy"],
+        },
+    ),
+    "x_lambdas": struct(
+        args = dict(
+            default = "class",
+            doc = "Change codegen behavior of lambdas",
+            values = ["class", "indy"],
+        ),
+        type = attr.string,
+        value_to_flag = {
+            "class": ["-Xlambdas=class"],
+            "indy": ["-Xlambdas=indy"],
+        },
+    ),
 }
 
 KotlincOptions = provider(

--- a/src/main/starlark/rkt_1_6/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_6/kotlin/opts.bzl
@@ -121,6 +121,30 @@ _KOPTS = {
             True: ["-Xmulti-platform"],
         },
     ),
+    "x_sam_conversions": struct(
+        args = dict(
+            default = "class",
+            doc = "Change codegen behavior of SAM/functional interfaces",
+            values = ["class", "indy"],
+        ),
+        type = attr.string,
+        value_to_flag = {
+            "class": ["-Xsam-conversions=class"],
+            "indy": ["-Xsam-conversions=indy"],
+        },
+    ),
+    "x_lambdas": struct(
+        args = dict(
+            default = "class",
+            doc = "Change codegen behavior of lambdas",
+            values = ["class", "indy"],
+        ),
+        type = attr.string,
+        value_to_flag = {
+            "class": ["-Xlambdas=class"],
+            "indy": ["-Xlambdas=indy"],
+        },
+    ),
 }
 
 KotlincOptions = provider(


### PR DESCRIPTION
**Background**

We see crashes in desugaring due to `invokedynamic` and need to set `-Xsam-conversions` to `class` to avoid the crash.

Crash stacktrace (not directly related to `rules_kotlin`):
```
failed: (Exit 1): desugar_java8 failed: error executing command 
2022-02-08 08:03:19   (cd /run/jenkins/bazel/userroot/6f9c9cb8506de64f63094a5ee74046fa/execroot/__main__ && \
2022-02-08 08:03:19   exec env - \
2022-02-08 08:03:19     PATH=/bin:/usr/bin:/usr/local/bin \
2022-02-08 08:03:19   bazel-out/k8-opt-exec-2B5CBBC6/bin/external/bazel_tools/tools/android/desugar_java8 @bazel-out/android-arm64-v8a-fastbuild/bin/external/snap_client/src/_dx/client_aar_import/classes_and_libs_merged.jar_desugared.jar-0.params)
2022-02-08 08:03:19 Execution platform: @local_config_platform//:host
2022-02-08 08:03:19 java.lang.TypeNotPresentException: Type kotlin.jvm.internal.Ref$ObjectRef not present
2022-02-08 08:03:19 	at java.base/sun.invoke.util.BytecodeDescriptor.parseSig(BytecodeDescriptor.java:97)
2022-02-08 08:03:19 	at java.base/sun.invoke.util.BytecodeDescriptor.parseMethod(BytecodeDescriptor.java:60)
2022-02-08 08:03:19 	at java.base/sun.invoke.util.BytecodeDescriptor.parseMethod(BytecodeDescriptor.java:45)
2022-02-08 08:03:19 	at java.base/java.lang.invoke.MethodType.fromDescriptor(MethodType.java:1135)
2022-02-08 08:03:19 	at java.base/java.lang.invoke.MethodType.fromMethodDescriptorString(MethodType.java:1114)
2022-02-08 08:03:19 	at com.google.devtools.build.android.desugar.LambdaDesugaring$InvokedynamicRewriter.visitInvokeDynamicInsn(LambdaDesugaring.java:406)
2022-02-08 08:03:19 	at org.objectweb.asm.MethodVisitor.visitInvokeDynamicInsn(MethodVisitor.java:461)
2022-02-08 08:03:19 	at org.objectweb.asm.MethodVisitor.visitInvokeDynamicInsn(MethodVisitor.java:461)
2022-02-08 08:03:19 	at com.google.devtools.build.android.desugar.strconcat.IndyStringConcatDesugaring$IndifiedStringConcatInvocationConverter.visitInvokeDynamicInsn(IndyStringConcatDesugaring.java:141)
2022-02-08 08:03:19 	at org.objectweb.asm.MethodVisitor.visitInvokeDynamicInsn(MethodVisitor.java:461)
2022-02-08 08:03:19 	at org.objectweb.asm.ClassReader.readCode(ClassReader.java:2444)
2022-02-08 08:03:19 	at org.objectweb.asm.ClassReader.readMethod(ClassReader.java:1487)
2022-02-08 08:03:19 	at org.objectweb.asm.ClassReader.accept(ClassReader.java:717)
2022-02-08 08:03:19 	at com.google.devtools.build.android.desugar.Desugar.desugarClassesInInput(Desugar.java:542)
```

**Changes**
Add support for `-Xsam_conversions` and `-Xlambdas`.