### PR TITLE
Support all -Xjvm-default options

### DIFF
--- a/src/main/starlark/legacy/kotlin/opts.bzl
+++ b/src/main/starlark/legacy/kotlin/opts.bzl
@@ -69,13 +69,16 @@ _KOPTS = {
         args = dict(
             default = "off",
             doc = "Specifies that a JVM default method should be generated for non-abstract Kotlin interface member.",
-            values = ["off", "enable", "compatibility"],
+            values = ["off", "enable", "disable", "compatibility", "all-compatibility", "all"],
         ),
         type = attr.string,
         value_to_flag = {
             "off": None,
             "enable": ["-Xjvm-default=enable"],
+            "disable": ["-Xjvm-default=disable"],
             "compatibility": ["-Xjvm-default=compatibility"],
+            "all-compatibility": ["-Xjvm-default=all-compatibility"],
+            "all": ["-Xjvm-default=all"],
         },
     ),
     "x_no_optimized_callable_references": struct(

--- a/src/main/starlark/rkt_1_4/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_4/kotlin/opts.bzl
@@ -69,13 +69,16 @@ _KOPTS = {
         args = dict(
             default = "off",
             doc = "Specifies that a JVM default method should be generated for non-abstract Kotlin interface member.",
-            values = ["off", "enable", "compatibility"],
+            values = ["off", "enable", "disable", "compatibility", "all-compatibility", "all"],
         ),
         type = attr.string,
         value_to_flag = {
             "off": None,
             "enable": ["-Xjvm-default=enable"],
+            "disable": ["-Xjvm-default=disable"],
             "compatibility": ["-Xjvm-default=compatibility"],
+            "all-compatibility": ["-Xjvm-default=all-compatibility"],
+            "all": ["-Xjvm-default=all"],
         },
     ),
     "x_no_optimized_callable_references": struct(

--- a/src/main/starlark/rkt_1_5/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_5/kotlin/opts.bzl
@@ -72,13 +72,16 @@ _KOPTS = {
         args = dict(
             default = "off",
             doc = "Specifies that a JVM default method should be generated for non-abstract Kotlin interface member.",
-            values = ["off", "enable", "compatibility"],
+            values = ["off", "enable", "disable", "compatibility", "all-compatibility", "all"],
         ),
         type = attr.string,
         value_to_flag = {
             "off": None,
             "enable": ["-Xjvm-default=enable"],
+            "disable": ["-Xjvm-default=disable"],
             "compatibility": ["-Xjvm-default=compatibility"],
+            "all-compatibility": ["-Xjvm-default=all-compatibility"],
+            "all": ["-Xjvm-default=all"],
         },
     ),
     "x_no_optimized_callable_references": struct(

--- a/src/main/starlark/rkt_1_6/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_6/kotlin/opts.bzl
@@ -62,13 +62,16 @@ _KOPTS = {
         args = dict(
             default = "off",
             doc = "Specifies that a JVM default method should be generated for non-abstract Kotlin interface member.",
-            values = ["off", "enable", "compatibility"],
+            values = ["off", "enable", "disable", "compatibility", "all-compatibility", "all"],
         ),
         type = attr.string,
         value_to_flag = {
             "off": None,
             "enable": ["-Xjvm-default=enable"],
+            "disable": ["-Xjvm-default=disable"],
             "compatibility": ["-Xjvm-default=compatibility"],
+            "all-compatibility": ["-Xjvm-default=all-compatibility"],
+            "all": ["-Xjvm-default=all"],
         },
     ),
     "x_no_optimized_callable_references": struct(


### PR DESCRIPTION
Back filling the missing CLI options for `-Xjvm-default` that we are missing. https://github.com/bazelbuild/rules_kotlin/issues/714

The options for reference https://github.com/JetBrains/kotlin/blob/1.4-M3/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/K2JVMCompilerArguments.kt#L271-L295

These flags are supported back to 1.4: https://blog.jetbrains.com/kotlin/2020/07/kotlin-1-4-m3-generating-default-methods-in-interfaces/