### PR TITLE
Update -Xuse-fir to -Xuse-k2

### DIFF
--- a/src/main/starlark/rkt_1_7/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_7/kotlin/opts.bzl
@@ -165,14 +165,14 @@ _KOPTS = {
         value_to_flag = None,
         map_value_to_flag = _map_optin_class_to_flag,
     ),
-    "x_use_fir": struct(
+    "x_use_k2": struct(
         args = dict(
             default = False,
-            doc = "Compile using the experimental Kotlin Front-end IR. Available from 1.6.",
+            doc = "Compile using experimental K2. K2 is a new compiler pipeline, no compatibility guarantees are yet provided",
         ),
         type = attr.bool,
         value_to_flag = {
-            True: ["-Xuse-fir"],
+            True: ["-Xuse-k2"],
         },
     ),
     "x_backend_threads": struct(


### PR DESCRIPTION
In kotlin 1.7 this flag got renamed and there are deprecation warnings using the old name.

Note that this flag doesn't actually work because they don't support plugins in K2 yet.

See: https://cs.github.com/JetBrains/kotlin/blob/6fc27c22f44d8051bf2e89f1657c0d9741c281c0/compiler/cli/cli-common/src/org/jetbrains/kotlin/cli/common/arguments/CommonCompilerArguments.kt#L298
