### PR TITLE
Ensure version of Android SDK is consistent when compiling kotlin targets

### DIFF
--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -37,7 +37,7 @@ def _kt_android_artifact(
     kt_name = name + "_kt"
 
     # TODO(bazelbuild/rules_kotlin/issues/273): This should be retrieved from a provider.
-    base_deps = deps + [_ANDROID_SDK_JAR]
+    base_deps = [_ANDROID_SDK_JAR] + deps
 
     # TODO(bazelbuild/rules_kotlin/issues/556): replace with starlark
     # buildifier: disable=native-android


### PR DESCRIPTION
It's possible Kotlin targets within a project can depend on other libraries that depend themselves (as provided deps) on different version on Android SDK library. It's certainly not a good practice, but can happen. 
In this case, because project android SDK appears later in the list of classpathes used for compilation when compiling kotlin targets, this different version of the Android SDK can take precedence and cause target failed to compile. An example is with android.os.BuildConfig.VERSION_CODE that might not contain latest entries in case different version of the SDK is older.