### PR TITLE
[KtLint] Append editorconfig to the ktlint_fix runfiles

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -19,10 +19,15 @@ exports_files([
     "scripts/noop.sh",
 ])
 
+filegroup(
+    name = "editorconfig",
+    srcs = [".editorconfig"],
+)
+
 ktlint_config(
     name = "ktlint_editorconfig",
     android_rules_enabled = False,
-    editorconfig = ".editorconfig",
+    editorconfig = "//:editorconfig",
     experimental_rules_enabled = False,
     visibility = ["//visibility:public"],
 )

--- a/kotlin/internal/lint/ktlint_fix.bzl
+++ b/kotlin/internal/lint/ktlint_fix.bzl
@@ -107,7 +107,7 @@ SRCS=${{SRCS[@]/#/$BUILD_DIR}}
         content = content,
         is_executable = True,
     )
-    runfiles = ctx.runfiles(files = [ctx.executable._ktlint_tool])
+    runfiles = ctx.runfiles(files = [ctx.executable._ktlint_tool, editorconfig])
 
     return [
         DefaultInfo(

--- a/kotlin/internal/lint/ktlint_fix.bzl
+++ b/kotlin/internal/lint/ktlint_fix.bzl
@@ -107,7 +107,11 @@ SRCS=${{SRCS[@]/#/$BUILD_DIR}}
         content = content,
         is_executable = True,
     )
-    runfiles = ctx.runfiles(files = [ctx.executable._ktlint_tool, editorconfig])
+
+    files = [ctx.executable._ktlint_tool]
+    if editorconfig:
+        files.append(editorconfig)
+    runfiles = ctx.runfiles(files = files)
 
     return [
         DefaultInfo(


### PR DESCRIPTION
Resolves the following KtLint warning when running a ktlint fix command:

```console
rules_kotlin on  master on ☁️
➜ bazel run //src/main/kotlin/io/bazel/kotlin/compiler:compiler_ktlint_fix --subcommands
...
17:42:49.039 [main] WARN com.pinterest.ktlint.core.internal.EditorConfigDefaultsLoader - File or directory '.editorconfig' is not found. Can not load '.editorconfig' properties
```