### PR TITLE
Example to repro jdeps issue 

### DIFF
--- a/examples/jdesp_issue/WORKSPACE
+++ b/examples/jdesp_issue/WORKSPACE
@@ -1,0 +1,45 @@
+local_repository(
+    name = "release_archive",
+    path = "../../src/main/starlark/release_archive",
+)
+
+load("@release_archive//:repository.bzl", "archive_repository")
+
+archive_repository(
+    name = "io_bazel_rules_kotlin",
+    local_path = "../..",
+)
+
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "versions")
+
+kotlin_repositories()
+
+register_toolchains("//bzl:experimental_toolchain")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = versions.SKYLIB_SHA,
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/%s/bazel-skylib-%s.tar.gz" % (
+        versions.SKYLIB_VERSION,
+        versions.SKYLIB_VERSION,
+    )],
+)
+
+http_archive(
+    name = "build_bazel_rules_android",
+    sha256 = versions.ANDROID.SHA,
+    strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
+    urls = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % versions.ANDROID.VERSION],
+)
+
+load(
+    "@build_bazel_rules_android//android:rules.bzl",
+    "android_sdk_repository",
+)
+
+android_sdk_repository(
+    name = "androidsdk",
+    build_tools_version = "30.0.2",
+)

--- a/examples/jdesp_issue/bzl/BUILD.bazel
+++ b/examples/jdesp_issue/bzl/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain", "kt_kotlinc_options")
+load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_javac_options")
+
+kt_kotlinc_options(
+    name = "default_kotlinc_options",
+)
+
+kt_javac_options(
+    name = "default_javac_options",
+)
+
+KOTLIN_LANGUAGE_LEVEL = "1.6"
+
+define_kt_toolchain(
+    name = "experimental_toolchain",
+    api_version = KOTLIN_LANGUAGE_LEVEL,
+    # TODO(630): enable when the reduced classpath can correctly manage transitive maven dependencies.
+    # experimental_reduce_classpath_mode = "KOTLINBUILDER_REDUCED",
+    experimental_report_unused_deps = "warn",
+    experimental_strict_kotlin_deps = "warn",
+    experimental_use_abi_jars = True,
+    javac_options = ":default_javac_options",
+    kotlinc_options = ":default_kotlinc_options",
+    language_version = KOTLIN_LANGUAGE_LEVEL,
+)

