### PR TITLE
Remove repo mapping from "@" in kotlin_repositories

### DIFF
--- a/src/main/starlark/core/repositories/initialize.release.bzl
+++ b/src/main/starlark/core/repositories/initialize.release.bzl
@@ -99,7 +99,6 @@ def kotlin_repositories(
         parent = KOTLIN_RULES,
         repo_mapping = {
             "@dev_io_bazel_rules_kotlin": "@%s" % KOTLIN_RULES.workspace_name,
-            "@": "@%s" % KOTLIN_RULES.workspace_name,
         },
     )
 


### PR DESCRIPTION
The repo "@" must always point to the main repo and cannot be remapped. Attempting to do so will result in a hard error from Bazel 6.0 onwards.

cc @meteorcloudy 