### PR TITLE
Fix jdeps tracking case for class extension

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -189,7 +189,9 @@ class JdepsGenExtension(
           descriptor.annotations.forEach { annotation ->
             collectTypeReferences(annotation.type)
           }
-          descriptor.extensionReceiverParameter?.value?.type?.let { collectTypeReferences(it) }
+          descriptor.extensionReceiverParameter?.value?.type?.let {
+            collectTypeReferences(it)
+          }
         }
         is PropertyDescriptor -> {
           collectTypeReferences(descriptor.type)

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -16,6 +16,7 @@ import org.jetbrains.kotlin.descriptors.ModuleDescriptor
 import org.jetbrains.kotlin.descriptors.FunctionDescriptor
 import org.jetbrains.kotlin.descriptors.ParameterDescriptor
 import org.jetbrains.kotlin.descriptors.PropertyDescriptor
+import org.jetbrains.kotlin.descriptors.ReceiverParameterDescriptor
 import org.jetbrains.kotlin.descriptors.SourceElement
 import org.jetbrains.kotlin.descriptors.impl.LocalVariableDescriptor
 import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor
@@ -39,6 +40,7 @@ import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
 import org.jetbrains.kotlin.resolve.calls.util.FakeCallableDescriptorForObject
 import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
 import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
+import org.jetbrains.kotlin.resolve.scopes.receivers.ExtensionReceiver
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeConstructor
@@ -187,6 +189,7 @@ class JdepsGenExtension(
           descriptor.annotations.forEach { annotation ->
             collectTypeReferences(annotation.type)
           }
+          descriptor.extensionReceiverParameter?.value?.type?.let { collectTypeReferences(it) }
         }
         is PropertyDescriptor -> {
           collectTypeReferences(descriptor.type)


### PR DESCRIPTION
'A?.foo() in class B' now tracks class A in jdeps.