### PR TITLE
Run `kapt` on `kt` files passed via `srcjar`s

### DIFF
--- a/examples/dagger/BUILD
+++ b/examples/dagger/BUILD
@@ -49,6 +49,36 @@ rm ChaiCup.kt
     toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
 )
 
+genrule(
+    name = "genereated_module_src",
+    outs = ["genarated_module_src.srcjar"],
+    cmd = """
+cat << EOF > GeneratedModule.kt
+package generated
+
+import dagger.Provides
+import dagger.Module
+
+@Module
+object GeneratedModule {
+    @Provides
+    fun provideString() = "Hello Coffee"
+}
+EOF
+$(JAVABASE)/bin/jar -cf $@ GeneratedModule.kt
+rm GeneratedModule.kt
+""",
+    toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],
+)
+
+kt_jvm_library(
+    name = "generated_lib",
+    srcs = [":genereated_module_src"],
+    deps = [
+        "//third_party:dagger",
+    ],
+)
+
 kt_jvm_library(
     name = "coffee_lib",
     srcs = glob(["src/**"]) + [
@@ -59,6 +89,7 @@ kt_jvm_library(
     deps = [
         "//third_party:dagger",
         "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
+         ":generated_lib",
     ],
 )
 

--- a/examples/dagger/BUILD
+++ b/examples/dagger/BUILD
@@ -87,9 +87,9 @@ kt_jvm_library(
         ":chai_lib_src",
     ],
     deps = [
+        ":generated_lib",
         "//third_party:dagger",
         "@maven//:org_jetbrains_kotlinx_kotlinx_coroutines_core",
-         ":generated_lib",
     ],
 )
 

--- a/examples/dagger/src/coffee/CoffeeApp.kt
+++ b/examples/dagger/src/coffee/CoffeeApp.kt
@@ -15,6 +15,7 @@
  */
 package coffee
 
+import generated.GeneratedModule
 import dagger.Component
 import kotlinx.coroutines.runBlocking
 import tea.TeaPot
@@ -23,7 +24,7 @@ import javax.inject.Singleton
 
 class CoffeeApp {
   @Singleton
-  @Component(modules = [(DripCoffeeModule::class)])
+  @Component(modules = [DripCoffeeModule::class, GeneratedModule::class])
   interface CoffeeShop {
     fun maker(): CoffeeMaker
   }

--- a/examples/dagger/src/coffee/CoffeeMaker.kt
+++ b/examples/dagger/src/coffee/CoffeeMaker.kt
@@ -23,7 +23,8 @@ import javax.inject.Inject
 class CoffeeMaker @Inject internal constructor(
   // Create a possibly costly heater only when we use it.
   private val heater: Lazy<Heater>,
-  private val pump: Pump
+  private val pump: Pump,
+  private val string: String
 ) {
 
   suspend fun brew() {
@@ -32,6 +33,7 @@ class CoffeeMaker @Inject internal constructor(
       heater.get().on()
       pump.pump()
       println(" [_]P coffee! [_]P ")
+      println(string)
       heater.get().off()
     }
   }

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -554,9 +554,10 @@ def _run_kt_java_builder_actions(
     compile_jars = []
     output_jars = []
     kt_stubs_for_java = []
+    has_sources = srcs.kt or srcs.src_jars
 
     # Run KAPT
-    if srcs.kt and annotation_processors:
+    if has_sources and annotation_processors:
         ap_generated_src_jar = ctx.actions.declare_file(ctx.label.name + "-kapt-gensrc.jar")
         kapt_generated_stub_jar = ctx.actions.declare_file(ctx.label.name + "-kapt-generated-stub.jar")
         kapt_generated_class_jar = ctx.actions.declare_file(ctx.label.name + "-kapt-generated-class.jar")
@@ -594,7 +595,7 @@ def _run_kt_java_builder_actions(
     java_infos = []
 
     # Build Kotlin
-    if srcs.kt or srcs.src_jars:
+    if has_sources:
         kt_runtime_jar = ctx.actions.declare_file(ctx.label.name + "-kt.jar")
         kt_jdeps = ctx.actions.declare_file(ctx.label.name + "-kt.jdeps")
         if not "kt_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_use_abi_jars == True:

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -554,10 +554,10 @@ def _run_kt_java_builder_actions(
     compile_jars = []
     output_jars = []
     kt_stubs_for_java = []
-    has_sources = srcs.kt or srcs.src_jars
+    has_kt_sources = srcs.kt or srcs.src_jars
 
     # Run KAPT
-    if has_sources and annotation_processors:
+    if has_kt_sources and annotation_processors:
         ap_generated_src_jar = ctx.actions.declare_file(ctx.label.name + "-kapt-gensrc.jar")
         kapt_generated_stub_jar = ctx.actions.declare_file(ctx.label.name + "-kapt-generated-stub.jar")
         kapt_generated_class_jar = ctx.actions.declare_file(ctx.label.name + "-kapt-generated-class.jar")
@@ -595,7 +595,7 @@ def _run_kt_java_builder_actions(
     java_infos = []
 
     # Build Kotlin
-    if has_sources:
+    if has_kt_sources:
         kt_runtime_jar = ctx.actions.declare_file(ctx.label.name + "-kt.jar")
         kt_jdeps = ctx.actions.declare_file(ctx.label.name + "-kt.jdeps")
         if not "kt_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_use_abi_jars == True:


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_kotlin/issues/748﻿

The issue is `srcjars` were not passed to `kapt`. `java` files in a `srcjar` works since `.java` files are handled by `java_common`.

An unfortunate side effect is `srcjars` need to be passed to multiple places even if they are not going to be used. For example, if srcjars contain only `kt` files they need not be passed to `java_common`. 

A better approach would be to unpack the srcjars to examine the content and then decide if they passed to relevant compiler but that might be premature optimisation.