### PR TITLE
Update custom kotlinc distribution docs to reference a newer Kotlin compiler release

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "
 
 kotlin_repositories(
     compiler_release = kotlinc_version(
-        release = "1.3.31", # just the numeric version
-        sha256 = "107325d56315af4f59ff28db6837d03c2660088e3efeb7d4e41f3e01bb848d6a"
+        release = "1.6.21", # just the numeric version
+        sha256 = "632166fed89f3f430482f5aa07f2e20b923b72ef688c8f5a7df3aa1502c6d8ba"
     )
 )
 ```


### PR DESCRIPTION
Referencing a more modern Kotlin compiler release in the custom distribution section.