### PR TITLE
Support -Xuse-fir to enable the experimental new Kotlin frontend

### DIFF
--- a/src/main/starlark/rkt_1_6/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_6/kotlin/opts.bzl
@@ -147,6 +147,16 @@ _KOPTS = {
         value_to_flag = None,
         map_value_to_flag = _map_optin_class_to_flag,
     ),
+    "x_use_fir": struct(
+        args = dict(
+            default = False,
+            doc = "Compile using the experimental Kotlin Front-end IR. Available from 1.6.",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xuse-fir"],
+        },
+    ),
 }
 
 KotlincOptions = provider(


### PR DESCRIPTION
The Kotlin team is working on a new experimental frontend that is expected to improve compile times. This is very much an experimental feature at the moment, but we should support dog fooding this in rules_kotlin so we can report issues. https://github.com/JetBrains/kotlin/blob/1.6.20/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt#L303-L308