### PR TITLE
Fix blankline printed for each action when executing on RBE

### DIFF
--- a/src/main/kotlin/io/bazel/worker/InvocationWorker.kt
+++ b/src/main/kotlin/io/bazel/worker/InvocationWorker.kt
@@ -23,7 +23,10 @@ class InvocationWorker(private val arguments: Iterable<String>) : Worker {
     runCatching {
       WorkerContext.run {
         doTask("invocation") { ctx -> execute(ctx, arguments) }.run {
-          println(log.out.toString())
+          val out = log.out.toString()
+          if (out != "") {
+            println(out)
+          }
           status.exit
         }
       }

--- a/src/main/kotlin/io/bazel/worker/InvocationWorker.kt
+++ b/src/main/kotlin/io/bazel/worker/InvocationWorker.kt
@@ -23,10 +23,7 @@ class InvocationWorker(private val arguments: Iterable<String>) : Worker {
     runCatching {
       WorkerContext.run {
         doTask("invocation") { ctx -> execute(ctx, arguments) }.run {
-          val out = log.out.toString()
-          if (out != "") {
-            println(out)
-          }
+          print(log.out.toString())
           status.exit
         }
       }


### PR DESCRIPTION
Before, when executing rules_kotlin actions on RBE, we would see the following output:

```
INFO: Starting clean (this may take a while). Consider using --async if the clean takes more than several minutes.
INFO: Invocation ID: 103e8c8e-dc23-42b2-9806-dfe404ef28b8
INFO: Streaming build results to: http://localhost:8080/invocation/103e8c8e-dc23-42b2-9806-dfe404ef28b8
INFO: Analyzed target //:foo (54 packages loaded, 935 targets configured).
INFO: Found 1 target...
INFO: From KotlinCompile //:foo { kt: 1, java: 0, srcjars: 0 } for k8:

INFO: From JdepsMerge //:foo { jdeps: 1 }:

Target //:foo up-to-date:
  bazel-bin/foo.jar
  bazel-bin/foo.jdeps
INFO: Elapsed time: 35.041s, Critical Path: 8.99s
INFO: 14 processes: 7 internal, 7 remote.
INFO: Streaming build results to: http://localhost:8080/invocation/103e8c8e-dc23-42b2-9806-dfe404ef28b8
INFO: Build completed successfully, 14 total actions
```

Note there is an unnecessary blank line printed from each action, specifically this part:

```
INFO: From KotlinCompile //:foo { kt: 1, java: 0, srcjars: 0 } for k8:

INFO: From JdepsMerge //:foo { jdeps: 1 }:

```


 For builds with hundreds or thousands of kotlin actions, this is quite noisy.

After this patch, we see:

```
INFO: Starting clean (this may take a while). Consider using --async if the clean takes more than several minutes.
INFO: Invocation ID: a9ceb126-c336-49b8-af91-250011d3b202
INFO: Streaming build results to: http://localhost:8080/invocation/a9ceb126-c336-49b8-af91-250011d3b202
INFO: Analyzed target //:foo (54 packages loaded, 935 targets configured).
INFO: Found 1 target...
Target //:foo up-to-date:
  bazel-bin/foo.jar
  bazel-bin/foo.jdeps
INFO: Elapsed time: 35.049s, Critical Path: 8.70s
INFO: 14 processes: 7 internal, 7 remote.
INFO: Streaming build results to: http://localhost:8080/invocation/a9ceb126-c336-49b8-af91-250011d3b202
INFO: Build completed successfully, 14 total actions
```