### PR TITLE
Bump Kotlin compiler from 1.6.20 -> 1.6.21

### DIFF
--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -26,11 +26,11 @@ versions = struct(
     IO_BAZEL_STARDOC_SHA = "6d07d18c15abb0f6d393adbd6075cd661a2219faab56a9517741f0fc755f6f3c",
     BAZEL_JAVA_LAUNCHER_VERSION = "5.0.0-pre.20210510.2",
     KOTLIN_CURRENT_COMPILER_RELEASE = version(
-        version = "1.6.20",
+        version = "1.6.21",
         url_templates = [
             "https://github.com/JetBrains/kotlin/releases/download/v{version}/kotlin-compiler-{version}.zip",
         ],
-        sha256 = "daf17db1c194f4205f3af67129367a69b388f819177963dc53a7b4b2c4d8ce22",
+        sha256 = "632166fed89f3f430482f5aa07f2e20b923b72ef688c8f5a7df3aa1502c6d8ba",
     ),
     ANDROID = struct(
         VERSION = "0.1.1",


### PR DESCRIPTION
https://github.com/JetBrains/kotlin/releases/tag/v1.6.21