### PR TITLE
Enable windows CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -63,6 +63,15 @@ tasks:
       - test
     build_targets:
       - //...
+  examples-trivial-windows:
+    name: "Example - Trivial (Windows)"
+    platform: windows
+    working_directory: examples/trivial
+    include_json_profile:
+      - build
+      - test
+    test_targets:
+      - //...
   examples-dagger:
     name: "Example - Dagger"
     platform: ubuntu1804

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -27,6 +27,9 @@ tasks:
   macos:
     test_targets:
       - "//:all_tests"
+  windows:
+    test_targets:
+      - "//:all_tests"
   example-android:
     name: "Example - Android"
     platform: ubuntu1804


### PR DESCRIPTION
There are a few issues like #599
which in order to fix without regressing
again it is ugely benefitial to have
some build automation verifying the
intended behaviour. This adds windows
platform testing just as described in
https://github.com/bazelbuild/continuous-integration/tree/master/buildkite