### PR TITLE
Fix some compiler warnings in JdepsGenExtension

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -82,11 +82,11 @@ class JdepsGenExtension(
       return when (val sourceElement: SourceElement = descriptor.source) {
         is JavaSourceElement ->
           if (sourceElement.javaElement is BinaryJavaClass) {
-            (sourceElement.javaElement as BinaryJavaClass).virtualFile!!.canonicalPath
+            (sourceElement.javaElement as BinaryJavaClass).virtualFile.canonicalPath
           } else if (sourceElement.javaElement is BinaryJavaField) {
             val containingClass = (sourceElement.javaElement as BinaryJavaField).containingClass
             if (containingClass is BinaryJavaClass) {
-              containingClass.virtualFile!!.canonicalPath
+              containingClass.virtualFile.canonicalPath
             } else {
               null
             }


### PR DESCRIPTION
```
INFO: From Executing genrule //src/main/kotlin/io/bazel/kotlin/plugin/jdeps:jdeps-gen-lib_jar:
src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt:85:71: warning: unnecessary non-null assertion (!!) on a non-null receiver of type VirtualFile
            (sourceElement.javaElement as BinaryJavaClass).virtualFile!!.canonicalPath
                                                                      ^
src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt:89:42: warning: unnecessary non-null assertion (!!) on a non-null receiver of type VirtualFile
              containingClass.virtualFile!!.canonicalPath
                                         ^
INFO: From Executing genrule //src/main/kotlin/io/bazel/kotlin/plugin/jdeps:jdeps-gen-lib_jar [for host]:
src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt:85:71: warning: unnecessary non-null assertion (!!) on a non-null receiver of type VirtualFile
            (sourceElement.javaElement as BinaryJavaClass).virtualFile!!.canonicalPath
                                                                      ^
src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt:89:42: warning: unnecessary non-null assertion (!!) on a non-null receiver of type VirtualFile
              containingClass.virtualFile!!.canonicalPath
                                         ^
INFO: From Building externa
```