### PR TITLE
Allow make variable substitution in kt_compiler_plugin

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -223,7 +223,9 @@ def kt_jvm_library_impl(ctx):
 
 def kt_jvm_binary_impl(ctx):
     providers = _kt_jvm_produce_jar_actions(ctx, "kt_jvm_binary")
-    jvm_flags = ctx.fragments.java.default_jvm_opts
+    jvm_flags = []
+    if hasattr(ctx.fragments.java, "default_jvm_opts"):
+        jvm_flags = ctx.fragments.java.default_jvm_opts
     jvm_flags.extend(ctx.attr.jvm_flags)
     _write_launcher_action(
         ctx,
@@ -275,7 +277,9 @@ def kt_jvm_junit_test_impl(ctx):
                         test_class = elements[1].split(".")[0].replace("/", ".")
                         break
 
-    jvm_flags = ctx.fragments.java.default_jvm_opts
+    jvm_flags = []
+    if hasattr(ctx.fragments.java, "default_jvm_opts"):
+        jvm_flags = ctx.fragments.java.default_jvm_opts
     jvm_flags.extend(ctx.attr.jvm_flags)
     coverage_metadata = _write_launcher_action(
         ctx,
@@ -380,7 +384,7 @@ def kt_compiler_plugin_impl(ctx):
     for (k, v) in ctx.attr.options.items():
         if "=" in k:
             fail("kt_compiler_plugin options keys cannot contain the = symbol")
-        options.append(struct(id = plugin_id, value = "%s=%s" % (k, v)))
+        options.append(struct(id = plugin_id, value = "%s=%s" % (k, ctx.expand_location(v))))
 
     if not (ctx.attr.compile_phase or ctx.attr.stubs_phase):
         fail("Plugin must execute during in one or more phases: stubs_phase, compile_phase")


### PR DESCRIPTION
It would be useful being able to use variable substitution in the plugin rule. I had some issues with the `{generatedSources}` and `{generatedClasses}` templates not returning proper directories in the bazel output dirs. To work around this, I added variable substition which allows me to write something like this:

```
kt_compiler_plugin(
    name = "kotlin_semanticdb_plugin",
    id = "my-id",
    options = {
        "targetroot": "$(execpath :some-rule)",
    },
    deps = [
        ":some-rule",
    ],
)
```

which gives me access to the execroot where I can output artifacts produced by the compiler plugin. I couldn't figure out any other ways to do this. The artifacts produced by the plugin will not be used by downstream targets. They will be picked up by a separate tool scraping the bazel-out folder after the build.

Any other ideas of implementing the thing I want or is this a reasonable change?