### PR TITLE
Remove ExperimentalCoroutinesApi usages

### DIFF
--- a/src/test/kotlin/io/bazel/worker/WorkerEnvironmentTest.kt
+++ b/src/test/kotlin/io/bazel/worker/WorkerEnvironmentTest.kt
@@ -20,10 +20,8 @@ package io.bazel.worker
 import com.google.common.truth.Truth.assertThat
 import com.google.devtools.build.lib.worker.WorkerProtocol
 import com.google.devtools.build.lib.worker.WorkerProtocol.WorkRequest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.junit.Test
 
-@ExperimentalCoroutinesApi
 class WorkerEnvironmentTest {
 
   @Test


### PR DESCRIPTION
We shouldn't need this anymore now that the workers aren't backed by coroutines.