### PR TITLE
Replace cfg=host with cfg=exec

### DIFF
--- a/kotlin/internal/js/js.bzl
+++ b/kotlin/internal/js/js.bzl
@@ -138,7 +138,7 @@ kt_js_import = rule(
             default = Label("//kotlin/internal/js:importer"),
             allow_files = True,
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
     },
     outputs = dict(

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -149,7 +149,7 @@ _implicit_deps = {
     ),
     "_host_javabase": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
-        cfg = "host",
+        cfg = "exec",
     ),
     "_java_runtime": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_runtime"),

--- a/kotlin/internal/lint/ktlint_test.bzl
+++ b/kotlin/internal/lint/ktlint_test.bzl
@@ -72,7 +72,7 @@ ktlint_test = rule(
         "_ktlint_tool": attr.label(
             default = "@com_github_pinterest_ktlint//file",
             executable = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "_javabase": attr.label(
             default = "@bazel_tools//tools/jdk:current_java_runtime",

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -112,14 +112,14 @@ _kt_toolchain = rule(
             default = Label("//src/main/kotlin:build"),
             executable = True,
             allow_files = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "jdeps_merger": attr.label(
             doc = "the jdeps merger executable",
             default = Label("//src/main/kotlin:jdeps_merger"),
             executable = True,
             allow_files = True,
-            cfg = "host",
+            cfg = "exec",
         ),
         "language_version": attr.string(
             doc = "this is the -language_version flag [see](https://kotlinlang.org/docs/reference/compatibility.html)",

--- a/kotlin/internal/utils/generate_jvm_service.bzl
+++ b/kotlin/internal/utils/generate_jvm_service.bzl
@@ -78,7 +78,7 @@ generate_jvm_service = rule(
             ),
             "_zipper": attr.label(
                 executable = True,
-                cfg = "host",
+                cfg = "exec",
                 default = Label("@bazel_tools//tools/zip:zipper"),
                 allow_files = True,
             ),

--- a/third_party/jarjar.bzl
+++ b/third_party/jarjar.bzl
@@ -49,7 +49,7 @@ jar_jar = rule(
         "rules": attr.label(allow_single_file = True),
         "jarjar_runner": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("//third_party:jarjar_runner"),
         ),
     },


### PR DESCRIPTION
As per the buildtools violation, `cfg = "host"` is deprecated and should be replaced with `cfg = "exec"`

https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md#cfg--data-for-attr-definitions-has-no-effect