### PR TITLE
Support testing both k2 and old compiler for Jdeps

### DIFF
--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -239,5 +239,10 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
                 .setGeneratedClassJar(instanceRoot().resolve("incremental.jar").toAbsolutePath().toString());
             return this;
         }
+
+        public TaskBuilder useK2() {
+            taskBuilder.getInfoBuilder().addPassthroughFlags("-Xuse-k2");
+            return this;
+        }
     }
 }


### PR DESCRIPTION
This does a bunch of cleanup of repeated test setup and adds the ability to write tests for the jdeps plugin using the k2 compiler.

Task: https://github.com/bazelbuild/rules_kotlin/issues/843
