### PR TITLE
Allow java 15 and 17 for jvm_target

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 define_kt_toolchain(
     name = "kotlin_toolchain",
     api_version = KOTLIN_LANGUAGE_LEVEL,  # "1.1", "1.2", "1.3", "1.4", "1.5", or "1.6"
-    jvm_target = JAVA_LANGUAGE_LEVEL, # "1.6", "1.8", "9", "10", "11", "12", or "13",
+    jvm_target = JAVA_LANGUAGE_LEVEL, # "1.6", "1.8", "9", "10", "11", "12", "13", "15", or "17"
     language_version = KOTLIN_LANGUAGE_LEVEL,  # "1.1", "1.2", "1.3", "1.4",  "1.5", or "1.6"
 )
 ```

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -184,6 +184,8 @@ _kt_toolchain = rule(
                 "11",
                 "12",
                 "13",
+                "15",
+                "17",
             ],
         ),
         "js_target": attr.string(


### PR DESCRIPTION
This seems to fix #711

I've tested some Kotlin targets at my company that depend on java deps and I can successfully build with java 17, but haven't done anything more thorough than that.

Also, what do y'all think about removing the check altogether? Kotlin compiler will fail if an invalid version is provided anyways, and this Bazel-level check doesn't even spare users from that error if they try to use java 17 with a Kotlin compiler that is too old.