### PR TITLE
Support Kotlin 1.7 api and language versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,9 @@ load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 
 define_kt_toolchain(
     name = "kotlin_toolchain",
-    api_version = KOTLIN_LANGUAGE_LEVEL,  # "1.1", "1.2", "1.3", "1.4", "1.5", or "1.6"
+    api_version = KOTLIN_LANGUAGE_LEVEL,  # "1.1", "1.2", "1.3", "1.4", "1.5" "1.6", or "1.7"
     jvm_target = JAVA_LANGUAGE_LEVEL, # "1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", or "17"
-    language_version = KOTLIN_LANGUAGE_LEVEL,  # "1.1", "1.2", "1.3", "1.4",  "1.5", or "1.6"
+    language_version = KOTLIN_LANGUAGE_LEVEL,  # "1.1", "1.2", "1.3", "1.4", "1.5" "1.6", or "1.7"
 )
 ```
 

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -131,6 +131,7 @@ _kt_toolchain = rule(
                 "1.4",
                 "1.5",
                 "1.6",
+                "1.7",
             ],
         ),
         "api_version": attr.string(
@@ -143,6 +144,7 @@ _kt_toolchain = rule(
                 "1.4",
                 "1.5",
                 "1.6",
+                "1.7",
             ],
         ),
         "debug": attr.string_list(


### PR DESCRIPTION
Kotlin 1.7 is on the horizon so adding the API and language versions https://github.com/JetBrains/kotlin/releases/tag/v1.7.0-RC