### PR TITLE
Support using --jvmopt with kt_jvm_binary

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -243,11 +243,13 @@ def kt_jvm_library_impl(ctx):
 
 def kt_jvm_binary_impl(ctx):
     providers = _kt_jvm_produce_jar_actions(ctx, "kt_jvm_binary")
+    jvm_flags = ctx.attr.jvm_flags[:]
+    jvm_flags.extend(ctx.fragments.java.default_jvm_opts)
     _write_launcher_action(
         ctx,
         providers.java.transitive_runtime_jars,
         ctx.attr.main_class,
-        ctx.attr.jvm_flags,
+        jvm_flags,
     )
     if len(ctx.attr.srcs) == 0 and len(ctx.attr.deps) > 0:
         fail("deps without srcs in invalid. To add runtime classpath and resources, use runtime_deps.", attr = "deps")

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -243,8 +243,8 @@ def kt_jvm_library_impl(ctx):
 
 def kt_jvm_binary_impl(ctx):
     providers = _kt_jvm_produce_jar_actions(ctx, "kt_jvm_binary")
-    jvm_flags = ctx.attr.jvm_flags[:]
-    jvm_flags.extend(ctx.fragments.java.default_jvm_opts)
+    jvm_flags = ctx.fragments.java.default_jvm_opts
+    jvm_flags.extend(ctx.attr.jvm_flags)
     _write_launcher_action(
         ctx,
         providers.java.transitive_runtime_jars,


### PR DESCRIPTION
Add the JVM options specified via [`--jvmopt`](https://docs.bazel.build/versions/main/user-manual.html#flag--jvmopt) to the `jvm_flags` of `kt_jvm_binary` targets.

Since `--jvmopt` options should apply to the JVM for all java binaries in the Bazel command, they should also affect the Kotlin JVM binaries. This is needed by the IntelliJ Bazel plugin to pass a javaagent from command line to the Kotlin binary targets to enable debugging coroutines.