### PR TITLE
Check if `default_jvm_opts` exists in `ctx.fragments.java`

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -223,7 +223,9 @@ def kt_jvm_library_impl(ctx):
 
 def kt_jvm_binary_impl(ctx):
     providers = _kt_jvm_produce_jar_actions(ctx, "kt_jvm_binary")
-    jvm_flags = ctx.fragments.java.default_jvm_opts
+    jvm_flags = []
+    if hasattr(ctx.fragments.java, "default_jvm_opts"):
+        jvm_flags = ctx.fragments.java.default_jvm_opts
     jvm_flags.extend(ctx.attr.jvm_flags)
     _write_launcher_action(
         ctx,
@@ -275,7 +277,9 @@ def kt_jvm_junit_test_impl(ctx):
                         test_class = elements[1].split(".")[0].replace("/", ".")
                         break
 
-    jvm_flags = ctx.fragments.java.default_jvm_opts
+    jvm_flags = []
+    if hasattr(ctx.fragments.java, "default_jvm_opts"):
+        jvm_flags = ctx.fragments.java.default_jvm_opts
     jvm_flags.extend(ctx.attr.jvm_flags)
     coverage_metadata = _write_launcher_action(
         ctx,


### PR DESCRIPTION
To make the changes in PRs: https://github.com/bazelbuild/rules_kotlin/pull/782 and https://github.com/bazelbuild/rules_kotlin/pull/689 backward compatible, we add a check if `default_jvm_opts` exists in `ctx.fragments.java` before using it.