### PR TITLE
Pin buildifier to 4.2.5 to unblock master

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,8 +1,8 @@
 ---
 validate_config: 1
-bazel: 5.0.0
+bazel: 4.2.5z
 buildifier:
-  version: latest
+  version: 4.2.5
   # no lint warnings for the moment. They are basically a smoke alarm in hell.
   # keep this argument in sync with .pre-commit-config.yaml
   warnings: "-confusing-name,-constant-glob,-duplicated-name,-function-docstring,-function-docstring-args,-function-docstring-header,-module-docstring,-name-conventions,-no-effect,-constant-glob,-provider-params,-print,-rule-impl-return,-bzl-visibility,-unnamed-macro,-uninitialized,-unreachable"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,6 @@
 ---
 validate_config: 1
-bazel: 4.2.5z
+bazel: 5.0.0
 buildifier:
   version: 4.2.5
   # no lint warnings for the moment. They are basically a smoke alarm in hell.


### PR DESCRIPTION
CI is set up to use the latest buildifier versions as they are released, which is breaking PRs unexpectedly.