### PR TITLE
Bazel 6.0: Fix config_setting visibility failure on bazel CI

### DIFF
--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -341,25 +341,30 @@ def kt_configure_toolchains():
     native.config_setting(
         name = "experimental_use_abi_jars",
         values = {"define": "experimental_use_abi_jars=1"},
+        visibility = ["//visibility:public"],
     )
     native.config_setting(
         name = "noexperimental_use_abi_jars",
         values = {"define": "experimental_use_abi_jars=0"},
+        visibility = ["//visibility:public"],
     )
 
     native.config_setting(
         name = "builder_debug_timings",
         values = {"define": "kt_timings=1"},
+        visibility = ["//visibility:public"],
     )
 
     native.config_setting(
         name = "experimental_multiplex_workers",
         values = {"define": "kt_multiplex=1"},
+        visibility = ["//visibility:public"],
     )
 
     native.config_setting(
         name = "builder_debug_trace",
         values = {"define": "kt_trace=1"},
+        visibility = ["//visibility:public"],
     )
 
     native.toolchain_type(


### PR DESCRIPTION
See bazelbuild/bazel#12933.

Repro: `$ USE_BAZEL_VERSION=a05276fea75d47370b363125a074c38cb2badc74 bazelisk build --nobuild --incompatible_config_setting_private_default_visibility //bzl:experimental_toolchain_impl`

Discovered in failing Bazel CI with `--incompatible_config_setting_private_default_visibility` flipped:

https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/1297#0183cee1-44c6-4fae-982b-874262458433