### PR TITLE
Run KSP using a kt_compiler_plugin

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -100,6 +100,12 @@ tasks:
     working_directory: examples/jetpack_compose
     test_targets:
       - //...
+  example-ksp:
+    name: "Example - KSP"
+    platform: ubuntu1804
+    working_directory: examples/ksp
+    test_targets:
+      - //...
   stardoc:
     name: Stardoc api documentation
     platform: ubuntu1804

--- a/examples/ksp/BUILD
+++ b/examples/ksp/BUILD
@@ -11,10 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-load("@rules_java//java:defs.bzl", "java_plugin")
 load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain", "kt_compiler_plugin")
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_plugin")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 package(default_visibility = ["//visibility:public"])

--- a/examples/ksp/BUILD
+++ b/examples/ksp/BUILD
@@ -22,10 +22,7 @@ package(default_visibility = ["//visibility:public"])
 
 define_kt_toolchain(
     name = "kotlin_toolchain",
-    api_version = "1.6",
-    experimental_use_abi_jars = True,
     jvm_target = "1.8",
-    language_version = "1.6",
 )
 
 kt_compiler_plugin(

--- a/examples/ksp/BUILD
+++ b/examples/ksp/BUILD
@@ -1,0 +1,98 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+load("@rules_java//java:defs.bzl", "java_plugin")
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain", "kt_compiler_plugin")
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
+
+package(default_visibility = ["//visibility:public"])
+
+# Kotlin Toolchain
+
+define_kt_toolchain(
+    name = "kotlin_toolchain",
+    api_version = "1.6",
+    experimental_use_abi_jars = True,
+    jvm_target = "1.8",
+    language_version = "1.6",
+)
+
+kt_compiler_plugin(
+    name = "ksp-symbol-processing",
+    id = "com.google.devtools.ksp.symbol-processing",
+    options = {
+        "apclasspath": "{apclasspath}",
+        "projectBaseDir": "{incrementalData}",
+        "incremental": "{temp}",
+        "classOutputDir": "{generatedClasses}",
+        "javaOutputDir": "{generatedSources}",
+        "kotlinOutputDir": "{generatedSources}",
+        "resourceOutputDir": "{generatedSources}",
+        "kspOutputDir": "{incrementalData}",
+        "cachesDir": "{incrementalData}",
+        "withCompilation": "true",
+        "allWarningsAsErrors": "false",
+    },
+    target_embedded_compiler = True,
+    visibility = ["//visibility:public"],
+    deps = [
+        "@maven//:com_google_devtools_ksp_symbol_processing",
+        "@maven//:com_google_devtools_ksp_symbol_processing_api",
+    ],
+)
+
+java_plugin(
+    name = "moshi-kotlin-codegen",
+    generates_api = 1,
+    processor_class = "com.squareup.moshi.kotlin.codegen.ksp.JsonClassSymbolProcessorProvider",
+    deps = [
+        "@maven//:com_squareup_moshi_moshi",
+        "@maven//:com_squareup_moshi_moshi_kotlin",
+        "@maven//:com_squareup_moshi_moshi_kotlin_codegen",
+    ],
+)
+
+java_library(
+    name = "moshi-java-plugin",
+    exported_plugins = [":moshi-kotlin-codegen"],
+    exports = [
+        "@maven//:com_squareup_moshi_moshi",
+        "@maven//:com_squareup_moshi_moshi_kotlin",
+    ],
+)
+
+kt_jvm_library(
+    name = "coffee_lib",
+    srcs = [
+        "CoffeeApp.kt",
+        "CoffeeAppModel.kt",
+    ],
+    plugins = ["//:ksp-symbol-processing"],
+    deps = ["//:moshi-java-plugin"],
+)
+
+java_binary(
+    name = "coffee_app",
+    main_class = "coffee.CoffeeApp",
+    visibility = ["//visibility:public"],
+    runtime_deps = [":coffee_lib"],
+)
+
+build_test(
+    name = "force_build_app_test",
+    targets = [
+        "//app:coffee_app",
+    ],
+)

--- a/examples/ksp/BUILD
+++ b/examples/ksp/BUILD
@@ -93,6 +93,6 @@ java_binary(
 build_test(
     name = "force_build_app_test",
     targets = [
-        "//app:coffee_app",
+        "//:coffee_app",
     ],
 )

--- a/examples/ksp/CoffeeApp.kt
+++ b/examples/ksp/CoffeeApp.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package coffee
+
+import com.squareup.moshi.Moshi
+
+class CoffeeApp {
+
+  companion object {
+
+    private val adapter = CoffeeAppModelJsonAdapter(Moshi.Builder().build())
+
+    @JvmStatic
+    fun main(args: Array<String>) {
+      println(
+        adapter.toJson(CoffeeAppModel("1"))
+      )
+    }
+  }
+}

--- a/examples/ksp/CoffeeAppModel.kt
+++ b/examples/ksp/CoffeeAppModel.kt
@@ -1,0 +1,8 @@
+package coffee
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class CoffeeAppModel(
+  val id: String
+)

--- a/examples/ksp/WORKSPACE
+++ b/examples/ksp/WORKSPACE
@@ -1,0 +1,63 @@
+_KOTLIN_COMPILER_VERSION = "1.7.10"
+
+_KOTLIN_COMPILER_SHA = "7683f5451ef308eb773a686ee7779a76a95ed8b143c69ac247937619d7ca3a09"
+
+local_repository(
+    name = "release_archive",
+    path = "../../src/main/starlark/release_archive",
+)
+
+load("@release_archive//:repository.bzl", "archive_repository")
+
+archive_repository(
+    name = "io_bazel_rules_kotlin",
+)
+
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "kotlinc_version", "versions")
+
+kotlin_repositories(
+    compiler_release = kotlinc_version(
+        release = _KOTLIN_COMPILER_VERSION,
+        sha256 = _KOTLIN_COMPILER_SHA,
+    ),
+)
+
+register_toolchains("//:kotlin_toolchain")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_jvm_external",
+    sha256 = versions.RULES_JVM_EXTERNAL_SHA,
+    strip_prefix = "rules_jvm_external-%s" % versions.RULES_JVM_EXTERNAL_TAG,
+    url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % versions.RULES_JVM_EXTERNAL_TAG,
+)
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = versions.SKYLIB_SHA,
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/%s/bazel-skylib-%s.tar.gz" % (
+        versions.SKYLIB_VERSION,
+        versions.SKYLIB_VERSION,
+    )],
+)
+
+load("@rules_jvm_external//:defs.bzl", "maven_install")
+
+maven_install(
+    artifacts = [
+        "com.squareup.moshi:moshi:1.13.0",
+        "com.squareup.moshi:moshi-kotlin:1.13.0",
+        "com.squareup.moshi:moshi-kotlin-codegen:1.13.0",
+        "org.jetbrains.kotlin:kotlin-stdlib:{}".format(_KOTLIN_COMPILER_VERSION),
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk7:{}".format(_KOTLIN_COMPILER_VERSION),
+        "org.jetbrains.kotlin:kotlin-stdlib-jdk8:{}".format(_KOTLIN_COMPILER_VERSION),
+        "org.jetbrains.kotlin:kotlin-stdlib-common:{}".format(_KOTLIN_COMPILER_VERSION),
+        "org.jetbrains.kotlin:kotlin-reflect:{}".format(_KOTLIN_COMPILER_VERSION),
+        "com.google.devtools.ksp:symbol-processing-api:{}-1.0.6".format(_KOTLIN_COMPILER_VERSION),
+        "com.google.devtools.ksp:symbol-processing:{}-1.0.6".format(_KOTLIN_COMPILER_VERSION),
+    ],
+    repositories = [
+        "https://repo1.maven.org/maven2",
+    ],
+)