--- a/examples/jdesp_issue/libKtAndroid1/BUILD.bazel
+++ b/examples/jdesp_issue/libKtAndroid1/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
+
+kt_android_library(
+    name = "src_main",
+    srcs = glob(["src/main/kt/examples/deps/KtDummy1.kt"]),
+    custom_package = "examples.deps.libktandroid1",
+    manifest = "src/main/AndroidManifest.xml",
+    resource_files = glob(["src/main/res/**/*"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libKtAndroid2:src_main",
+    ],
+)

--- a/examples/jdesp_issue/libKtAndroid1/src/main/AndroidManifest.xml
+++ b/examples/jdesp_issue/libKtAndroid1/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="examples.deps.libktandroid1">
+        <uses-sdk
+        android:minSdkVersion="23"
+        android:targetSdkVersion="23"
+        android:maxSdkVersion="29" />
+</manifest>  

--- a/examples/jdesp_issue/libKtAndroid1/src/main/kt/examples/deps/KtDummy1.kt
+++ b/examples/jdesp_issue/libKtAndroid1/src/main/kt/examples/deps/KtDummy1.kt
@@ -1,0 +1,19 @@
+package examples.deps.libktandroid1
+import examples.deps.libktandroid2.KtDummy2
+
+class KtDummy1{
+
+  companion object {
+
+    private val resourceId = R.string.dummy1;
+  }
+
+  // Fails with jdeps:
+  //    --@io_bazel_rules_kotlin//kotlin/internal/jvm:experimental_prune_transitive_deps=True
+  //    --@io_bazel_rules_kotlin//kotlin/internal/jvm:kotlin_deps=True
+  // Passes without jdeps:
+  //    --@io_bazel_rules_kotlin//kotlin/internal/jvm:experimental_prune_transitive_deps=True
+  //    --@io_bazel_rules_kotlin//kotlin/internal/jvm:kotlin_deps=False
+  fun returnSomeType():KtDummy2 = KtDummy2()
+
+}

--- a/examples/jdesp_issue/libKtAndroid1/src/main/res/values/strings.xml
+++ b/examples/jdesp_issue/libKtAndroid1/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources translatable="false">
+    <string name="dummy1">Dummy</string>
+</resources>

--- a/examples/jdesp_issue/libKtAndroid2/BUILD.bazel
+++ b/examples/jdesp_issue/libKtAndroid2/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
+
+kt_android_library(
+    name = "src_main",
+    srcs = glob(["src/main/kt/**/*.kt"]),
+    custom_package = "examples.deps.libktandroid2",
+    manifest = "src/main/AndroidManifest.xml",
+    resource_files = glob(["src/main/res/**/*"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//libKtAndroid3:src_main",
+    ],
+)
+

--- a/examples/jdesp_issue/libKtAndroid2/src/main/AndroidManifest.xml
+++ b/examples/jdesp_issue/libKtAndroid2/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="examples.deps.libktandroid2">
+        <uses-sdk
+        android:minSdkVersion="23"
+        android:targetSdkVersion="23"
+        android:maxSdkVersion="29" />
+</manifest>  

--- a/examples/jdesp_issue/libKtAndroid2/src/main/kt/examples/deps/KtDummy2.kt
+++ b/examples/jdesp_issue/libKtAndroid2/src/main/kt/examples/deps/KtDummy2.kt
@@ -1,0 +1,16 @@
+package examples.deps.libktandroid2
+import examples.deps.libktandroid3.KtDummy3
+
+class KtDummy2 : KtDummy3() {
+
+  companion object {
+
+    private val resourceId = R.string.dummy2;
+  }
+
+  override fun dummy() {
+    System.out.println("dummy")
+  }
+
+  fun foo() { }
+}

--- a/examples/jdesp_issue/libKtAndroid2/src/main/res/values/strings.xml
+++ b/examples/jdesp_issue/libKtAndroid2/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources translatable="false">
+    <string name="dummy2">Dummy</string>
+</resources>

--- a/examples/jdesp_issue/libKtAndroid3/BUILD.bazel
+++ b/examples/jdesp_issue/libKtAndroid3/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_library")
+
+kt_android_library(
+    name = "src_main",
+    srcs = glob(["src/main/kt/**/*.kt"]),
+    custom_package = "examples.deps.libktandroid3",
+    manifest = "src/main/AndroidManifest.xml",
+    resource_files = glob(["src/main/res/**/*"]),
+    visibility = ["//visibility:public"],
+    deps = [
+    ],
+)

--- a/examples/jdesp_issue/libKtAndroid3/src/main/AndroidManifest.xml
+++ b/examples/jdesp_issue/libKtAndroid3/src/main/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="examples.deps.libktandroid3">
+        <uses-sdk
+        android:minSdkVersion="23"
+        android:targetSdkVersion="23"
+        android:maxSdkVersion="29" />
+</manifest>  

--- a/examples/jdesp_issue/libKtAndroid3/src/main/kt/examples/deps/KtDummy3.kt
+++ b/examples/jdesp_issue/libKtAndroid3/src/main/kt/examples/deps/KtDummy3.kt
@@ -1,0 +1,13 @@
+package examples.deps.libktandroid3
+
+open class KtDummy3 {
+
+  companion object {
+
+    private val resourceId = R.string.dummy3;
+  }
+
+  open fun dummy() {
+    System.out.println("dummy")
+  }
+}

--- a/examples/jdesp_issue/libKtAndroid3/src/main/res/values/strings.xml
+++ b/examples/jdesp_issue/libKtAndroid3/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources translatable="false">
+    <string name="dummy3">Dummy</string>
+</resources>

--- a/kotlin/internal/jvm/BUILD
+++ b/kotlin/internal/jvm/BUILD
@@ -33,3 +33,13 @@ bzl_library(
         "@build_bazel_rules_android//android",
     ],
 )
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+# Kotlin strict deps can be enabled by setting the following value on the command line
+# --@io_bazel_rules_kotlin//kotlin/internal/jvm:experimental_prune_transitive_deps=True
+bool_flag(
+    name = "experimental_prune_transitive_deps",
+    build_setting_default = False,
+    visibility = ["//visibility:public"]
+)

--- a/kotlin/internal/jvm/BUILD
+++ b/kotlin/internal/jvm/BUILD
@@ -16,6 +16,8 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 # limitations under the License.
 exports_files(["jetbrains-deshade.jarjar"])
 
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
 release_archive(
     name = "pkg",
     srcs = glob(["*.bzl"]) + ["jetbrains-deshade.jarjar"],
@@ -34,8 +36,6 @@ bzl_library(
     ],
 )
 
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
-
 # Kotlin strict deps can be enabled by setting the following value on the command line
 # --@io_bazel_rules_kotlin//kotlin/internal/jvm:experimental_prune_transitive_deps=True
 bool_flag(
@@ -43,3 +43,12 @@ bool_flag(
     build_setting_default = False,
     visibility = ["//visibility:public"]
 )
+
+# Jdeps plugin can be enabled or disabled using the following flag ont the command line
+# --@io_bazel_rules_kotlin//kotlin/internal/jvm:kotlin_deps=false
+bool_flag(
+    name = "kotlin_deps",
+    build_setting_default = True,  # Upstream default behavior
+    visibility = ["//visibility:public"],
+)
+

--- a/kotlin/internal/jvm/BUILD.release.bazel
+++ b/kotlin/internal/jvm/BUILD.release.bazel
@@ -22,3 +22,10 @@ bool_flag(
     build_setting_default = False,
     visibility = ["//visibility:public"]
 )
+
+# Jdeps plugin can be enabled or disabled using the following flag ont the command line
+# --@io_bazel_rules_kotlin//kotlin/internal/jvm:kotlin_deps=false
+bool_flag(
+    name = "kotlin_deps",
+    build_setting_default = True, # Upstream default behavior
+    visibility = ["//visibility:public"])

--- a/kotlin/internal/jvm/BUILD.release.bazel
+++ b/kotlin/internal/jvm/BUILD.release.bazel
@@ -12,3 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 exports_files(["jetbrains-deshade.jarjar"])
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+
+# Kotlin strict deps can be enabled by setting the following value on the command line
+# --@io_bazel_rules_kotlin//kotlin/internal/jvm:experimental_prune_transitive_deps=True
+bool_flag(
+    name = "experimental_prune_transitive_deps",
+    build_setting_default = False,
+    visibility = ["//visibility:public"]
+)

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -30,6 +30,7 @@ def _kt_android_artifact(
         enable_data_binding = False,
         tags = [],
         exec_properties = None,
+        resource_files = None,
         **kwargs):
     """Delegates Android related build attributes to the native rules but uses the Kotlin builder to compile Java and
     Kotlin srcs. Returns a sequence of labels that a wrapping macro should export.
@@ -40,18 +41,47 @@ def _kt_android_artifact(
     # TODO(bazelbuild/rules_kotlin/issues/273): This should be retrieved from a provider.
     base_deps = [_ANDROID_SDK_JAR] + deps
 
-    # TODO(bazelbuild/rules_kotlin/issues/556): replace with starlark
-    # buildifier: disable=native-android
-    native.android_library(
-        name = base_name,
-        visibility = ["//visibility:private"],
-        exports = base_deps,
-        deps = deps if enable_data_binding else [],
-        enable_data_binding = enable_data_binding,
-        tags = tags,
-        exec_properties = exec_properties,
-        **kwargs
-    )
+    exported_target_labels = [kt_name]
+    if "kt_prune_transitive_deps_incompatible" in tags:
+        # TODO(https://github.com/bazelbuild/rules_kotlin/issues/556): replace with starlark
+        # buildifier: disable=native-android
+        native.android_library(
+            name = base_name,
+            resource_files = resource_files,
+            exports = base_deps,
+            deps = deps if enable_data_binding else [],
+            enable_data_binding = enable_data_binding,
+            tags = tags,
+            visibility = ["//visibility:private"],
+            **kwargs
+        )
+        exported_target_labels.append(base_name)
+    elif resource_files:
+        # TODO(https://github.com/bazelbuild/rules_kotlin/issues/556): replace with starlark
+        # buildifier: disable=native-android
+        # Do not export deps to avoid all upstream targets to be invalidated when ABI changes.
+        native.android_library(
+            name = base_name,
+            resource_files = resource_files,
+            deps = deps,
+            custom_package = kwargs.get("custom_package", default = None),
+            manifest = kwargs.get("manifest", default = None),
+            enable_data_binding = enable_data_binding,
+            tags = tags,
+            visibility = ["//visibility:private"],
+        )
+        exported_target_labels.append(base_name)
+    else:
+        # No need to export this target, as it's used exclusively internally
+        native.android_library(
+            name = base_name,
+            exports = deps,
+            enable_data_binding = enable_data_binding,
+            tags = tags,
+            visibility = ["//visibility:private"],
+            **kwargs
+        )
+
     _kt_jvm_library(
         name = kt_name,
         srcs = srcs,

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -499,7 +499,11 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
     generated_src_jars = []
     annotation_processing = None
     compile_jar = ctx.actions.declare_file(ctx.label.name + ".abi.jar")
-    output_jdeps = ctx.actions.declare_file(ctx.label.name + ".jdeps")
+
+    output_jdeps = None
+    if ctx.attr._kotlin_deps[BuildSettingInfo].value:
+        output_jdeps = ctx.actions.declare_file(ctx.label.name + ".jdeps")
+
     outputs_struct = _run_kt_java_builder_actions(
         ctx = ctx,
         rule_kind = rule_kind,
@@ -641,20 +645,22 @@ def _run_kt_java_builder_actions(
     # Build Kotlin
     if has_kt_sources:
         kt_runtime_jar = ctx.actions.declare_file(ctx.label.name + "-kt.jar")
-        kt_jdeps = ctx.actions.declare_file(ctx.label.name + "-kt.jdeps")
         if not "kt_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_use_abi_jars == True:
             kt_compile_jar = ctx.actions.declare_file(ctx.label.name + "-kt.abi.jar")
             outputs = {
                 "output": kt_runtime_jar,
                 "abi_jar": kt_compile_jar,
-                "kotlin_output_jdeps": kt_jdeps,
             }
         else:
             kt_compile_jar = kt_runtime_jar
             outputs = {
                 "output": kt_runtime_jar,
-                "kotlin_output_jdeps": kt_jdeps,
             }
+
+        kt_jdeps = None
+        if ctx.attr._kotlin_deps[BuildSettingInfo].value:
+            kt_jdeps = ctx.actions.declare_file(ctx.label.name + "-kt.jdeps")
+            outputs["kotlin_output_jdeps"] = kt_jdeps
 
         _run_kt_builder_action(
             ctx = ctx,
@@ -732,24 +738,25 @@ def _run_kt_java_builder_actions(
         input_jars = compile_jars,
     )
 
-    jdeps = []
-    for java_info in java_infos:
-        if java_info.outputs.jdeps:
-            jdeps.append(java_info.outputs.jdeps)
+    if ctx.attr._kotlin_deps[BuildSettingInfo].value:
+        jdeps = []
+        for java_info in java_infos:
+            if java_info.outputs.jdeps:
+                jdeps.append(java_info.outputs.jdeps)
 
-    if jdeps:
-        _run_merge_jdeps_action(
-            ctx = ctx,
-            toolchains = toolchains,
-            jdeps = jdeps,
-            deps = compile_deps.deps,
-            outputs = {"output": output_jdeps},
-        )
-    else:
-        ctx.actions.symlink(
-            output = output_jdeps,
-            target_file = toolchains.kt.empty_jdeps,
-        )
+        if jdeps:
+            _run_merge_jdeps_action(
+                ctx = ctx,
+                toolchains = toolchains,
+                jdeps = jdeps,
+                deps = compile_deps.deps,
+                outputs = {"output": output_jdeps},
+            )
+        else:
+            ctx.actions.symlink(
+                output = output_jdeps,
+                target_file = toolchains.kt.empty_jdeps,
+            )
 
     annotation_processing = None
     if annotation_processors:
@@ -793,7 +800,6 @@ def export_only_providers(ctx, actions, attr, outputs):
         kt_compiler_result
     """
     toolchains = _compiler_toolchains(ctx)
-    output_jdeps = ctx.actions.declare_file(ctx.label.name + ".jdeps")
 
     # satisfy the outputs requirement. should never execute during normal compilation.
     actions.symlink(
@@ -806,10 +812,13 @@ def export_only_providers(ctx, actions, attr, outputs):
         target_file = toolchains.kt.empty_jar,
     )
 
-    actions.symlink(
-        output = output_jdeps,
-        target_file = toolchains.kt.empty_jdeps,
-    )
+    output_jdeps = None
+    if ctx.attr._kotlin_deps[BuildSettingInfo].value:
+        output_jdeps = ctx.actions.declare_file(ctx.label.name + ".jdeps")
+        actions.symlink(
+            output = output_jdeps,
+            target_file = toolchains.kt.empty_jdeps,
+        )
 
     java = JavaInfo(
         output_jar = toolchains.kt.empty_jar,

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -40,6 +40,7 @@ load(
     "//kotlin/internal/utils:sets.bzl",
     _sets = "sets",
 )
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 load(
     "@bazel_tools//tools/jdk:toolchain_utils.bzl",
     "find_java_runtime_toolchain",
@@ -89,7 +90,7 @@ def _compiler_toolchains(ctx):
         java_runtime = find_java_runtime_toolchain(ctx, ctx.attr._host_javabase),
     )
 
-def _jvm_deps(toolchains, associated_targets, deps, runtime_deps = []):
+def _jvm_deps(ctx, toolchains, associated_targets, deps, runtime_deps = []):
     """Encapsulates jvm dependency metadata."""
     diff = _sets.intersection(
         _sets.copy_of([x.label for x in associated_targets]),
@@ -101,16 +102,26 @@ def _jvm_deps(toolchains, associated_targets, deps, runtime_deps = []):
             ",\n ".join(["    %s" % x for x in list(diff)]),
         )
     dep_infos = [_java_info(d) for d in associated_targets + deps] + [toolchains.kt.jvm_stdlibs]
+
+    # Reduced classpath, exclude transitive deps from compilation
+    if (ctx.attr._experimental_prune_transitive_deps[BuildSettingInfo].value):
+        transitive = [
+            d.compile_jars
+            for d in dep_infos
+        ]
+    else:
+        transitive = [
+            d.compile_jars
+            for d in dep_infos
+        ] + [
+            d.transitive_compile_time_jars
+            for d in dep_infos
+        ]
+
     return struct(
         deps = dep_infos,
         compile_jars = depset(
-            transitive = [
-                d.compile_jars
-                for d in dep_infos
-            ] + [
-                d.transitive_compile_time_jars
-                for d in dep_infos
-            ],
+            transitive = transitive,
         ),
         runtime_deps = [_java_info(d) for d in runtime_deps],
     )
@@ -474,6 +485,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
     srcs = _partitioned_srcs(ctx.files.srcs)
     associates = _associate_utils.get_associates(ctx)
     compile_deps = _jvm_deps(
+        ctx,
         toolchains,
         associates.targets,
         deps = ctx.attr.deps,

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -33,6 +33,9 @@ def _is_absolute(path):
     return path.startswith("/") or (len(path) > 2 and path[1] == ":")
 
 def _make_providers(ctx, providers, transitive_files = depset(order = "default"), *additional_providers):
+    files = [ctx.outputs.jar]
+    if providers.java.outputs.jdeps:
+        files.append(providers.java.outputs.jdeps)
     return struct(
         kt = providers.kt,
         providers = [
@@ -40,7 +43,7 @@ def _make_providers(ctx, providers, transitive_files = depset(order = "default")
             providers.kt,
             providers.instrumented_files,
             DefaultInfo(
-                files = depset([ctx.outputs.jar, providers.java.outputs.jdeps]),
+                files = depset(files),
                 runfiles = ctx.runfiles(
                     # explicitly include data files, otherwise they appear to be missing
                     files = ctx.files.data,

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -237,6 +237,7 @@ _common_attr = utils.add_dicts(
             Transitive deps required for compilation must be explicitly added""",
             default = ":experimental_prune_transitive_deps",
         ),
+        "_kotlin_deps": attr.label(default = ":kotlin_deps"),
     },
 )
 

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -232,6 +232,11 @@ _common_attr = utils.add_dicts(
             providers = [_JavacOptions],
             mandatory = False,
         ),
+        "_experimental_prune_transitive_deps": attr.label(
+            doc = """If enabled, compilation is performed against only direct dependencies.
+            Transitive deps required for compilation must be explicitly added""",
+            default = ":experimental_prune_transitive_deps",
+        ),
     },
 )
 


### PR DESCRIPTION
 Fails with jdeps:
```
cd examples/jdesp_issue
bazel build //libKtAndroid1:src_main_kt --@io_bazel_rules_kotlin//kotlin/internal/jvm:experimental_prune_transitive_deps=True --@io_bazel_rules_kotlin//kotlin/internal/jvm:kotlin_deps=True
```

Passes without jdeps:
```
cd examples/jdesp_issue
bazel build //libKtAndroid1:src_main_kt --@io_bazel_rules_kotlin//kotlin/internal/jvm:experimental_prune_transitive_deps=True --@io_bazel_rules_kotlin//kotlin/internal/jvm:kotlin_deps=False
```

Error:
```
ERROR: /Users/nkorostelev/Snapchat/Dev/rules_kotlin/examples/jdesp_issue/libKtAndroid1/BUILD.bazel:3:19: KotlinCompile //libKtAndroid1:src_main_kt { kt: 1, java: 0, srcjars: 0 } for darwin_arm64 failed: (Exit 1): build failed: error executing command (from target //libKtAndroid1:src_main_kt)
  (cd /Users/nkorostelev/Snapchat/Dev/.cache/bazel/arm64/f7a5653e44abf3a0528c8c383a926394/execroot/__main__ && \
  exec env - \
    LC_CTYPE=en_US.UTF-8 \
    REPOSITORY_NAME=io_bazel_rules_kotlin \
  bazel-out/darwin_arm64-opt-exec-2B5CBBC6/bin/external/io_bazel_rules_kotlin/src/main/kotlin/build '--flagfile=bazel-out/darwin_arm64-fastbuild/bin/libKtAndroid1/src_main_kt-kt.jar-0.params')
# Configuration: 3222cb75a37bee8592598dc8e5437da815dc34e08dd4cee307b00b4cc8e60a77
# Execution platform: @local_config_platform//:host
error: supertypes of the following classes cannot be resolved. Please make sure you have the required dependencies in the classpath:
    class examples.deps.libktandroid2.KtDummy2, unresolved supertypes: examples.deps.libktandroid3.KtDummy3
Adding -Xextended-compiler-checks argument might provide additional information.
```

Probably caused by https://github.com/bazelbuild/rules_kotlin/pull/807 

In theory, I think if the build doesn't fail without jdeps then it should also not fail with jdeps - @aeremin  thoughts?