### PR TITLE
Add an env attribute to kt_jvm_test

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -300,7 +300,7 @@ def kt_jvm_junit_test_impl(ctx):
             direct = ctx.files._java_runtime,
         ),
         # adds common test variables, including TEST_WORKSPACE.
-        testing.TestEnvironment(environment = ctx.attr.env)
+        testing.TestEnvironment(environment = ctx.attr.env),
     )
 
 _KtCompilerPluginClasspathInfo = provider(

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -300,7 +300,7 @@ def kt_jvm_junit_test_impl(ctx):
             direct = ctx.files._java_runtime,
         ),
         # adds common test variables, including TEST_WORKSPACE.
-        testing.TestEnvironment({}),
+        testing.TestEnvironment(environment = ctx.attr.env)
     )
 
 _KtCompilerPluginClasspathInfo = provider(

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -346,6 +346,10 @@ Setup a simple kotlin_test.
             default = "",
         ),
         "main_class": attr.string(default = "com.google.testing.junit.runner.BazelTestRunner"),
+        "env": attr.string_dict(
+            doc = "Specifies additional environment variables to set when the target is executed by bazel test.",
+            default = {},
+        ),
         "_lcov_merger": attr.label(
             default = Label("@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"),
         ),


### PR DESCRIPTION
This is consistent with the `env` attribute supported by native test rules:
https://docs.bazel.build/versions/main/be/common-definitions.html#common-attributes-tests

It's possible to support env_inherit, but only for Bazel versions >= 5.2.0. I'm not sure of the rules_kotlin bazel support policy so I did not go ahead and do this. It would also be possible but a little complicated to support env_inherit for bazel >= 5.2.0 while not breaking users on older versions with a dynamic check as in [this rules_go PR](https://github.com/bazelbuild/rules_go/pull/3256)