### PR TITLE
Add `-XX:-MaxFDLimit` to builder binaries to allow it use system open files limit

### DIFF
--- a/src/main/kotlin/BUILD.release.bazel
+++ b/src/main/kotlin/BUILD.release.bazel
@@ -43,6 +43,10 @@ java_binary(
         "@com_github_jetbrains_kotlin//:lib/jvm-abi-gen.jar",
         "@com_github_jetbrains_kotlin//:lib/kotlin-compiler.jar",
     ],
+    jvm_flags = [
+        "-XX:-MaxFDLimit",
+        "-XX:+IgnoreUnrecognizedVMOptions",
+    ],
     main_class = "io.bazel.kotlin.builder.cmd.Build",
     visibility = ["//visibility:public"],
     runtime_deps = [
@@ -53,6 +57,10 @@ java_binary(
 
 java_binary(
     name = "jdeps_merger",
+    jvm_flags = [
+        "-XX:-MaxFDLimit",
+        "-XX:+IgnoreUnrecognizedVMOptions",
+    ],
     main_class = "io.bazel.kotlin.builder.cmd.MergeJdeps",
     visibility = ["//visibility:public"],
     runtime_deps = [":jdeps_merger_worker"],


### PR DESCRIPTION
When compiling large modules we noticed `KotlinKapt` would fail with `Too many open files` on MacOS. 

We increased the shell limit manually from default 256 to 65536. Verified by running `ulimit -a` 

```bash
-t: cpu time (seconds)              unlimited
-f: file size (blocks)              unlimited
-d: data seg size (kbytes)          unlimited
-s: stack size (kbytes)             8176
-c: core file size (blocks)         0
-v: address space (kbytes)          unlimited
-l: locked-in-memory size (kbytes)  unlimited
-u: processes                       5333
-n: file descriptors                65536
```

Even then the worker action failed, it seems that JVM has its own FD limit which can be changed to use the system/shell limits via `-XX:-MaxFDLimit` arg. Adding these to `java_binary` targets worked for us.

References:

- https://wilsonmar.github.io/maximum-limits/
- https://stackoverflow.com/a/33838568
- https://github.com/gradle/gradle/issues/17274
- https://github.com/bazelbuild/bazel/issues/15278