### PR TITLE
Fix RBE builds on master

### DIFF
--- a/src/main/starlark/core/repositories/download.bzl
+++ b/src/main/starlark/core/repositories/download.bzl
@@ -58,10 +58,11 @@ def kt_download_local_dev_dependencies():
         ],
     )
 
+    # This tarball intentionally does not have a SHA256 because the upstream URL can change without notice
+    # For more context: https://github.com/bazelbuild/bazel-toolchains/blob/0c1f7c3c5f9e63f1e0ee91738b964937eea2d3e0/WORKSPACE#L28-L32
     maybe(
         http_archive,
         name = "buildkite_config",
-        sha256 = versions.RBE.SHA,
         urls = versions.RBE.URLS,
     )
 

--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -65,7 +65,8 @@ versions = struct(
     },
     # To update: https://github.com/bazelbuild/bazel-toolchains#latest-bazel-and-latest-ubuntu-1604-container
     RBE = struct(
-        SHA = "6ac1093b2c8c1199c038697ca726f48390a17bbe0d3108b8b508611ce1e6c1b5",
+        # This tarball intentionally does not have a SHA256 because the upstream URL can change without notice
+        # For more context: https://github.com/bazelbuild/bazel-toolchains/blob/0c1f7c3c5f9e63f1e0ee91738b964937eea2d3e0/WORKSPACE#L28-L32
         URLS = ["https://storage.googleapis.com/rbe-toolchain/bazel-configs/rbe-ubuntu1604/latest/rbe_default.tar"],
     ),
 )


### PR DESCRIPTION
The `sha256` for this URL has changed causing PRs and master to fail unexpectedly. 

As mentioned in the docs for this URL, the tarball can change without notice and should not have a hardcoded sha256. https://github.com/bazelbuild/bazel-toolchains/blob/0c1f7c3c5f9e63f1e0ee91738b964937eea2d3e0/WORKSPACE#L28-L32

The CI failures can be seen here: https://buildkite.com/bazel/rules-kotlin-kotlin/builds/2701#0182955e-df6f-46e3-8edc-94a550d0fb58/227-260