### PR TITLE
Add CI task for building a release

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -90,4 +90,9 @@ tasks:
     platform: ubuntu1804
     build_targets:
       - //kotlin:stardoc
+  build_release:
+    name: Build rules_kotlin release
+    platform: ubuntu1804
+    shell_commands:
+      - ./scripts/release.sh
 


### PR DESCRIPTION
We can also upload these to Buildkite artifacts, which could make it easier for us to support rolling releases without Github actions.