### PR TITLE
Support -Xreport-perf

### DIFF
--- a/src/main/starlark/rkt_1_5/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_5/kotlin/opts.bzl
@@ -170,6 +170,16 @@ _KOPTS = {
         value_to_flag = None,
         map_value_to_flag = _map_optin_class_to_flag,
     ),
+    "x_report_perf": struct(
+        args = dict(
+            default = False,
+            doc = "Report detailed performance statistics",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xreport-perf"],
+        },
+    ),
 }
 
 KotlincOptions = provider(

--- a/src/main/starlark/rkt_1_6/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_6/kotlin/opts.bzl
@@ -170,6 +170,16 @@ _KOPTS = {
             True: ["-Xuse-fir"],
         },
     ),
+    "x_report_perf": struct(
+        args = dict(
+            default = False,
+            doc = "Report detailed performance statistics",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xreport-perf"],
+        },
+    ),
 }
 
 KotlincOptions = provider(

--- a/src/main/starlark/rkt_1_7/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_7/kotlin/opts.bzl
@@ -170,6 +170,16 @@ _KOPTS = {
             True: ["-Xuse-fir"],
         },
     ),
+    "x_report_perf": struct(
+        args = dict(
+            default = False,
+            doc = "Report detailed performance statistics",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xreport-perf"],
+        },
+    ),
 }
 
 KotlincOptions = provider(


### PR DESCRIPTION
Our codebase's compilation is getting really slow and I'd like to give jetbrains more information before filing an issue to see what is taking so long.

See: https://cs.github.com/JetBrains/kotlin/blob/6fc27c22f44d8051bf2e89f1657c0d9741c281c0/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt#L176
