### PR TITLE
`ktlint_test` windows support

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -71,6 +71,8 @@ tasks:
       - test
     build_targets:
       - //...
+    test_flags:
+      - "--enable_runfiles"
     test_targets:
       - //...
   examples-dagger:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -51,14 +51,27 @@ tasks:
     working_directory: examples/plugin
     test_targets:
       - //...
-  examples-trivial:
-    name: "Example - Trivial"
+  examples-trivial-ubuntu1804:
+    name: "Example - Trivial (Ubuntu 18.04)"
     platform: ubuntu1804
     working_directory: examples/trivial
     include_json_profile:
       - build
       - test
     build_targets:
+      - //...
+    test_targets:
+      - //...
+  examples-trivial-windows:
+    name: "Example - Trivial (Windows)"
+    platform: windows
+    working_directory: examples/trivial
+    include_json_profile:
+      - build
+      - test
+    build_targets:
+      - //...
+    test_targets:
       - //...
   examples-dagger:
     name: "Example - Dagger"

--- a/examples/trivial/app/app.kt
+++ b/examples/trivial/app/app.kt
@@ -8,21 +8,18 @@ import graphql.GraphQL
 data class Foo(val name: String, val age: Int)
 
 class Query {
-  fun foo(bar: String?) = Foo("$bar!", 42)
+    fun foo(bar: String?) = Foo("$bar!", 42)
 }
 
 class MyApp {
-  companion object {
-    @JvmStatic
-    fun main(args: Array<String>) {
-      val schema = toSchema(queries = listOf(TopLevelObject(Query())),
-          config = SchemaGeneratorConfig(listOf("app")))
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) {
+            val schema = toSchema(queries = listOf(TopLevelObject(Query())), config = SchemaGeneratorConfig(listOf("app")))
+            val graphql = GraphQL.newGraphQL(schema).build()
+            val result = graphql.execute("""{ foo(bar: "baz") { name, age } }""").toSpecification()
 
-      val graphql = GraphQL.newGraphQL(schema).build()
-
-      val result = graphql.execute("""{ foo(bar: "baz") { name, age } }""").toSpecification()
-
-      println(result)
+            println(result)
+        }
     }
-  }
 }

--- a/kotlin/internal/lint/ktlint_test.bzl
+++ b/kotlin/internal/lint/ktlint_test.bzl
@@ -9,8 +9,6 @@ def _ktlint(ctx, srcs, editorconfig):
     This requires running under elevated privileges (Admin rights), Windows 10 Creators Update (1703) or later system version, and enabling developer mode.
 
     ```
-    build --enable_runfiles
-    run --enable_runfiles
     test --enable_runfiles
     ```
 

--- a/kotlin/internal/lint/ktlint_test.bzl
+++ b/kotlin/internal/lint/ktlint_test.bzl
@@ -52,11 +52,11 @@ def _ktlint_test_impl(ctx):
 
     if ctx.target_platform_has_constraint(windows_constraint):
         launcher = create_windows_native_launcher_script(ctx, executable)
-        transitive_files = depset(transitive_files.to_list() + [executable])
+        transitive_files = depset([executable], transitive = [transitive_files])
     else:
         launcher = executable
 
-    files = [ctx.executable._ktlint_tool] + ctx.files.srcs + [launcher]
+    files = [ctx.executable._ktlint_tool] + ctx.files.srcs
     if editorconfig:
         files.append(editorconfig)
 
@@ -64,7 +64,7 @@ def _ktlint_test_impl(ctx):
         DefaultInfo(
             runfiles = ctx.runfiles(
                 files = files,
-                transitive_files = transitive_files
+                transitive_files = transitive_files,
             ).merge(ctx.attr._ktlint_tool[DefaultInfo].default_runfiles),
             executable = launcher,
         ),

--- a/kotlin/internal/lint/ktlint_test.bzl
+++ b/kotlin/internal/lint/ktlint_test.bzl
@@ -1,8 +1,18 @@
 load(":editorconfig.bzl", "get_editorconfig")
 load(":ktlint_config.bzl", "KtlintConfigInfo")
