### PR TITLE
[KtLint] Add ktlint.check and ktlint.fix make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,20 @@ test:
 test.local:
 	bazel test all_local_tests
 
+ktlint.check:
+	bazel test //... --test_tag_filters="ktlint" --test_output=errors
+ktlint.fix:
+	bazel run //src/main/kotlin/io/bazel/kotlin/builder/cmd:build_lib_ktlint_fix
+	bazel run //src/main/kotlin/io/bazel/kotlin/builder/cmd:merge_jdeps_lib_ktlint_fix
+	bazel run //src/main/kotlin/io/bazel/kotlin/builder/tasks:tasks_ktlint_fix
+	bazel run //src/main/kotlin/io/bazel/kotlin/builder/toolchain:toolchain_ktlint_fix
+	bazel run //src/main/kotlin/io/bazel/kotlin/builder/utils:utils_ktlint_fix
+	bazel run //src/main/kotlin/io/bazel/kotlin/builder/utils/jars:jars_ktlint_fix
+	bazel run //src/main/kotlin/io/bazel/kotlin/compiler:compiler_ktlint_fix
+	bazel run //src/main/kotlin/io/bazel/kotlin/plugin:skip-code-gen-lib_ktlint_fix
+	bazel run //src/main/kotlin/io/bazel/kotlin/plugin/jdeps:jdeps-gen-lib_ktlint_fix
+	bazel run //src/main/kotlin/io/bazel/worker:worker_ktlint_fix
+
 test.no_worker:
 	bazel clean
 	bazel shutdown


### PR DESCRIPTION
Adding some convenience make commands for ktlint fixing and validation. Note that the fix command is broken into individual invocations because Bazel doesn't support running multiple targets using `bazel run`.