### PR TITLE
pass exec_properties to underlying android_local_test macro

### DIFF
--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -94,6 +94,7 @@ def kt_android_local_test(
         shard_count = None,
         visibility = None,
         testonly = True,
+        exec_properties = None,
         **kwargs):
     """Creates a testable Android sandwich library.
 
@@ -119,4 +120,5 @@ def kt_android_local_test(
         manifest_values = manifest_values,
         tags = kwargs.get("tags", default = None),
         testonly = testonly,
+        exec_properties = exec_properties,
     )

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -29,6 +29,7 @@ def _kt_android_artifact(
         javac_opts = None,
         enable_data_binding = False,
         tags = [],
+        exec_properties = None,
         **kwargs):
     """Delegates Android related build attributes to the native rules but uses the Kotlin builder to compile Java and
     Kotlin srcs. Returns a sequence of labels that a wrapping macro should export.
@@ -48,6 +49,7 @@ def _kt_android_artifact(
         deps = deps if enable_data_binding else [],
         enable_data_binding = enable_data_binding,
         tags = tags,
+        exec_properties = exec_properties,
         **kwargs
     )
     _kt_jvm_library(
@@ -62,10 +64,11 @@ def _kt_android_artifact(
         kotlinc_opts = kotlinc_opts,
         javac_opts = javac_opts,
         tags = tags,
+        exec_properties = exec_properties,
     )
     return [base_name, kt_name]
 
-def kt_android_library(name, exports = [], visibility = None, **kwargs):
+def kt_android_library(name, exports = [], visibility = None, exec_properties = None, **kwargs):
     """Creates an Android sandwich library.
 
     `srcs`, `deps`, `plugins` are routed to `kt_jvm_library` the other android
@@ -76,10 +79,11 @@ def kt_android_library(name, exports = [], visibility = None, **kwargs):
     # buildifier: disable=native-android
     native.android_library(
         name = name,
-        exports = exports + _kt_android_artifact(name, **kwargs),
+        exports = exports + _kt_android_artifact(name, exec_properties = exec_properties, **kwargs),
         visibility = visibility,
         tags = kwargs.get("tags", default = None),
         testonly = kwargs.get("testonly", default = 0),
+        exec_properties = exec_properties,
     )
 
 def kt_android_local_test(

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -107,7 +107,7 @@ def kt_android_local_test(
     # buildifier: disable=native-android
     native.android_local_test(
         name = name,
-        deps = kwargs.get("deps", []) + _kt_android_artifact(name = name, testonly = testonly, **kwargs),
+        deps = kwargs.get("deps", []) + _kt_android_artifact(name = name, testonly = testonly, exec_properties = exec_properties, **kwargs),
         jvm_flags = jvm_flags,
         test_class = test_class,
         visibility = visibility,


### PR DESCRIPTION
`exec_properties` is supported by `android_local_test`, it should be supported by `kt_android_local_test` too.