+load("//kotlin/internal/utils:windows.bzl", "create_windows_native_launcher_script")
 
 def _ktlint(ctx, srcs, editorconfig):
     """Generates a test action linting the input files.
+
+    To make the tests running on windows as well you have to add the `--enable_runfiles` flag to your `.bazelrc`.
+    This requires running under elevated privileges (Admin rights), Windows 10 Creators Update (1703) or later system version, and enabling developer mode.
+
+    ```
+    build --enable_runfiles
+    run --enable_runfiles
+    test --enable_runfiles
+    ```
 
     Args:
       ctx: analysis context.
@@ -35,12 +45,18 @@ def _ktlint_test_impl(ctx):
         editorconfig = editorconfig,
     )
 
-    ctx.actions.write(
-        output = ctx.outputs.executable,
-        content = script,
-    )
+    executable = ctx.actions.declare_file(ctx.attr.name)
+    ctx.actions.write(executable, content = script, is_executable = True)
+    transitive_files = ctx.attr._javabase[java_common.JavaRuntimeInfo].files
+    windows_constraint = ctx.attr._windows_constraint[platform_common.ConstraintValueInfo]
 
-    files = [ctx.executable._ktlint_tool] + ctx.files.srcs
+    if ctx.target_platform_has_constraint(windows_constraint):
+        launcher = create_windows_native_launcher_script(ctx, executable)
+        transitive_files = depset(transitive_files.to_list() + [executable])
+    else:
+        launcher = executable
+
+    files = [ctx.executable._ktlint_tool] + ctx.files.srcs + [launcher]
     if editorconfig:
         files.append(editorconfig)
 
@@ -48,9 +64,9 @@ def _ktlint_test_impl(ctx):
         DefaultInfo(
             runfiles = ctx.runfiles(
                 files = files,
-                transitive_files = ctx.attr._javabase[java_common.JavaRuntimeInfo].files,
+                transitive_files = transitive_files
             ).merge(ctx.attr._ktlint_tool[DefaultInfo].default_runfiles),
-            executable = ctx.outputs.executable,
+            executable = launcher,
         ),
     ]
 
@@ -77,10 +93,12 @@ ktlint_test = rule(
         "_javabase": attr.label(
             default = "@bazel_tools//tools/jdk:current_java_runtime",
         ),
+        "_windows_constraint": attr.label(default = "@platforms//os:windows"),
     },
     doc = "Lint Kotlin files, and fail if the linter raises errors.",
     test = True,
     toolchains = [
         "@bazel_tools//tools/jdk:toolchain_type",
+        "@bazel_tools//tools/sh:toolchain_type",
     ],
 )

--- a/kotlin/internal/utils/windows.bzl
+++ b/kotlin/internal/utils/windows.bzl
@@ -1,0 +1,114 @@
+# Copyright 2017 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"Helpers for rules running on windows"
+
+# cmd.exe function for looking up runfiles.
+# Equivalent of the BASH_RLOCATION_FUNCTION in paths.bzl.
+# Use this to write actions that don't require bash.
+# Originally by @meteorcloudy in
+# https://github.com/bazelbuild/rules_nodejs/commit/f06553a
+BATCH_RLOCATION_FUNCTION = r"""
+rem Usage of rlocation function:
+rem        call :rlocation <runfile_path> <abs_path>
+rem        The rlocation function maps the given <runfile_path> to its absolute
+rem        path and stores the result in a variable named <abs_path>.
+rem        This function fails if the <runfile_path> doesn't exist in mainifest
+rem        file.
+:: Start of rlocation
+goto :rlocation_end
+:rlocation
+if "%~2" equ "" (
+  echo>&2 ERROR: Expected two arguments for rlocation function.
+  exit 1
+)
+if "%RUNFILES_MANIFEST_ONLY%" neq "1" (
+  set %~2=%~1
+  exit /b 0
+)
+if exist "%RUNFILES_DIR%" (
+  set RUNFILES_MANIFEST_FILE=%RUNFILES_DIR%_manifest
+)
+if "%RUNFILES_MANIFEST_FILE%" equ "" (
+  set RUNFILES_MANIFEST_FILE=%~f0.runfiles\MANIFEST
+)
+if not exist "%RUNFILES_MANIFEST_FILE%" (
+  set RUNFILES_MANIFEST_FILE=%~f0.runfiles_manifest
+)
+set MF=%RUNFILES_MANIFEST_FILE:/=\%
+if not exist "%MF%" (
+  echo>&2 ERROR: Manifest file %MF% does not exist.
+  exit 1
+)
+set runfile_path=%~1
+for /F "tokens=2* usebackq" %%i in (`%SYSTEMROOT%\system32\findstr.exe /l /c:"!runfile_path! " "%MF%"`) do (
+  set abs_path=%%i
+)
+if "!abs_path!" equ "" (
+  echo>&2 ERROR: !runfile_path! not found in runfiles manifest
+  exit 1
+)
+set %~2=!abs_path!
+exit /b 0
+:rlocation_end
+:: End of rlocation
+"""
+
+def _to_manifest_path(ctx, file):
+    if file.short_path.startswith("../"):
+        return file.short_path[3:]
+    else:
+        return ctx.workspace_name + "/" + file.short_path
+
+def create_windows_native_launcher_script(ctx, shell_script):
+    """Create a Windows Batch file to launch the given shell script.
+
+    The rule should specify @bazel_tools//tools/sh:toolchain_type as a required toolchain.
+
+    Args:
+        ctx: Rule context
+        shell_script: The bash launcher script
+
+    Returns:
+        A windows launcher script
+    """
+    name = shell_script.basename
+    if name.endswith(".sh"):
+        name = name[:-3]
+    win_launcher = ctx.actions.declare_file(name + ".bat", sibling = shell_script)
+    ctx.actions.write(
+        output = win_launcher,
+        content = r"""@echo off
+SETLOCAL ENABLEEXTENSIONS
+SETLOCAL ENABLEDELAYEDEXPANSION
+set RUNFILES_MANIFEST_ONLY=1
+{rlocation_function}
+call :rlocation "{sh_script}" run_script
+for %%a in ("{bash_bin}") do set "bash_bin_dir=%%~dpa"
+set PATH=%bash_bin_dir%;%PATH%
+set args=%*
+rem Escape \ and * in args before passsing it with double quote
+if defined args (
+  set args=!args:\=\\\\!
+  set args=!args:"=\"!
+)
+"{bash_bin}" -c "!run_script! !args!"
+""".format(
+            bash_bin = ctx.toolchains["@bazel_tools//tools/sh:toolchain_type"].path,
+            sh_script = _to_manifest_path(ctx, shell_script),
+            rlocation_function = BATCH_RLOCATION_FUNCTION,
+        ),
+        is_executable = True,
+    )
+    return win_launcher


### PR DESCRIPTION
This enables windows linting support with the `ktlint_test` rule.
Previously this rule would fail such as:

```
cd examples/trivial && bazel test //... --enable_runfiles -s --test_output=all
ERROR(tools/test/windows/tw.cc:1294) ERROR: src/main/native/windows/process.cc(202): CreateProcessW("C:\users\xxxx\s7xd2g5q\execroot\__main__\bazel-out\x64_windows-fastbuild\bin\app\lint_test.runfiles\__main__\app\lint_test"): %1 ist keine zulssige Win32-Anwendung.
 (error: 193)
ERROR(tools/test/windows/tw.cc:1451) Failed to start test process (arg: C:\users\xxxx\_bazel_xxxx\s7xd2g5q\execroot\__main__\bazel-out\x64_windows-fastbuild\bin\app\lint_test.runfiles\__main__\app\lint_test)
```

Now it runs successfully. However, the actual files being linted there fail the linter due to wrong indentation.
<del>I'll probably also submit a PR that fixes indentation so we can run `test //...` on CI for the trivial examples.</del>
Included in this PR now is also the CI changes to proof that it works.