### PR TITLE
Remove -Xuse-experimental from legacy opts

### DIFF
--- a/src/main/starlark/legacy/kotlin/opts.bzl
+++ b/src/main/starlark/legacy/kotlin/opts.bzl
@@ -25,16 +25,6 @@ _KOPTS = {
             "none": ["-no-stdlib"],
         },
     ),
-    "x_use_experimental": struct(
-        args = dict(
-            default = True,
-            doc = "Allow the experimental language features.",
-        ),
-        type = attr.bool,
-        value_to_flag = {
-            True: ["-Xuse-experimental=kotlin.Experimental"],
-        },
-    ),
     "x_skip_prerelease_check": struct(
         args = dict(
             default = False,

--- a/src/main/starlark/rkt_1_5/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_5/kotlin/opts.bzl
@@ -28,17 +28,7 @@ _KOPTS = {
             "none": ["-no-stdlib"],
         },
     ),
-    "x_use_experimental": struct(
-        args = dict(
-            default = True,
-            doc = "Allow the experimental language features.",
-        ),
-        type = attr.bool,
-        value_to_flag = {
-            True: ["-Xuse-experimental=kotlin.Experimental"],
-        },
-    ),
-    "x_skip_prerelease_check": struct(
+   "x_skip_prerelease_check": struct(
         args = dict(
             default = False,
             doc = "Suppress errors thrown when using pre-release classes.",

--- a/src/main/starlark/rkt_1_5/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_5/kotlin/opts.bzl
@@ -28,7 +28,7 @@ _KOPTS = {
             "none": ["-no-stdlib"],
         },
     ),
-   "x_skip_prerelease_check": struct(
+    "x_skip_prerelease_check": struct(
         args = dict(
             default = False,
             doc = "Suppress errors thrown when using pre-release classes.",


### PR DESCRIPTION
This CLI flag is being removed soon and no longer needed in the opts that we use to build our rules_kotlin releases. This flag ends up causing the Kotlin compiler to spam the console with warnings while building the example apps.