--- a/examples/ksp/WORKSPACE
+++ b/examples/ksp/WORKSPACE
@@ -1,6 +1,4 @@
-_KOTLIN_COMPILER_VERSION = "1.7.10"
-
-_KOTLIN_COMPILER_SHA = "7683f5451ef308eb773a686ee7779a76a95ed8b143c69ac247937619d7ca3a09"
+_KOTLIN_COMPILER_VERSION = "1.8.0"
 
 local_repository(
     name = "release_archive",
@@ -15,12 +13,7 @@ archive_repository(
 
 load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "kotlinc_version", "versions")
 
-kotlin_repositories(
-    compiler_release = kotlinc_version(
-        release = _KOTLIN_COMPILER_VERSION,
-        sha256 = _KOTLIN_COMPILER_SHA,
-    ),
-)
+kotlin_repositories()
 
 register_toolchains("//:kotlin_toolchain")
 
@@ -46,16 +39,16 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
     artifacts = [
-        "com.squareup.moshi:moshi:1.13.0",
-        "com.squareup.moshi:moshi-kotlin:1.13.0",
-        "com.squareup.moshi:moshi-kotlin-codegen:1.13.0",
+        "com.squareup.moshi:moshi:1.14.0",
+        "com.squareup.moshi:moshi-kotlin:1.14.0",
+        "com.squareup.moshi:moshi-kotlin-codegen:1.14.0",
         "org.jetbrains.kotlin:kotlin-stdlib:{}".format(_KOTLIN_COMPILER_VERSION),
         "org.jetbrains.kotlin:kotlin-stdlib-jdk7:{}".format(_KOTLIN_COMPILER_VERSION),
         "org.jetbrains.kotlin:kotlin-stdlib-jdk8:{}".format(_KOTLIN_COMPILER_VERSION),
         "org.jetbrains.kotlin:kotlin-stdlib-common:{}".format(_KOTLIN_COMPILER_VERSION),
         "org.jetbrains.kotlin:kotlin-reflect:{}".format(_KOTLIN_COMPILER_VERSION),
-        "com.google.devtools.ksp:symbol-processing-api:{}-1.0.6".format(_KOTLIN_COMPILER_VERSION),
-        "com.google.devtools.ksp:symbol-processing:{}-1.0.6".format(_KOTLIN_COMPILER_VERSION),
+        "com.google.devtools.ksp:symbol-processing-api:{}-1.0.8".format(_KOTLIN_COMPILER_VERSION),
+        "com.google.devtools.ksp:symbol-processing:{}-1.0.8".format(_KOTLIN_COMPILER_VERSION),
     ],
     repositories = [
         "https://repo1.maven.org/maven2",

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -657,7 +657,7 @@ def _run_kt_java_builder_actions(
             associates = associates,
             compile_deps = compile_deps,
             deps_artifacts = deps_artifacts,
-            annotation_processors = [],
+            annotation_processors = annotation_processors,
             transitive_runtime_jars = transitive_runtime_jars,
             plugins = plugins,
             outputs = outputs,

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
@@ -99,8 +99,11 @@ internal fun JvmCompilationTask.plugins(
 
     val dirTokens = mapOf(
       "{generatedClasses}" to directories.generatedClasses,
-      "{stubs}" to directories.stubs,
       "{generatedSources}" to directories.generatedSources,
+      "{incrementalData}" to directories.incrementalData,
+      "{stubs}" to directories.stubs,
+      "{temp}" to directories.temp,
+      "{apclasspath}" to inputs.processorpathsList.joinToString(File.pathSeparator),
     )
     options.forEach { opt ->
       val formatted = dirTokens.entries.fold(opt) { formatting, (token, value) ->


### PR DESCRIPTION
This is a second attempt at getting a less intrusive version of KSP working with rules_kotlin based on some feedback in the previous PR.

This approach relies on a kt_compiler_plugin to pass the KSP compiler into builds.