### PR TITLE
Support multiple `kt_android_library` targets with same package name.

### DIFF
--- a/examples/android/libKtAndroid/BUILD.bazel
+++ b/examples/android/libKtAndroid/BUILD.bazel
@@ -32,8 +32,16 @@ kt_android_library(
     tags = ["trace"],
     visibility = ["//visibility:public"],
     deps = [
+        ":res2",
         "@maven//:androidx_appcompat_appcompat",
         "@maven//:com_google_auto_value_auto_value_annotations",
         "@maven//:org_jetbrains_kotlinx_kotlinx_serialization_runtime",
     ],
+)
+
+android_library(
+    name = "res2",
+    custom_package = "examples.android.lib",
+    manifest = "src/main/AndroidManifest.xml",
+    resource_files = glob(["res2/**"]),
 )

--- a/examples/android/libKtAndroid/res2/values/strings.xml
+++ b/examples/android/libKtAndroid/res2/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="hello">hello?</string>
+</resources>

--- a/examples/android/libKtAndroid/src/main/java/examples/android/lib/MainActivity.kt
+++ b/examples/android/libKtAndroid/src/main/java/examples/android/lib/MainActivity.kt
@@ -17,7 +17,7 @@ class MainActivity : AppCompatActivity() {
     setContentView(parent, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
     AlertDialog.Builder(this)
       .setTitle(this.getString(R.string.where_you_at))
-      .setMessage("Blah blah blah?")
+      .setMessage("Blah blah blah? " + getString(R.string.hello))
       .show()
     // Ensure Serialization plugin has run and generated code correctly.
     Data.serializer()

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -53,7 +53,7 @@ def _kt_android_artifact(
     _kt_jvm_library(
         name = kt_name,
         srcs = srcs,
-        deps = base_deps + [base_name],
+        deps = [base_name] + base_deps,
         resources = resources,
         plugins = plugins,
         associates = associates,


### PR DESCRIPTION
When two `kt_android_library` or `android_library` has the same package name either provided via `custom_package` or due to same package name in `AndroidManifest.xml`, `R` class fields from current module's resources were not compilable due to order of jars appearing in `--direct_dependencies`. 

The current module's resources jar would contain merged `R` class from all dependencies but because it appears later in the list, the dependencies' `R` class is used which does not contain merged R class. The problem only appears when two targets contains the same package name.

The fix is similar to one [applied](https://github.com/bazelbuild/bazel/blob/525df32b5dc60448e1abcd3d537ed3454a841946/src/main/java/com/google/devtools/build/lib/rules/android/AndroidCommon.java#L512-L513) in Bazel 

This PR ensures the merged resources jar always comes ensuring order in deps attribute
