### PR TITLE
[KtLint] Add CI job for enforcing Kotlin formatting

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -105,4 +105,11 @@ tasks:
     platform: ubuntu1804
     build_targets:
       - //kotlin:stardoc
+  ktlint:
+    name: KtLint formatting
+    platform: ubuntu1804
+    test_targets:
+      - //...
+    test_flags:
+      - "--enable_runfiles"
 

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -111,5 +111,5 @@ tasks:
     test_targets:
       - //...
     test_flags:
-      - "--enable_runfiles"
+      - "----test_tag_filters ktlint"
 

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -111,5 +111,4 @@ tasks:
     test_targets:
       - //...
     test_flags:
-      - "--test_tag_filters ktlint"
-
+      - "--test_tag_filters=ktlint"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -106,10 +106,10 @@ tasks:
     build_targets:
       - //kotlin:stardoc
   ktlint:
-    name: KtLint formatting
+    name: KtLint
     platform: ubuntu1804
     test_targets:
       - //...
     test_flags:
-      - "----test_tag_filters ktlint"
+      - "--test_tag_filters ktlint"
 

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -112,3 +112,4 @@ tasks:
       - //...
     test_flags:
       - "--test_tag_filters=ktlint"
+      - "--test_output=errors"

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JacocoInstrumentation.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JacocoInstrumentation.kt
@@ -12,63 +12,66 @@ import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 
-internal fun JvmCompilationTask.createCoverageInstrumentedJar() {
-  val instrumentedClassesDirectory = Paths.get(directories.coverageMetadataClasses)
-  Files.createDirectories(instrumentedClassesDirectory)
+object JacocoInstrumentation {
 
-  val instr = Instrumenter(OfflineInstrumentationAccessGenerator())
+  internal fun JvmCompilationTask.createCoverageInstrumentedJar() {
+    val instrumentedClassesDirectory = Paths.get(directories.coverageMetadataClasses)
+    Files.createDirectories(instrumentedClassesDirectory)
 
-  instrumentRecursively(instr, instrumentedClassesDirectory, Paths.get(directories.classes))
-  instrumentRecursively(instr, instrumentedClassesDirectory, Paths.get(directories.javaClasses))
-  instrumentRecursively(
-    instr,
-    instrumentedClassesDirectory,
-    Paths.get(directories.generatedClasses),
-  )
+    val instr = Instrumenter(OfflineInstrumentationAccessGenerator())
 
-  val pathsForCoverage = instrumentedClassesDirectory.resolve(
-    "${Paths.get(outputs.jar).fileName}-paths-for-coverage.txt",
-  )
-  Files.write(
-    pathsForCoverage,
-    inputs.javaSourcesList + inputs.kotlinSourcesList,
-  )
+    instrumentRecursively(instr, instrumentedClassesDirectory, Paths.get(directories.classes))
+    instrumentRecursively(instr, instrumentedClassesDirectory, Paths.get(directories.javaClasses))
+    instrumentRecursively(
+      instr,
+      instrumentedClassesDirectory,
+      Paths.get(directories.generatedClasses),
+    )
 
-  JarCreator(
-    path = Paths.get(outputs.jar),
-    normalize = true,
-    verbose = false,
-  ).also {
-    it.addDirectory(Paths.get(directories.classes))
-    it.addDirectory(Paths.get(directories.javaClasses))
-    it.addDirectory(Paths.get(directories.generatedClasses))
-    it.addDirectory(instrumentedClassesDirectory)
-    it.setJarOwner(info.label, info.bazelRuleKind)
-    it.execute()
-  }
-}
+    val pathsForCoverage = instrumentedClassesDirectory.resolve(
+      "${Paths.get(outputs.jar).fileName}-paths-for-coverage.txt",
+    )
+    Files.write(
+      pathsForCoverage,
+      inputs.javaSourcesList + inputs.kotlinSourcesList,
+    )
 
-private fun instrumentRecursively(instr: Instrumenter, metadataDir: Path, root: Path) {
-  val visitor = object : SimpleFileVisitor<Path>() {
-    override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
-      if (file.toFile().extension != "class") {
-        return FileVisitResult.CONTINUE
-      }
-
-      val absoluteUninstrumentedCopy = Paths.get("$file.uninstrumented")
-      val uninstrumentedCopy = metadataDir.resolve(root.relativize(absoluteUninstrumentedCopy))
-
-      Files.createDirectories(uninstrumentedCopy.parent)
-      Files.move(file, uninstrumentedCopy)
-
-      Files.newInputStream(uninstrumentedCopy).buffered().use { input ->
-        Files.newOutputStream(file).buffered().use { output ->
-          instr.instrument(input, output, file.toString())
-        }
-      }
-
-      return FileVisitResult.CONTINUE
+    JarCreator(
+      path = Paths.get(outputs.jar),
+      normalize = true,
+      verbose = false,
+    ).also {
+      it.addDirectory(Paths.get(directories.classes))
+      it.addDirectory(Paths.get(directories.javaClasses))
+      it.addDirectory(Paths.get(directories.generatedClasses))
+      it.addDirectory(instrumentedClassesDirectory)
+      it.setJarOwner(info.label, info.bazelRuleKind)
+      it.execute()
     }
   }
-  Files.walkFileTree(root, visitor)
+
+  private fun instrumentRecursively(instr: Instrumenter, metadataDir: Path, root: Path) {
+    val visitor = object : SimpleFileVisitor<Path>() {
+      override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+        if (file.toFile().extension != "class") {
+          return FileVisitResult.CONTINUE
+        }
+
+        val absoluteUninstrumentedCopy = Paths.get("$file.uninstrumented")
+        val uninstrumentedCopy = metadataDir.resolve(root.relativize(absoluteUninstrumentedCopy))
+
+        Files.createDirectories(uninstrumentedCopy.parent)
+        Files.move(file, uninstrumentedCopy)
+
+        Files.newInputStream(uninstrumentedCopy).buffered().use { input ->
+          Files.newOutputStream(file).buffered().use { output ->
+            instr.instrument(input, output, file.toString())
+          }
+        }
+
+        return FileVisitResult.CONTINUE
+      }
+    }
+    Files.walkFileTree(root, visitor)
+  }
 }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JacocoInstrumentation.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JacocoInstrumentation.kt
@@ -12,66 +12,63 @@ import java.nio.file.Paths
 import java.nio.file.SimpleFileVisitor
 import java.nio.file.attribute.BasicFileAttributes
 
-object JacocoInstrumentation {
+internal fun JvmCompilationTask.createCoverageInstrumentedJar() {
+  val instrumentedClassesDirectory = Paths.get(directories.coverageMetadataClasses)
+  Files.createDirectories(instrumentedClassesDirectory)
 
-  internal fun JvmCompilationTask.createCoverageInstrumentedJar() {
-    val instrumentedClassesDirectory = Paths.get(directories.coverageMetadataClasses)
-    Files.createDirectories(instrumentedClassesDirectory)
+  val instr = Instrumenter(OfflineInstrumentationAccessGenerator())
 
-    val instr = Instrumenter(OfflineInstrumentationAccessGenerator())
+  instrumentRecursively(instr, instrumentedClassesDirectory, Paths.get(directories.classes))
+  instrumentRecursively(instr, instrumentedClassesDirectory, Paths.get(directories.javaClasses))
+  instrumentRecursively(
+    instr,
+    instrumentedClassesDirectory,
+    Paths.get(directories.generatedClasses),
+  )
 
-    instrumentRecursively(instr, instrumentedClassesDirectory, Paths.get(directories.classes))
-    instrumentRecursively(instr, instrumentedClassesDirectory, Paths.get(directories.javaClasses))
-    instrumentRecursively(
-      instr,
-      instrumentedClassesDirectory,
-      Paths.get(directories.generatedClasses),
-    )
+  val pathsForCoverage = instrumentedClassesDirectory.resolve(
+    "${Paths.get(outputs.jar).fileName}-paths-for-coverage.txt",
+  )
+  Files.write(
+    pathsForCoverage,
+    inputs.javaSourcesList + inputs.kotlinSourcesList,
+  )
 
-    val pathsForCoverage = instrumentedClassesDirectory.resolve(
-      "${Paths.get(outputs.jar).fileName}-paths-for-coverage.txt",
-    )
-    Files.write(
-      pathsForCoverage,
-      inputs.javaSourcesList + inputs.kotlinSourcesList,
-    )
-
-    JarCreator(
-      path = Paths.get(outputs.jar),
-      normalize = true,
-      verbose = false,
-    ).also {
-      it.addDirectory(Paths.get(directories.classes))
-      it.addDirectory(Paths.get(directories.javaClasses))
-      it.addDirectory(Paths.get(directories.generatedClasses))
-      it.addDirectory(instrumentedClassesDirectory)
-      it.setJarOwner(info.label, info.bazelRuleKind)
-      it.execute()
-    }
+  JarCreator(
+    path = Paths.get(outputs.jar),
+    normalize = true,
+    verbose = false,
+  ).also {
+    it.addDirectory(Paths.get(directories.classes))
+    it.addDirectory(Paths.get(directories.javaClasses))
+    it.addDirectory(Paths.get(directories.generatedClasses))
+    it.addDirectory(instrumentedClassesDirectory)
+    it.setJarOwner(info.label, info.bazelRuleKind)
+    it.execute()
   }
+}
 
-  private fun instrumentRecursively(instr: Instrumenter, metadataDir: Path, root: Path) {
-    val visitor = object : SimpleFileVisitor<Path>() {
-      override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
-        if (file.toFile().extension != "class") {
-          return FileVisitResult.CONTINUE
-        }
-
-        val absoluteUninstrumentedCopy = Paths.get("$file.uninstrumented")
-        val uninstrumentedCopy = metadataDir.resolve(root.relativize(absoluteUninstrumentedCopy))
-
-        Files.createDirectories(uninstrumentedCopy.parent)
-        Files.move(file, uninstrumentedCopy)
-
-        Files.newInputStream(uninstrumentedCopy).buffered().use { input ->
-          Files.newOutputStream(file).buffered().use { output ->
-            instr.instrument(input, output, file.toString())
-          }
-        }
-
+private fun instrumentRecursively(instr: Instrumenter, metadataDir: Path, root: Path) {
+  val visitor = object : SimpleFileVisitor<Path>() {
+    override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
+      if (file.toFile().extension != "class") {
         return FileVisitResult.CONTINUE
       }
+
+      val absoluteUninstrumentedCopy = Paths.get("$file.uninstrumented")
+      val uninstrumentedCopy = metadataDir.resolve(root.relativize(absoluteUninstrumentedCopy))
+
+      Files.createDirectories(uninstrumentedCopy.parent)
+      Files.move(file, uninstrumentedCopy)
+
+      Files.newInputStream(uninstrumentedCopy).buffered().use { input ->
+        Files.newOutputStream(file).buffered().use { output ->
+          instr.instrument(input, output, file.toString())
+        }
+      }
+
+      return FileVisitResult.CONTINUE
     }
-    Files.walkFileTree(root, visitor)
   }
+  Files.walkFileTree(root, visitor)
 }


### PR DESCRIPTION
Adding a dedicated CI step for running KtLint to dog food our own tooling and to keep all of our Kotlin sources aligned in the codebase.