### PR TITLE
cleanup: don't pull pre-release java templates

### DIFF
--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -136,7 +136,8 @@ _implicit_deps = {
     ),
     "_java_stub_template": attr.label(
         cfg = "exec",
-        default = Label("@kt_java_stub_template//file"),
+        default = Label("@bazel_tools//tools/java:java_stub_template.txt"),
+        allow_files = True,
     ),
     "_toolchain": attr.label(
         doc = """The Kotlin JVM Runtime. it's only purpose is to enable the Android native rules to discover the Kotlin

--- a/src/main/starlark/core/repositories/initialize.release.bzl
+++ b/src/main/starlark/core/repositories/initialize.release.bzl
@@ -52,15 +52,6 @@ def kotlin_repositories(
         kotlin_rules = RULES_KOTLIN.workspace_name,
     )
 
-    http_file(
-        name = "kt_java_stub_template",
-        urls = [("https://raw.githubusercontent.com/bazelbuild/bazel/" +
-                 versions.BAZEL_JAVA_LAUNCHER_VERSION +
-                 "/src/main/java/com/google/devtools/build/lib/bazel/rules/java/" +
-                 "java_stub_template.txt")],
-        sha256 = "ab1370fd990a8bff61a83c7bd94746a3401a6d5d2299e54b1b6bc02db4f87f68",
-    )
-
     maybe(
         http_file,
         name = "com_github_pinterest_ktlint",


### PR DESCRIPTION
java template is exposed by bazel it self, and should point to whatever
the current release of bazel has, instead of pulling a pre-5.x version.