### PR TITLE
[KtLint] Run ktlint format against all Kotlin sources

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/cmd/Build.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/cmd/Build.kt
@@ -32,7 +32,7 @@ object Build {
             .builder()
             .toolchain(createToolchain())
             .build()
-            .work()
+            .work(),
         )
       }
       .run(::exitProcess)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -43,7 +43,7 @@ import javax.inject.Singleton
 @Suppress("MemberVisibilityCanBePrivate")
 class KotlinBuilder @Inject internal constructor(
   private val jvmTaskExecutor: KotlinJvmTaskExecutor,
-  private val jsTaskExecutor: Kotlin2JsTaskExecutor
+  private val jsTaskExecutor: Kotlin2JsTaskExecutor,
 ) {
   companion object {
     @JvmStatic
@@ -85,13 +85,14 @@ class KotlinBuilder @Inject internal constructor(
       BUILD_KOTLIN("--build_kotlin"),
       STRICT_KOTLIN_DEPS("--strict_kotlin_deps"),
       REDUCED_CLASSPATH_MODE("--reduced_classpath_mode"),
-      INSTRUMENT_COVERAGE("--instrument_coverage");
+      INSTRUMENT_COVERAGE("--instrument_coverage"),
+      ;
     }
   }
 
   fun build(
     taskContext: WorkerContext.TaskContext,
-    args: List<String>
+    args: List<String>,
   ): Int {
     val (argMap, compileContext) = buildContext(taskContext, args)
     var success = false
@@ -102,7 +103,7 @@ class KotlinBuilder @Inject internal constructor(
         Platform.JVM -> executeJvmTask(compileContext, taskContext.directory, argMap)
         Platform.JS -> executeJsTask(compileContext, taskContext.directory, argMap)
         Platform.UNRECOGNIZED -> throw IllegalStateException(
-          "unrecognized platform: ${compileContext.info}"
+          "unrecognized platform: ${compileContext.info}",
         )
       }
       success = true
@@ -119,7 +120,7 @@ class KotlinBuilder @Inject internal constructor(
 
   private fun buildContext(
     ctx: WorkerContext.TaskContext,
-    args: List<String>
+    args: List<String>,
   ): Pair<ArgMap, CompilationTaskContext> {
     check(args.isNotEmpty()) { "expected at least a single arg got: ${args.joinToString(" ")}" }
     val lines = FLAGFILE_RE.matchEntire(args[0])?.groups?.get(1)?.let {
@@ -165,7 +166,7 @@ class KotlinBuilder @Inject internal constructor(
   private fun executeJsTask(
     context: CompilationTaskContext,
     workingDir: Path,
-    argMap: ArgMap
+    argMap: ArgMap,
   ) =
     buildJsTask(context.info, workingDir, argMap).let { jsTask ->
       context.whenTracing { printProto("js task input", jsTask) }
@@ -175,7 +176,7 @@ class KotlinBuilder @Inject internal constructor(
   private fun buildJsTask(
     info: CompilationTaskInfo,
     workingDir: Path,
-    argMap: ArgMap
+    argMap: ArgMap,
   ): JsCompilationTask =
     with(JsCompilationTask.newBuilder()) {
       this.info = info
@@ -200,7 +201,7 @@ class KotlinBuilder @Inject internal constructor(
   private fun executeJvmTask(
     context: CompilationTaskContext,
     workingDir: Path,
-    argMap: ArgMap
+    argMap: ArgMap,
   ) {
     val task = buildJvmTask(context.info, workingDir, argMap)
     context.whenTracing {
@@ -212,14 +213,14 @@ class KotlinBuilder @Inject internal constructor(
   private fun buildJvmTask(
     info: CompilationTaskInfo,
     workingDir: Path,
-    argMap: ArgMap
+    argMap: ArgMap,
   ): JvmCompilationTask =
     JvmCompilationTask.newBuilder().let { root ->
       root.info = info
 
       root.compileKotlin = argMap.mandatorySingle(KotlinBuilderFlags.BUILD_KOTLIN).toBoolean()
       root.instrumentCoverage = argMap.mandatorySingle(
-        KotlinBuilderFlags.INSTRUMENT_COVERAGE
+        KotlinBuilderFlags.INSTRUMENT_COVERAGE,
       ).toBoolean()
 
       with(root.outputsBuilder) {
@@ -245,13 +246,15 @@ class KotlinBuilder @Inject internal constructor(
           workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "classes")).toString()
         javaClasses =
           workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "java_classes")).toString()
-        if (argMap.hasAll(KotlinBuilderFlags.ABI_JAR)) abiClasses =
-          workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "abi_classes")).toString()
+        if (argMap.hasAll(KotlinBuilderFlags.ABI_JAR)) {
+          abiClasses =
+            workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "abi_classes")).toString()
+        }
         generatedClasses =
           workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "generated_classes"))
             .toString()
         temp = workingDir.resolveNewDirectories(
-          getOutputDirPath(moduleName, "temp")
+          getOutputDirPath(moduleName, "temp"),
         ).toString()
         generatedSources =
           workingDir.resolveNewDirectories(getOutputDirPath(moduleName, "generated_sources"))
@@ -269,7 +272,7 @@ class KotlinBuilder @Inject internal constructor(
       with(root.inputsBuilder) {
         addAllClasspath(argMap.mandatory(KotlinBuilderFlags.CLASSPATH))
         addAllDepsArtifacts(
-          argMap.optional(KotlinBuilderFlags.DEPS_ARTIFACTS) ?: emptyList()
+          argMap.optional(KotlinBuilderFlags.DEPS_ARTIFACTS) ?: emptyList(),
         )
         addAllDirectDependencies(argMap.mandatory(KotlinBuilderFlags.DIRECT_DEPENDENCIES))
 
@@ -277,24 +280,24 @@ class KotlinBuilder @Inject internal constructor(
         addAllProcessorpaths(argMap.optional(KotlinBuilderFlags.PROCESSOR_PATH) ?: emptyList())
 
         addAllStubsPluginOptions(
-          argMap.optional(KotlinBuilderFlags.STUBS_PLUGIN_OPTIONS) ?: emptyList()
+          argMap.optional(KotlinBuilderFlags.STUBS_PLUGIN_OPTIONS) ?: emptyList(),
         )
         addAllStubsPluginClasspath(
-          argMap.optional(KotlinBuilderFlags.STUBS_PLUGIN_CLASS_PATH) ?: emptyList()
+          argMap.optional(KotlinBuilderFlags.STUBS_PLUGIN_CLASS_PATH) ?: emptyList(),
         )
 
         addAllCompilerPluginOptions(
-          argMap.optional(KotlinBuilderFlags.COMPILER_PLUGIN_OPTIONS) ?: emptyList()
+          argMap.optional(KotlinBuilderFlags.COMPILER_PLUGIN_OPTIONS) ?: emptyList(),
         )
         addAllCompilerPluginClasspath(
-          argMap.optional(KotlinBuilderFlags.COMPILER_PLUGIN_CLASS_PATH) ?: emptyList()
+          argMap.optional(KotlinBuilderFlags.COMPILER_PLUGIN_CLASS_PATH) ?: emptyList(),
         )
 
         argMap.optional(KotlinBuilderFlags.SOURCES)
           ?.iterator()
           ?.partitionJvmSources(
             { addKotlinSources(it) },
-            { addJavaSources(it) }
+            { addJavaSources(it) },
           )
         argMap.optional(KotlinBuilderFlags.SOURCE_JARS)
           ?.also {
@@ -311,7 +314,7 @@ class KotlinBuilder @Inject internal constructor(
 
   private fun getOutputDirPath(
     moduleName: String,
-    dirName: String
+    dirName: String,
   ) =
     "_kotlinc/${moduleName}_jvm/$dirName"
 }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationArgs.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationArgs.kt
@@ -30,12 +30,12 @@ import java.util.Base64
  */
 class CompilationArgs(
   val args: MutableList<String> = mutableListOf(),
-  private val dfs: FileSystem = FileSystems.getDefault()
+  private val dfs: FileSystem = FileSystems.getDefault(),
 ) {
 
   class StringConditional(
     val value: String,
-    val parent: CompilationArgs
+    val parent: CompilationArgs,
   ) {
     fun notEmpty(conditionalArgs: CompilationArgs.(it: String) -> Unit): CompilationArgs {
       if (value.isNotEmpty()) {
@@ -55,7 +55,7 @@ class CompilationArgs(
   interface SetFlag {
     fun flag(
       name: String,
-      value: String
+      value: String,
     ): SetFlag
   }
 
@@ -65,13 +65,13 @@ class CompilationArgs(
 
   fun plugin(
     p: KotlinToolchain.CompilerPlugin,
-    flagArgs: SetFlag.() -> Unit
+    flagArgs: SetFlag.() -> Unit,
   ): CompilationArgs {
     value("-Xplugin=${p.jarPath}")
     object : SetFlag {
       override fun flag(
         name: String,
-        value: String
+        value: String,
       ): SetFlag {
         args.add("-P")
         args.add("plugin:${p.id}:$name=$value")
@@ -83,7 +83,7 @@ class CompilationArgs(
 
   fun given(
     test: Boolean,
-    conditionalArgs: CompilationArgs.() -> Unit
+    conditionalArgs: CompilationArgs.() -> Unit,
   ): CompilationArgs {
     if (test) {
       this.conditionalArgs()
@@ -96,12 +96,12 @@ class CompilationArgs(
   }
 
   operator fun plus(other: CompilationArgs): CompilationArgs = CompilationArgs(
-    (args.asSequence() + other.args.asSequence()).toMutableList()
+    (args.asSequence() + other.args.asSequence()).toMutableList(),
   )
 
   fun absolutePaths(
     paths: Collection<String>,
-    toArgs: (Sequence<Path>) -> String
+    toArgs: (Sequence<Path>) -> String,
   ): CompilationArgs {
     if (paths.isEmpty()) {
       return this
@@ -110,14 +110,14 @@ class CompilationArgs(
       toArgs(
         paths.asSequence()
           .map { dfs.getPath(it) }
-          .map(Path::toAbsolutePath)
-      )
+          .map(Path::toAbsolutePath),
+      ),
     )
   }
 
   fun paths(
     paths: Collection<String>,
-    toArgs: (Sequence<Path>) -> String
+    toArgs: (Sequence<Path>) -> String,
   ): CompilationArgs {
     if (paths.isEmpty()) {
       return this
@@ -125,8 +125,8 @@ class CompilationArgs(
     return value(
       toArgs(
         paths.asSequence()
-          .map { dfs.getPath(it) }
-      )
+          .map { dfs.getPath(it) },
+      ),
     )
   }
 
@@ -147,7 +147,7 @@ class CompilationArgs(
 
   fun flag(
     key: String,
-    value: () -> String
+    value: () -> String,
   ): CompilationArgs {
     args.add(key)
     args.add(value())
@@ -156,7 +156,7 @@ class CompilationArgs(
 
   fun flag(
     flag: String,
-    value: String
+    value: String,
   ): CompilationArgs {
     args.add(flag)
     args.add(value)
@@ -170,7 +170,7 @@ class CompilationArgs(
 
   fun xFlag(
     flag: String,
-    value: String
+    value: String,
   ): CompilationArgs {
     args.add("-X$flag=$value")
     return this
@@ -179,7 +179,7 @@ class CompilationArgs(
   fun repeatFlag(
     flag: String,
     vararg flagValues: Pair<String, List<String>>,
-    transform: (option: String, value: String) -> String
+    transform: (option: String, value: String) -> String,
   ): CompilationArgs {
     flagValues.forEach { (option, optionValues) ->
       optionValues.forEach {
@@ -194,7 +194,7 @@ class CompilationArgs(
   fun base64Encode(
     flag: String,
     vararg values: Pair<String, List<String>>,
-    transform: (String) -> String = { it }
+    transform: (String) -> String = { it },
   ): CompilationArgs {
     val os = ByteArrayOutputStream()
     val oos = ObjectOutputStream(os)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
@@ -77,7 +77,7 @@ fun JvmCompilationTask.baseArgs(): CompilationArgs {
   return CompilationArgs()
     .flag("-cp")
     .paths(
-      classpath + directories.generatedClasses
+      classpath + directories.generatedClasses,
     ) {
       it.map(Path::toString)
         .joinToString(File.pathSeparator)
@@ -90,7 +90,7 @@ fun JvmCompilationTask.baseArgs(): CompilationArgs {
 
 internal fun JvmCompilationTask.plugins(
   options: List<String>,
-  classpath: List<String>
+  classpath: List<String>,
 ): CompilationArgs =
   CompilationArgs().apply {
     classpath.forEach {
@@ -100,7 +100,7 @@ internal fun JvmCompilationTask.plugins(
     val dirTokens = mapOf(
       "{generatedClasses}" to directories.generatedClasses,
       "{stubs}" to directories.stubs,
-      "{generatedSources}" to directories.generatedSources
+      "{generatedSources}" to directories.generatedSources,
     )
     options.forEach { opt ->
       val formatted = dirTokens.entries.fold(opt) { formatting, (token, value) ->
@@ -111,7 +111,7 @@ internal fun JvmCompilationTask.plugins(
   }
 
 internal fun JvmCompilationTask.preProcessingSteps(
-  context: CompilationTaskContext
+  context: CompilationTaskContext,
 ): JvmCompilationTask {
   return context.execute("expand sources") { expandWithSourceJarSources() }
 }
@@ -134,11 +134,11 @@ internal fun encodeMap(options: Map<String, String>): String {
 internal fun JvmCompilationTask.kaptArgs(
   context: CompilationTaskContext,
   plugins: InternalCompilerPlugins,
-  aptMode: String
+  aptMode: String,
 ): CompilationArgs {
   val javacArgs = mapOf<String, String>(
     "-target" to info.toolchainInfo.jvm.jvmTarget,
-    "-source" to info.toolchainInfo.jvm.jvmTarget
+    "-source" to info.toolchainInfo.jvm.jvmTarget,
   )
   return CompilationArgs().apply {
     xFlag("plugin", plugins.kapt.jarPath)
@@ -152,17 +152,17 @@ internal fun JvmCompilationTask.kaptArgs(
       "correctErrorTypes" to listOf("false"),
       "verbose" to listOf(context.whenTracing { "true" } ?: "false"),
       "apclasspath" to inputs.processorpathsList,
-      "aptMode" to listOf(aptMode)
+      "aptMode" to listOf(aptMode),
     )
     val version = info.toolchainInfo.common.apiVersion.toFloat()
     when {
       version < 1.5 -> base64Encode(
         "-P",
-        *values + ("processors" to inputs.processorsList).asKeyToCommaList()
+        *values + ("processors" to inputs.processorsList).asKeyToCommaList(),
       ) { enc -> "plugin:${plugins.kapt.id}:configuration=$enc" }
       else -> repeatFlag(
         "-P",
-        *values + ("processors" to inputs.processorsList)
+        *values + ("processors" to inputs.processorsList),
       ) { option, value ->
         "plugin:${plugins.kapt.id}:$option=$value"
       }
@@ -176,7 +176,7 @@ private fun Pair<String, List<String>>.asKeyToCommaList() =
 internal fun JvmCompilationTask.runPlugins(
   context: CompilationTaskContext,
   plugins: InternalCompilerPlugins,
-  compiler: KotlinToolchain.KotlincInvoker
+  compiler: KotlinToolchain.KotlincInvoker,
 ): JvmCompilationTask {
   if ((
     inputs.processorsList.isEmpty() &&
@@ -192,11 +192,11 @@ internal fun JvmCompilationTask.runPlugins(
           .plus(
             plugins(
               options = inputs.stubsPluginOptionsList,
-              classpath = inputs.stubsPluginClasspathList
-            )
+              classpath = inputs.stubsPluginClasspathList,
+            ),
           )
           .plus(
-            kaptArgs(context, plugins, "stubsAndApt")
+            kaptArgs(context, plugins, "stubsAndApt"),
           )
         )
         .flag("-d", directories.generatedClasses)
@@ -205,7 +205,7 @@ internal fun JvmCompilationTask.runPlugins(
           context.executeCompilerTask(
             args,
             compiler::compile,
-            printOnSuccess = context.whenTracing { false } ?: true
+            printOnSuccess = context.whenTracing { false } ?: true,
           )
         }.let { outputLines ->
           // if tracing is enabled the output should be formatted in a special way, if we aren't
@@ -226,7 +226,7 @@ internal fun JvmCompilationTask.createOutputJar() =
   JarCreator(
     path = Paths.get(outputs.jar),
     normalize = true,
-    verbose = false
+    verbose = false,
   ).also {
     it.addDirectory(Paths.get(directories.classes))
     it.addDirectory(Paths.get(directories.javaClasses))
@@ -242,7 +242,7 @@ internal fun JvmCompilationTask.createAbiJar() =
   JarCreator(
     path = Paths.get(outputs.abijar),
     normalize = true,
-    verbose = false
+    verbose = false,
   ).also {
     it.addDirectory(Paths.get(directories.abiClasses))
     it.addDirectory(Paths.get(directories.generatedClasses))
@@ -257,7 +257,7 @@ internal fun JvmCompilationTask.createGeneratedJavaSrcJar() {
   JarCreator(
     path = Paths.get(outputs.generatedJavaSrcJar),
     normalize = true,
-    verbose = false
+    verbose = false,
   ).also {
     it.addDirectory(Paths.get(directories.generatedJavaSources))
     it.setJarOwner(info.label, info.bazelRuleKind)
@@ -272,7 +272,7 @@ internal fun JvmCompilationTask.createGeneratedStubJar() {
   JarCreator(
     path = Paths.get(outputs.generatedJavaStubJar),
     normalize = true,
-    verbose = false
+    verbose = false,
   ).also {
     it.addDirectory(Paths.get(directories.incrementalData))
     it.setJarOwner(info.label, info.bazelRuleKind)
@@ -287,7 +287,7 @@ internal fun JvmCompilationTask.createGeneratedClassJar() {
   JarCreator(
     path = Paths.get(outputs.generatedClassJar),
     normalize = true,
-    verbose = false
+    verbose = false,
   ).also {
     it.addDirectory(Paths.get(directories.generatedClasses))
     it.setJarOwner(info.label, info.bazelRuleKind)
@@ -302,7 +302,7 @@ fun JvmCompilationTask.compileKotlin(
   context: CompilationTaskContext,
   compiler: KotlinToolchain.KotlincInvoker,
   args: CompilationArgs = baseArgs(),
-  printOnFail: Boolean = true
+  printOnFail: Boolean = true,
 ): List<String> {
   if (inputs.kotlinSourcesList.isEmpty()) {
     writeJdeps(outputs.jdeps, emptyJdeps(info.label))
@@ -311,7 +311,7 @@ fun JvmCompilationTask.compileKotlin(
     return (
       args + plugins(
         options = inputs.compilerPluginOptionsList,
-        classpath = inputs.compilerPluginClasspathList
+        classpath = inputs.compilerPluginClasspathList,
       )
       )
       .values(inputs.javaSourcesList)
@@ -332,13 +332,13 @@ fun JvmCompilationTask.compileKotlin(
                   directories.generatedClasses,
                   directories.generatedSources,
                   directories.generatedJavaSources,
-                  directories.temp
+                  directories.temp,
                 )
                   .map { Paths.get(it) }
                   .flatMap { walk(it) }
                   .filter { !isDirectory(it) }
                   .map { it.toString() }
-                  .collect(toList())
+                  .collect(toList()),
               )
             }
           }
@@ -351,28 +351,30 @@ fun JvmCompilationTask.compileKotlin(
  * Java and Kotlin sources merged in.
  */
 internal fun JvmCompilationTask.expandWithSourceJarSources(): JvmCompilationTask =
-  if (inputs.sourceJarsList.isEmpty())
+  if (inputs.sourceJarsList.isEmpty()) {
     this
-  else expandWithSources(
-    SourceJarExtractor(
-      destDir = Paths.get(directories.temp).resolve("_srcjars"),
-      fileMatcher = IS_JVM_SOURCE_FILE
-    ).also {
-      it.jarFiles.addAll(inputs.sourceJarsList.map { p -> Paths.get(p) })
-      it.execute()
-    }.sourcesList.iterator()
-  )
+  } else {
+    expandWithSources(
+      SourceJarExtractor(
+        destDir = Paths.get(directories.temp).resolve("_srcjars"),
+        fileMatcher = IS_JVM_SOURCE_FILE,
+      ).also {
+        it.jarFiles.addAll(inputs.sourceJarsList.map { p -> Paths.get(p) })
+        it.execute()
+      }.sourcesList.iterator(),
+    )
+  }
 
 private val Directories.stubs
   get() = Files.createDirectories(
     Paths.get(temp)
-      .resolve("stubs")
+      .resolve("stubs"),
   )
     .toString()
 private val Directories.incrementalData
   get() = Files.createDirectories(
     Paths.get(temp)
-      .resolve("incrementalData")
+      .resolve("incrementalData"),
   )
     .toString()
 
@@ -388,19 +390,19 @@ internal fun JvmCompilationTask.expandWithGeneratedSources(): JvmCompilationTask
       .filter { !isDirectory(it) }
       .map { it.toString() }
       .distinct()
-      .iterator()
+      .iterator(),
   )
 
 private fun JvmCompilationTask.expandWithSources(sources: Iterator<String>): JvmCompilationTask =
   updateBuilder { builder ->
     sources.filterOutNonCompilableSources().partitionJvmSources(
       { builder.inputsBuilder.addKotlinSources(it) },
-      { builder.inputsBuilder.addJavaSources(it) }
+      { builder.inputsBuilder.addJavaSources(it) },
     )
   }
 
 private fun JvmCompilationTask.updateBuilder(
-  block: (JvmCompilationTask.Builder) -> Unit
+  block: (JvmCompilationTask.Builder) -> Unit,
 ): JvmCompilationTask =
   toBuilder().let {
     block(it)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/InternalCompilerPlugins.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/InternalCompilerPlugins.kt
@@ -23,5 +23,5 @@ class InternalCompilerPlugins constructor(
   val jvmAbiGen: KotlinToolchain.CompilerPlugin,
   val skipCodeGen: KotlinToolchain.CompilerPlugin,
   val kapt: KotlinToolchain.CompilerPlugin,
-  val jdeps: KotlinToolchain.CompilerPlugin
+  val jdeps: KotlinToolchain.CompilerPlugin,
 )

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JDepsGenerator.kt
@@ -16,20 +16,9 @@
 package io.bazel.kotlin.builder.tasks.jvm
 
 import com.google.devtools.build.lib.view.proto.Deps
-import io.bazel.kotlin.builder.toolchain.CompilationException
-import io.bazel.kotlin.builder.toolchain.CompilationStatusException
-import io.bazel.kotlin.builder.toolchain.KotlinToolchain
-import io.bazel.kotlin.builder.utils.joinedClasspath
-import io.bazel.kotlin.builder.utils.resolveVerified
-import io.bazel.kotlin.builder.utils.rootCause
-import io.bazel.kotlin.model.JvmCompilationTask
-import java.io.ByteArrayOutputStream
 import java.io.FileOutputStream
-import java.io.PrintWriter
 import java.nio.file.Files
 import java.nio.file.Paths
-import javax.inject.Inject
-import javax.inject.Singleton
 
 object JDepsGenerator {
   internal fun writeJdeps(path: String, jdepsContent: Deps.Dependencies) {

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JacocoInstrumentation.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JacocoInstrumentation.kt
@@ -20,18 +20,24 @@ internal fun JvmCompilationTask.createCoverageInstrumentedJar() {
 
   instrumentRecursively(instr, instrumentedClassesDirectory, Paths.get(directories.classes))
   instrumentRecursively(instr, instrumentedClassesDirectory, Paths.get(directories.javaClasses))
-  instrumentRecursively(instr, instrumentedClassesDirectory, Paths.get(directories.generatedClasses))
+  instrumentRecursively(
+    instr,
+    instrumentedClassesDirectory,
+    Paths.get(directories.generatedClasses),
+  )
 
-  val pathsForCoverage = instrumentedClassesDirectory.resolve( "${Paths.get(outputs.jar).fileName}-paths-for-coverage.txt")
+  val pathsForCoverage = instrumentedClassesDirectory.resolve(
+    "${Paths.get(outputs.jar).fileName}-paths-for-coverage.txt",
+  )
   Files.write(
     pathsForCoverage,
-    inputs.javaSourcesList + inputs.kotlinSourcesList
+    inputs.javaSourcesList + inputs.kotlinSourcesList,
   )
 
   JarCreator(
     path = Paths.get(outputs.jar),
     normalize = true,
-    verbose = false
+    verbose = false,
   ).also {
     it.addDirectory(Paths.get(directories.classes))
     it.addDirectory(Paths.get(directories.javaClasses))
@@ -43,7 +49,7 @@ internal fun JvmCompilationTask.createCoverageInstrumentedJar() {
 }
 
 private fun instrumentRecursively(instr: Instrumenter, metadataDir: Path, root: Path) {
-  val visitor = object: SimpleFileVisitor<Path>() {
+  val visitor = object : SimpleFileVisitor<Path>() {
     override fun visitFile(file: Path, attrs: BasicFileAttributes): FileVisitResult {
       if (file.toFile().extension != "class") {
         return FileVisitResult.CONTINUE

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMerger.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMerger.kt
@@ -45,7 +45,7 @@ class JdepsMerger {
           val manifest = jarFile.manifest ?: return JarOwner(jarPath)
           val attributes = manifest.mainAttributes
           val label = attributes[TARGET_LABEL] as String?
-                      ?: return JarOwner(jarPath)
+            ?: return JarOwner(jarPath)
           val injectingRuleKind = attributes[INJECTING_RULE_KIND] as String?
           return JarOwner(jarPath, label, injectingRuleKind)
         }
@@ -60,9 +60,8 @@ class JdepsMerger {
       label: String,
       inputs: List<String>,
       output: String,
-      reportUnusedDeps: String
+      reportUnusedDeps: String,
     ): Int {
-
       val rootBuilder = Deps.Dependencies.newBuilder()
       rootBuilder.success = false
       rootBuilder.ruleLabel = label
@@ -101,11 +100,13 @@ class JdepsMerger {
             val open = "\u001b[35m\u001b[1m"
             val close = "\u001b[0m"
             return@info """
-            |$open ** Please remove the following dependencies:$close ${unusedLabels.joinToString(" ")} from $label 
+            |$open ** Please remove the following dependencies:$close ${unusedLabels.joinToString(
+              " ",
+            )} from $label 
             |$open ** You can use the following buildozer command:$close buildozer 'remove deps ${
-              unusedLabels.joinToString(" ")
+            unusedLabels.joinToString(" ")
             }' $label
-          """.trimMargin()
+            """.trimMargin()
           }
           return if (reportUnusedDeps == "error") 1 else 0
         }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsParser.kt
@@ -22,7 +22,7 @@ import java.util.HashMap
 import java.util.function.Predicate
 
 internal class JdepsParser private constructor(
-  private val isImplicit: Predicate<String>
+  private val isImplicit: Predicate<String>,
 ) {
   private val depMap = HashMap<String, Deps.Dependency.Builder>()
   private val moduleDeps = HashMap<String, MutableList<String>>()
@@ -60,7 +60,7 @@ internal class JdepsParser private constructor(
   private fun processLine(line: String) {
     val parts = line.split(arrowRegex).dropLastWhile { it.isEmpty() }.toTypedArray()
     if (parts.size == 2 && parts[1].endsWith(".jar")) {
-      addModuleDependency(parts[0], parts[1]);
+      addModuleDependency(parts[0], parts[1])
     }
   }
 
@@ -95,7 +95,7 @@ internal class JdepsParser private constructor(
       jarFile: String,
       classPath: MutableList<String>,
       lines: List<String>,
-      isImplicit: Predicate<String>
+      isImplicit: Predicate<String>,
     ): Deps.Dependencies {
       val filename = Paths.get(jarFile).fileName.toString()
       val jdepsParser = JdepsParser(isImplicit)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -32,7 +32,7 @@ const val X_FRIENDS_PATH_SEPARATOR = ","
 @Singleton
 class KotlinJvmTaskExecutor @Inject internal constructor(
   private val compiler: KotlinToolchain.KotlincInvoker,
-  private val plugins: InternalCompilerPlugins
+  private val plugins: InternalCompilerPlugins,
 ) {
 
   private fun combine(one: Throwable?, two: Throwable?): Throwable? {
@@ -82,12 +82,13 @@ class KotlinJvmTaskExecutor @Inject internal constructor(
                         plugin(plugins.skipCodeGen)
                       }
                     },
-                  printOnFail = false)
+                  printOnFail = false,
+                )
               } else {
                 emptyList()
               }
             }
-          }
+          },
         ).map {
           (it.getOrNull() ?: emptyList()) to it.exceptionOrNull()
         }.map {

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/CompilationTaskContext.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/CompilationTaskContext.kt
@@ -29,7 +29,7 @@ class CompilationTaskContext(
   val info: CompilationTaskInfo,
   private val out: PrintStream,
   private val executionRoot: String = FileSystems.getDefault().getPath("").toAbsolutePath()
-    .toString() + File.separator
+    .toString() + File.separator,
 ) {
   private val start = System.currentTimeMillis()
   private var timings: MutableList<String>?
@@ -63,7 +63,7 @@ class CompilationTaskContext(
     header: String,
     lines: List<String>,
     prefix: String = "|  ",
-    filterEmpty: Boolean = false
+    filterEmpty: Boolean = false,
   ) {
     check(header.isNotEmpty())
     out.println(if (header.endsWith(":")) header else "$header:")
@@ -78,7 +78,9 @@ class CompilationTaskContext(
   fun <T> whenTracing(block: CompilationTaskContext.() -> T): T? {
     return if (isTracing) {
       block()
-    } else null
+    } else {
+      null
+    }
   }
 
   /**
@@ -99,7 +101,9 @@ class CompilationTaskContext(
     // trim off the workspace component
     return if (toPrint.startsWith(executionRoot)) {
       toPrint.replaceFirst(executionRoot, "")
-    } else toPrint
+    } else {
+      toPrint
+    }
   }
 
   /**
@@ -115,7 +119,7 @@ class CompilationTaskContext(
     args: List<String>,
     compile: (Array<String>, PrintStream) -> Int,
     printOnFail: Boolean = true,
-    printOnSuccess: Boolean = true
+    printOnSuccess: Boolean = true,
   ): List<String> {
     val outputStream = ByteArrayOutputStream()
     val ps = PrintStream(outputStream)
@@ -147,7 +151,9 @@ class CompilationTaskContext(
   fun <T> execute(name: () -> String, task: () -> T): T {
     return if (timings == null) {
       task()
-    } else pushTimedTask(name(), task)
+    } else {
+      pushTimedTask(name(), task)
+    }
   }
 
   private inline fun <T> pushTimedTask(name: String, task: () -> T): T {
@@ -177,7 +183,8 @@ class CompilationTaskContext(
     if (successful) {
       timings?.also {
         printLines(
-          "Task timings for ${info.label} (total: ${System.currentTimeMillis() - start} ms)", it
+          "Task timings for ${info.label} (total: ${System.currentTimeMillis() - start} ms)",
+          it,
         )
       }
     }

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolException.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolException.kt
@@ -17,7 +17,7 @@ package io.bazel.kotlin.builder.toolchain
 
 sealed class KotlinToolException(
   msg: String,
-  ex: Throwable? = null
+  ex: Throwable? = null,
 ) : RuntimeException(msg, ex)
 
 class CompilationException(msg: String, cause: Throwable? = null) :
@@ -26,5 +26,5 @@ class CompilationException(msg: String, cause: Throwable? = null) :
 class CompilationStatusException(
   msg: String,
   val status: Int,
-  val lines: List<String> = emptyList()
+  val lines: List<String> = emptyList(),
 ) : KotlinToolException("$msg:${lines.joinToString("\n", "\n")}")

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
@@ -36,39 +36,52 @@ class KotlinToolchain private constructor(
   val classLoader: ClassLoader,
   val kapt3Plugin: CompilerPlugin = CompilerPlugin(
     kotlinHome.resolveVerified("lib", "kotlin-annotation-processing.jar").absolutePath,
-    "org.jetbrains.kotlin.kapt3"
+    "org.jetbrains.kotlin.kapt3",
   ),
   val jvmAbiGen: CompilerPlugin,
   val skipCodeGen: CompilerPlugin,
-  val jdepsGen: CompilerPlugin
+  val jdepsGen: CompilerPlugin,
 ) {
 
   companion object {
     // TODO(issue/432): Remove this gross hack and pass the file locations on the command line.
     private var RULES_REPOSITORY_NAME =
       System.getenv("TEST_WORKSPACE")?.takeIf { it.isNotBlank() }
-      ?: System.getenv("REPOSITORY_NAME")?.takeIf { it.isNotBlank() }
-   //   ?: System.getProperty("TEST_WORKSPACE")?.takeIf { it.isNotBlank() }
-      ?: error("Unable to determine rules_kotlin repository name.\nenv:${System.getenv()}\nproperties:${System.getProperties()}")
+        ?: System.getenv("REPOSITORY_NAME")?.takeIf { it.isNotBlank() }
+        //   ?: System.getProperty("TEST_WORKSPACE")?.takeIf { it.isNotBlank() }
+        ?: error(
+          "Unable to determine rules_kotlin repository " +
+            "name.\nenv:${System.getenv()}\nproperties:${System.getProperties()}",
+        )
 
     private val DEFAULT_JVM_ABI_PATH = BazelRunFiles.resolveVerified(
-      "external", "com_github_jetbrains_kotlin", "lib", "jvm-abi-gen.jar"
+      "external",
+      "com_github_jetbrains_kotlin",
+      "lib",
+      "jvm-abi-gen.jar",
     ).toPath()
 
     private val COMPILER = BazelRunFiles.resolveVerified(
       RULES_REPOSITORY_NAME,
       "src", "main", "kotlin", "io", "bazel", "kotlin", "compiler",
-      "compiler.jar").toPath()
+      "compiler.jar",
+    ).toPath()
 
     private val SKIP_CODE_GEN_PLUGIN = BazelRunFiles.resolveVerified(
       RULES_REPOSITORY_NAME,
-      "src", "main", "kotlin",
-      "skip-code-gen.jar").toPath()
+      "src",
+      "main",
+      "kotlin",
+      "skip-code-gen.jar",
+    ).toPath()
 
     private val JDEPS_GEN_PLUGIN = BazelRunFiles.resolveVerified(
       RULES_REPOSITORY_NAME,
-      "src", "main", "kotlin",
-      "jdeps-gen.jar").toPath()
+      "src",
+      "main",
+      "kotlin",
+      "jdeps-gen.jar",
+    ).toPath()
 
     internal val NO_ARGS = arrayOf<Any>()
 
@@ -84,7 +97,7 @@ class KotlinToolchain private constructor(
         },
         Preloader.DEFAULT_CLASS_NUMBER_ESTIMATE,
         ClassLoader.getSystemClassLoader(),
-        null
+        null,
       )
 
     @JvmStatic
@@ -103,7 +116,11 @@ class KotlinToolchain private constructor(
       val jdepsGenFile = JDEPS_GEN_PLUGIN.verified().absoluteFile
 
       val kotlinCompilerJar = BazelRunFiles.resolveVerified(
-        "external", "com_github_jetbrains_kotlin", "lib", "kotlin-compiler.jar")
+        "external",
+        "com_github_jetbrains_kotlin",
+        "lib",
+        "kotlin-compiler.jar",
+      )
 
       val jvmAbiGenFile = jvmAbiGenPath.verified()
       return KotlinToolchain(
@@ -118,19 +135,21 @@ class KotlinToolchain private constructor(
             // This may cause issues in accepting user defined compiler plugins.
             jvmAbiGenFile.absoluteFile,
             skipCodeGenFile,
-            jdepsGenFile
-          )
+            jdepsGenFile,
+          ),
         ),
         jvmAbiGen = CompilerPlugin(
           jvmAbiGenFile.absolutePath,
-          "org.jetbrains.kotlin.jvm.abi"),
+          "org.jetbrains.kotlin.jvm.abi",
+        ),
         skipCodeGen = CompilerPlugin(
           skipCodeGenFile.absolutePath,
-          "io.bazel.kotlin.plugin.SkipCodeGen"),
+          "io.bazel.kotlin.plugin.SkipCodeGen",
+        ),
         jdepsGen = CompilerPlugin(
           jdepsGenFile.absolutePath,
-          "io.bazel.kotlin.plugin.jdeps.JDepsGen"
-        )
+          "io.bazel.kotlin.plugin.jdeps.JDepsGen",
+        ),
       )
     }
   }
@@ -139,7 +158,7 @@ class KotlinToolchain private constructor(
 
   open class KotlinCliToolInvoker internal constructor(
     toolchain: KotlinToolchain,
-    clazz: String
+    clazz: String,
   ) {
     private val compiler: Any
     private val execMethod: Method
@@ -168,11 +187,11 @@ class KotlinToolchain private constructor(
 
   @Singleton
   class KotlincInvoker @Inject constructor(
-    toolchain: KotlinToolchain
+    toolchain: KotlinToolchain,
   ) : KotlinCliToolInvoker(toolchain, "io.bazel.kotlin.compiler.BazelK2JVMCompiler")
 
   @Singleton
   class K2JSCompilerInvoker @Inject constructor(
-    toolchain: KotlinToolchain
+    toolchain: KotlinToolchain,
   ) : KotlinCliToolInvoker(toolchain, "org.jetbrains.kotlin.cli.js.K2JSCompiler")
 }

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/ArgMap.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/ArgMap.kt
@@ -32,7 +32,7 @@ class ArgMap(private val map: Map<String, List<String>>) {
       ?.windowed(2, 2)
       ?.map { it[0] to it[1] }
       ?.toMap()
-    ?: emptyMap()
+      ?: emptyMap()
 
   private fun optionalSingle(key: String): String? =
     optional(key)?.let {
@@ -60,9 +60,9 @@ class ArgMap(private val map: Map<String, List<String>>) {
   }
 
   private fun mandatory(key: String): List<String> = optional(key)
-                                                     ?: throw IllegalArgumentException(
-                                                       "$key is not optional"
-                                                     )
+    ?: throw IllegalArgumentException(
+      "$key is not optional",
+    )
 
   private fun optional(key: String): List<String>? = map[key]
 
@@ -95,7 +95,7 @@ object ArgMaps {
   private fun argsToMap(
     args: List<String>,
     argMap: MutableMap<String, MutableList<String>>,
-    isFlag: (String) -> Boolean = { it.startsWith("--") }
+    isFlag: (String) -> Boolean = { it.startsWith("--") },
   ) {
     var currentKey: String =
       args.first().also { require(isFlag(it)) { "first arg must be a flag" } }

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/BazelRunFiles.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/BazelRunFiles.kt
@@ -29,27 +29,29 @@ object BazelRunFiles {
    * Set depending on --enable_runfiles, which defaults to false on Windows and true otherwise.
    */
   private val manifestFile: String? =
-      if (isWindows) {
-        System.getenv("RUNFILES_MANIFEST_FILE")
-      } else null
+    if (isWindows) {
+      System.getenv("RUNFILES_MANIFEST_FILE")
+    } else {
+      null
+    }
 
   private val javaRunFiles = Paths.get(System.getenv("JAVA_RUNFILES"))
 
   private val runfiles by lazy {
     with(mutableMapOf<String, String>()) {
       FileInputStream(manifestFile)
-          .bufferedReader(Charset.forName("UTF-8"))
-          .lines()
-          .forEach { it ->
-            val line = it.trim { it <= ' ' }
-            if (!line.isEmpty()) {
-              // TODO(bazel-team): This is buggy when the path contains spaces, we should fix the manifest format.
-              line.split(" ").also {
-                check(it.size == 2) { "RunFiles manifest entry $line contains more than one space" }
-                put(it[0], it[1])
-              }
+        .bufferedReader(Charset.forName("UTF-8"))
+        .lines()
+        .forEach { it ->
+          val line = it.trim { it <= ' ' }
+          if (!line.isEmpty()) {
+            // TODO(bazel-team): This is buggy when the path contains spaces, we should fix the manifest format.
+            line.split(" ").also {
+              check(it.size == 2) { "RunFiles manifest entry $line contains more than one space" }
+              put(it[0], it[1])
             }
           }
+        }
       Collections.unmodifiableMap(this)
     }
   }
@@ -64,15 +66,15 @@ object BazelRunFiles {
       path.joinToString("/").let { rfPath ->
         // trim off the external/ prefix if it is present.
         val trimmedPath =
-            if (rfPath.startsWith("external/")) {
-              rfPath.replaceFirst("external/", "")
-            } else {
-              rfPath
-            }
+          if (rfPath.startsWith("external/")) {
+            rfPath.replaceFirst("external/", "")
+          } else {
+            rfPath
+          }
         File(
-            checkNotNull(runfiles[trimmedPath]) {
-              "runfile manifest $mf did not contain path mapping for $rfPath"
-            }
+          checkNotNull(runfiles[trimmedPath]) {
+            "runfile manifest $mf did not contain path mapping for $rfPath"
+          },
         )
       }.also {
         check(it.exists()) { "file $it resolved from runfiles did not exist" }
@@ -82,7 +84,7 @@ object BazelRunFiles {
       return fromManifest
     }
 
-    /// if it could not be resolved from the manifest then first try to resolve it directly.
+    // / if it could not be resolved from the manifest then first try to resolve it directly.
     val resolvedDirect = File(path.joinToString(File.separator)).takeIf { it.exists() }
     if (resolvedDirect != null) {
       return resolvedDirect

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/IOUtils.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/IOUtils.kt
@@ -69,11 +69,12 @@ private fun BufferedReader.drainTo(pw: PrintStream) {
 
 fun Path.resolveTwinVerified(extension: String): Path =
   parent.resolve(
-    "${toFile().nameWithoutExtension}${if (extension.startsWith(".")) "" else "."}$extension"
+    "${toFile().nameWithoutExtension}${if (extension.startsWith(".")) "" else "."}$extension",
   ).verified().toPath()
 
 fun Path.resolveNewDirectories(vararg parts: String) = Files.createDirectories(
-    parts.fold(this, Path::resolve))
+  parts.fold(this, Path::resolve),
+)
 
 fun Path.resolveVerified(vararg parts: String): File =
   resolve(Paths.get(parts[0], *Arrays.copyOfRange(parts, 1, parts.size))).verified()
@@ -82,11 +83,10 @@ fun Path.resolveVerifiedToAbsoluteString(vararg parts: String): String =
   resolveVerified(*parts).absolutePath.toString()
 
 fun Path.verified(): File = this.toFile()
-    .also { check(it.exists()) { "file did not exist: $this" } }
+  .also { check(it.exists()) { "file did not exist: $this" } }
 
 fun Path.verifiedPath(): Path = this.toFile()
-    .also { check(it.exists()) { "file did not exist: $this" } }.toPath()
-
+  .also { check(it.exists()) { "file did not exist: $this" } }.toPath()
 
 val Throwable.rootCause: Throwable
   get() {

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/TaskUtils.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/TaskUtils.kt
@@ -19,9 +19,13 @@ import io.bazel.kotlin.model.CompilationTaskInfo
 import io.bazel.kotlin.model.JvmCompilationTask
 import java.io.File
 
-val JvmCompilationTask.Inputs.joinedClasspath: String get() = this.classpathList.joinToString(File.pathSeparator)
+val JvmCompilationTask.Inputs.joinedClasspath: String
+  get() = this.classpathList.joinToString(
+    File.pathSeparator,
+  )
 
-val CompilationTaskInfo.bazelRuleKind: String get() = "kt_${platform.name.lowercase()}_${ruleKind.name.lowercase()}"
+val CompilationTaskInfo.bazelRuleKind: String
+  get() = "kt_${platform.name.lowercase()}_${ruleKind.name.lowercase()}"
 
 fun Iterator<String>.partitionJvmSources(kt: (String) -> Unit, java: (String) -> Unit) {
   forEach {

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/WorkingDirectoryContext.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/WorkingDirectoryContext.kt
@@ -25,7 +25,8 @@ import java.nio.file.Path
 class WorkingDirectoryContext(val dir: Path) : Closeable {
   companion object {
     fun newContext(): WorkingDirectoryContext = WorkingDirectoryContext(
-        Files.createTempDirectory("working"))
+      Files.createTempDirectory("working"),
+    )
   }
 
   override fun close() {

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/JarCreator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/JarCreator.kt
@@ -32,15 +32,15 @@ import java.util.jar.Attributes
 import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
 
-@Suppress("unused")
 /**
  * A class for creating Jar files. Allows normalization of Jar entries by setting their timestamp to
  * the DOS epoch. All Jar entries are sorted alphabetically.
  */
+@Suppress("unused")
 class JarCreator(
   path: Path,
   normalize: Boolean = true,
-  verbose: Boolean = false
+  verbose: Boolean = false,
 ) : JarHelper(path, normalize, verbose), Closeable {
   // Map from Jar entry names to files. Use TreeMap so we can establish a canonical order for the
   // entries regardless in what order they get added.
@@ -133,7 +133,7 @@ class JarCreator(
             }
             jarEntries[sb.toString()] = path
           }
-        }
+        },
       )
     } catch (e: IOException) {
       throw UncheckedIOException(e)

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/JarExtractor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/JarExtractor.kt
@@ -20,7 +20,7 @@ import java.nio.file.Path
 import java.util.jar.JarFile
 
 open class JarExtractor protected constructor(
-  protected var destDir: Path
+  protected var destDir: Path,
 ) {
 
   /**

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/JarHelper.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/JarHelper.kt
@@ -44,7 +44,7 @@ open class JarHelper internal constructor(
   // The properties to describe how to create the Jar
   protected val normalize: Boolean = true,
   protected val verbose: Boolean = false,
-  compression: Boolean = true
+  compression: Boolean = true,
 ) {
   private var storageMethod: Int = JarEntry.DEFLATED
 
@@ -168,8 +168,12 @@ open class JarHelper internal constructor(
         val size = if (isDirectory) 0 else Files.size(path)
         val outEntry = JarEntry(normalizedName)
         val newtime =
-          if (normalize) normalizedTimestamp(normalizedName) else Files.getLastModifiedTime(path)
-            .toMillis()
+          if (normalize) {
+            normalizedTimestamp(normalizedName)
+          } else {
+            Files.getLastModifiedTime(path)
+              .toMillis()
+          }
         outEntry.time = newtime
         outEntry.size = size
         if (size == 0L) {
@@ -210,7 +214,7 @@ open class JarHelper internal constructor(
   protected fun JarOutputStream.copyEntry(
     name: String,
     path: Path? = null,
-    data: ByteArray = EMPTY_BYTEARRAY
+    data: ByteArray = EMPTY_BYTEARRAY,
   ) {
     val outEntry = JarEntry(name)
     outEntry.time = when {

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreator.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/jars/SourceJarCreator.kt
@@ -29,7 +29,7 @@ import java.util.stream.Stream
  */
 class SourceJarCreator(
   path: Path,
-  verbose: Boolean = false
+  verbose: Boolean = false,
 ) : JarHelper(path, normalize = true, verbose = verbose) {
   companion object {
     private const val BL = """\p{Blank}*"""
@@ -198,7 +198,8 @@ class SourceJarCreator(
 
     val result = entries.putIfAbsent(name, Entry.File(path, bytes))
     require(result as? Entry.Directory != null || result == null) {
-      "source entry jarName: $name from: $path collides with entry from: ${(result as Entry.File).path}"
+      "source entry jarName: $name from: $path " +
+        "collides with entry from: ${(result as Entry.File).path}"
     }
   }
 }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/SkipCodeGen.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/SkipCodeGen.kt
@@ -40,10 +40,12 @@ class SkipCodeGen : ComponentRegistrar {
 
   override fun registerProjectComponents(
     project: MockProject,
-    configuration: CompilerConfiguration
+    configuration: CompilerConfiguration,
   ) {
-    AnalysisHandlerExtension.registerExtension(project,
-        SkipCodeGen)
+    AnalysisHandlerExtension.registerExtension(
+      project,
+      SkipCodeGen,
+    )
   }
 
   /**
@@ -57,7 +59,7 @@ class SkipCodeGen : ComponentRegistrar {
       projectContext: ProjectContext,
       files: Collection<KtFile>,
       bindingTrace: BindingTrace,
-      componentProvider: ComponentProvider
+      componentProvider: ComponentProvider,
     ): AnalysisResult? {
       return null
     }
@@ -67,13 +69,14 @@ class SkipCodeGen : ComponentRegistrar {
       project: Project,
       module: ModuleDescriptor,
       bindingTrace: BindingTrace,
-      files: Collection<KtFile>
+      files: Collection<KtFile>,
     ): AnalysisResult? {
       // Ensure this is the last plugin, as it will short circuit any other plugin analysisCompleted
       // calls.
       Preconditions.checkState(
-          AnalysisHandlerExtension.getInstances(project).last() == this,
-          "SkipCodeGen must be the last plugin: ${AnalysisHandlerExtension.getInstances(project)}")
+        AnalysisHandlerExtension.getInstances(project).last() == this,
+        "SkipCodeGen must be the last plugin: ${AnalysisHandlerExtension.getInstances(project)}",
+      )
       return AnalysisResult.Companion.success(bindingTrace.bindingContext, module, false)
     }
   }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
@@ -14,8 +14,14 @@ class JdepsGenCommandLineProcessor : CommandLineProcessor {
       CliOption("output", "<path>", "Output path for generated jdeps", required = true)
     val TARGET_LABEL_OPTION: CliOption =
       CliOption("target_label", "<String>", "Label of target being analyzed", required = true)
-     val DIRECT_DEPENDENCIES_OPTION: CliOption =
-      CliOption("direct_dependencies", "<List>", "List of targets direct dependencies", required = false, allowMultipleOccurrences = true)
+    val DIRECT_DEPENDENCIES_OPTION: CliOption =
+      CliOption(
+        "direct_dependencies",
+        "<List>",
+        "List of targets direct dependencies",
+        required = false,
+        allowMultipleOccurrences = true,
+      )
     val STRICT_KOTLIN_DEPS_OPTION: CliOption =
       CliOption("strict_kotlin_deps", "<String>", "Report strict deps violations", required = true)
   }
@@ -23,14 +29,29 @@ class JdepsGenCommandLineProcessor : CommandLineProcessor {
   override val pluginId: String
     get() = COMPILER_PLUGIN_ID
   override val pluginOptions: Collection<AbstractCliOption>
-    get() = listOf(OUTPUT_JDEPS_FILE_OPTION, TARGET_LABEL_OPTION, DIRECT_DEPENDENCIES_OPTION, STRICT_KOTLIN_DEPS_OPTION)
+    get() = listOf(
+      OUTPUT_JDEPS_FILE_OPTION,
+      TARGET_LABEL_OPTION,
+      DIRECT_DEPENDENCIES_OPTION,
+      STRICT_KOTLIN_DEPS_OPTION,
+    )
 
-  override fun processOption(option: AbstractCliOption, value: String, configuration: CompilerConfiguration) {
+  override fun processOption(
+    option: AbstractCliOption,
+    value: String,
+    configuration: CompilerConfiguration,
+  ) {
     when (option) {
       OUTPUT_JDEPS_FILE_OPTION -> configuration.put(JdepsGenConfigurationKeys.OUTPUT_JDEPS, value)
       TARGET_LABEL_OPTION -> configuration.put(JdepsGenConfigurationKeys.TARGET_LABEL, value)
-      DIRECT_DEPENDENCIES_OPTION -> configuration.appendList(JdepsGenConfigurationKeys.DIRECT_DEPENDENCIES, value)
-      STRICT_KOTLIN_DEPS_OPTION -> configuration.put(JdepsGenConfigurationKeys.STRICT_KOTLIN_DEPS, value)
+      DIRECT_DEPENDENCIES_OPTION -> configuration.appendList(
+        JdepsGenConfigurationKeys.DIRECT_DEPENDENCIES,
+        value,
+      )
+      STRICT_KOTLIN_DEPS_OPTION -> configuration.put(
+        JdepsGenConfigurationKeys.STRICT_KOTLIN_DEPS,
+        value,
+      )
       else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
     }
   }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenComponentRegistrar.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenComponentRegistrar.kt
@@ -1,7 +1,6 @@
 package io.bazel.kotlin.plugin.jdeps
 
 import com.intellij.mock.MockProject
-import org.jetbrains.kotlin.codegen.extensions.ClassBuilderInterceptorExtension
 import org.jetbrains.kotlin.compiler.plugin.ComponentRegistrar
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor
@@ -11,9 +10,8 @@ class JdepsGenComponentRegistrar : ComponentRegistrar {
 
   override fun registerProjectComponents(
     project: MockProject,
-    configuration: CompilerConfiguration
+    configuration: CompilerConfiguration,
   ) {
-
     // Capture all types referenced by the compiler for this module and look up the jar from which
     // they were loaded from
     val extension = JdepsGenExtension(project, configuration)

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenConfigurationKeys.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenConfigurationKeys.kt
@@ -7,7 +7,9 @@ object JdepsGenConfigurationKeys {
    * Output path of generated Jdeps proto file.
    */
   val OUTPUT_JDEPS: CompilerConfigurationKey<String> =
-    CompilerConfigurationKey.create(JdepsGenCommandLineProcessor.OUTPUT_JDEPS_FILE_OPTION.description)
+    CompilerConfigurationKey.create(
+      JdepsGenCommandLineProcessor.OUTPUT_JDEPS_FILE_OPTION.description,
+    )
 
   /**
    * Label of the Bazel target being analyzed.
@@ -19,11 +21,15 @@ object JdepsGenConfigurationKeys {
    * Label of the Bazel target being analyzed.
    */
   val STRICT_KOTLIN_DEPS: CompilerConfigurationKey<String> =
-    CompilerConfigurationKey.create(JdepsGenCommandLineProcessor.STRICT_KOTLIN_DEPS_OPTION.description)
+    CompilerConfigurationKey.create(
+      JdepsGenCommandLineProcessor.STRICT_KOTLIN_DEPS_OPTION.description,
+    )
 
   /**
    * List of direct dependencies of the target.
    */
   val DIRECT_DEPENDENCIES: CompilerConfigurationKey<List<String>> =
-    CompilerConfigurationKey.create(JdepsGenCommandLineProcessor.DIRECT_DEPENDENCIES_OPTION.description)
+    CompilerConfigurationKey.create(
+      JdepsGenCommandLineProcessor.DIRECT_DEPENDENCIES_OPTION.description,
+    )
 }

--- a/src/main/kotlin/io/bazel/worker/ContextLog.kt
+++ b/src/main/kotlin/io/bazel/worker/ContextLog.kt
@@ -24,18 +24,18 @@ import java.util.logging.Level
 /** Log encapsulates standard out and error of execution. */
 data class ContextLog(
   val out: CharSequence,
-  val profiles: List<String> = emptyList()
+  val profiles: List<String> = emptyList(),
 ) :
   CharSequence by out {
   constructor(
     bytes: ByteArray,
-    profiles: List<String>
+    profiles: List<String>,
   ) : this(String(bytes, UTF_8), profiles)
 
   enum class Granularity(val level: Level) {
     INFO(Level.INFO),
     ERROR(Level.SEVERE),
-    DEBUG(Level.FINEST)
+    DEBUG(Level.FINEST),
   }
 
   /** Logging runtime messages lazily */
@@ -44,7 +44,7 @@ data class ContextLog(
     fun info(msg: () -> String)
     fun error(
       t: Throwable,
-      msg: () -> String
+      msg: () -> String,
     )
 
     fun error(msg: () -> String)

--- a/src/main/kotlin/io/bazel/worker/CpuTimeBasedGcScheduler.kt
+++ b/src/main/kotlin/io/bazel/worker/CpuTimeBasedGcScheduler.kt
@@ -12,7 +12,7 @@ class CpuTimeBasedGcScheduler(
    * After this much CPU time has elapsed, we may force a GC run. Set to [Duration.ZERO] to
    * disable.
    */
-  private val cpuUsageBeforeGc: Duration
+  private val cpuUsageBeforeGc: Duration,
 ) : GcScheduler {
 
   /** The total process CPU time at the last GC run (or from the start of the worker).  */

--- a/src/main/kotlin/io/bazel/worker/IO.kt
+++ b/src/main/kotlin/io/bazel/worker/IO.kt
@@ -30,7 +30,7 @@ class IO(
   val input: InputStream,
   val output: PrintStream,
   private val captured: CapturingOutputStream,
-  private val restore: () -> Unit = {}
+  private val restore: () -> Unit = {},
 ) : Closeable {
 
   /**

--- a/src/main/kotlin/io/bazel/worker/PersistentWorker.kt
+++ b/src/main/kotlin/io/bazel/worker/PersistentWorker.kt
@@ -41,7 +41,7 @@ import java.util.concurrent.atomic.AtomicLong
 class PersistentWorker(
   private val captureIO: () -> IO,
   private val executor: ExecutorService,
-  private val cpuTimeBasedGcScheduler: GcScheduler
+  private val cpuTimeBasedGcScheduler: GcScheduler,
 ) : Worker {
 
   constructor(
@@ -50,13 +50,13 @@ class PersistentWorker(
   ) : this(
     captureIO,
     executor,
-    GcScheduler {}
+    GcScheduler {},
   )
 
   constructor() : this(
     IO.Companion::capture,
     Executors.newCachedThreadPool(),
-    CpuTimeBasedGcScheduler(Duration.ofSeconds(10))
+    CpuTimeBasedGcScheduler(Duration.ofSeconds(10)),
   )
 
   override fun start(execute: Work) = WorkerContext.run {
@@ -69,7 +69,7 @@ class PersistentWorker(
           completion.submit {
             doTask(
               name = "request ${request.requestId}",
-              task = request.workTo(execute)
+              task = request.workTo(execute),
             ).asResponseTo(request.requestId, io)
           }
         }
@@ -112,7 +112,7 @@ class PersistentWorker(
         // append whatever falls through standard out.
         output = listOf(
           log.out.toString(),
-          cap
+          cap,
         ).joinToString("\n").trim()
         exitCode = status.exit
         requestId = id

--- a/src/main/kotlin/io/bazel/worker/Status.kt
+++ b/src/main/kotlin/io/bazel/worker/Status.kt
@@ -20,5 +20,6 @@ package io.bazel.worker
 /** Status for the Result of Work. */
 enum class Status(val exit: Int) {
   ERROR(1),
-  SUCCESS(0);
+  SUCCESS(0),
+  ;
 }

--- a/src/main/kotlin/io/bazel/worker/TaskResult.kt
+++ b/src/main/kotlin/io/bazel/worker/TaskResult.kt
@@ -19,5 +19,5 @@ package io.bazel.worker
 
 data class TaskResult(
   val status: Status,
-  val log: ContextLog
+  val log: ContextLog,
 )

--- a/src/main/kotlin/io/bazel/worker/Work.kt
+++ b/src/main/kotlin/io/bazel/worker/Work.kt
@@ -23,6 +23,6 @@ import io.bazel.worker.WorkerContext.TaskContext
 fun interface Work {
   operator fun invoke(
     ctx: TaskContext,
-    args: Iterable<String>
+    args: Iterable<String>,
   ): Status
 }

--- a/src/main/kotlin/io/bazel/worker/Worker.kt
+++ b/src/main/kotlin/io/bazel/worker/Worker.kt
@@ -22,7 +22,7 @@ interface Worker {
   companion object {
     fun from(
       args: Iterable<String>,
-      then: Worker.(Iterable<String>) -> Int
+      then: Worker.(Iterable<String>) -> Int,
     ): Int {
       val worker = when {
         "--persistent_worker" in args -> PersistentWorker()

--- a/src/main/kotlin/io/bazel/worker/WorkerContext.kt
+++ b/src/main/kotlin/io/bazel/worker/WorkerContext.kt
@@ -34,7 +34,7 @@ import java.util.logging.StreamHandler
 /** WorkerContext encapsulates logging, filesystem, and profiling for a task invocation. */
 class WorkerContext private constructor(
   private val name: String = Companion::class.java.canonicalName,
-  private val verbose: Granularity = INFO
+  private val verbose: Granularity = INFO,
 ) : Closeable, ScopeLogging by ContextLogger(name, verbose.level, null) {
 
   companion object {
@@ -42,7 +42,7 @@ class WorkerContext private constructor(
       named: String = "worker",
       verbose: Granularity = INFO,
       report: (ContextLog) -> Unit = {},
-      work: WorkerContext.() -> T
+      work: WorkerContext.() -> T,
     ): T {
       return WorkerContext(verbose = verbose, name = named).run {
         use(work).also {
@@ -55,7 +55,7 @@ class WorkerContext private constructor(
   private class ContextLogger(
     val name: String,
     val level: Level,
-    val propagateTo: ContextLogger? = null
+    val propagateTo: ContextLogger? = null,
   ) : ScopeLogging {
 
     private val profiles = mutableListOf<String>()
@@ -88,7 +88,7 @@ class WorkerContext private constructor(
 
     override fun error(
       t: Throwable,
-      msg: () -> String
+      msg: () -> String,
     ) {
       logger.logp(Level.SEVERE, sourceName, name, t, msg)
     }
@@ -112,11 +112,11 @@ class WorkerContext private constructor(
 
   class TaskContext internal constructor(
     val directory: Path,
-    logging: ScopeLogging
+    logging: ScopeLogging,
   ) : ScopeLogging by logging {
     fun <T> subTask(
       name: String = javaClass.canonicalName,
-      task: (sub: TaskContext) -> T
+      task: (sub: TaskContext) -> T,
     ): T {
       return task(TaskContext(directory, logging = narrowTo(name)))
     }
@@ -126,7 +126,7 @@ class WorkerContext private constructor(
       try {
         return TaskResult(
           executeTaskIn(this),
-          contents()
+          contents(),
         )
       } catch (t: Throwable) {
         when (t.causes.lastOrNull()) {
@@ -135,7 +135,7 @@ class WorkerContext private constructor(
         }
         return TaskResult(
           ERROR,
-          contents()
+          contents(),
         )
       }
     }
@@ -149,7 +149,7 @@ class WorkerContext private constructor(
   /** doTask work in a TaskContext. */
   fun doTask(
     name: String,
-    task: (sub: TaskContext) -> Status
+    task: (sub: TaskContext) -> Status,
   ): TaskResult {
     info { "start task $name" }
     return WorkingDirectoryContext.use {


### PR DESCRIPTION
Most notable changes:
- Enforcing the 100 character line length
- `compilation_task.kt` got renamed to `CompilationTask.kt` to conform with `PascalCase`
- `BazelUtils.kt` got renamed to `BazelRunFiles.kt` to match it's inner class name
- Trailing commas have been added to all Kotlin source files