### PR TITLE
Add kt_kotlinc_options for additional bytecode generation options

### DIFF
--- a/src/main/starlark/rkt_1_4/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_4/kotlin/opts.bzl
@@ -81,6 +81,36 @@ _KOPTS = {
             "all": ["-Xjvm-default=all"],
         },
     ),
+    "x_no_call_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertions for arguments of platform types",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-call-assertions"],
+        },
+    ),
+    "x_no_param_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertions on parameters of methods accessible from Java",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-param-assertions"],
+        },
+    ),
+    "x_no_receiver_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertion for extension receiver arguments of platform types",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-receiver-assertions"],
+        },
+    ),
     "x_no_optimized_callable_references": struct(
         args = dict(
             default = False,

--- a/src/main/starlark/rkt_1_5/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_5/kotlin/opts.bzl
@@ -84,6 +84,36 @@ _KOPTS = {
             "all": ["-Xjvm-default=all"],
         },
     ),
+    "x_no_call_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertions for arguments of platform types",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-call-assertions"],
+        },
+    ),
+    "x_no_param_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertions on parameters of methods accessible from Java",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-param-assertions"],
+        },
+    ),
+    "x_no_receiver_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertion for extension receiver arguments of platform types",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-receiver-assertions"],
+        },
+    ),
     "x_no_optimized_callable_references": struct(
         args = dict(
             default = False,

--- a/src/main/starlark/rkt_1_6/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_6/kotlin/opts.bzl
@@ -79,6 +79,36 @@ _KOPTS = {
             "all": ["-Xjvm-default=all"],
         },
     ),
+    "x_no_call_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertions for arguments of platform types",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-call-assertions"],
+        },
+    ),
+    "x_no_param_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertions on parameters of methods accessible from Java",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-param-assertions"],
+        },
+    ),
+    "x_no_receiver_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertion for extension receiver arguments of platform types",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-receiver-assertions"],
+        },
+    ),
     "x_no_optimized_callable_references": struct(
         args = dict(
             default = False,

--- a/src/main/starlark/rkt_1_7/kotlin/opts.bzl
+++ b/src/main/starlark/rkt_1_7/kotlin/opts.bzl
@@ -79,6 +79,36 @@ _KOPTS = {
             "all": ["-Xjvm-default=all"],
         },
     ),
+    "x_no_call_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertions for arguments of platform types",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-call-assertions"],
+        },
+    ),
+    "x_no_param_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertions on parameters of methods accessible from Java",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-param-assertions"],
+        },
+    ),
+    "x_no_receiver_assertions": struct(
+        args = dict(
+            default = False,
+            doc = "Don't generate not-null assertion for extension receiver arguments of platform types",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xno-receiver-assertions"],
+        },
+    ),
     "x_no_optimized_callable_references": struct(
         args = dict(
             default = False,


### PR DESCRIPTION
This is a pull request addressing #801.

It would be great if this can make it into ``v1.7.0``. These are options that affect bytecode generation and, in specific performance-critical code, measurably increases performance.
