### PR TITLE
Fix AbstractMethodError in JdepsGenCommandLineProcessor

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
@@ -5,6 +5,7 @@ import org.jetbrains.kotlin.compiler.plugin.CliOption
 import org.jetbrains.kotlin.compiler.plugin.CliOptionProcessingException
 import org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor
 import org.jetbrains.kotlin.config.CompilerConfiguration
+import org.jetbrains.kotlin.config.CompilerConfigurationKey
 
 class JdepsGenCommandLineProcessor : CommandLineProcessor {
   companion object {
@@ -54,5 +55,23 @@ class JdepsGenCommandLineProcessor : CommandLineProcessor {
       )
       else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")
     }
+  }
+
+  override fun <T> CompilerConfiguration.appendList(
+    option: CompilerConfigurationKey<List<T>>,
+    value: T,
+  ) {
+    val paths = getList(option).toMutableList()
+    paths.add(value)
+    put(option, paths)
+  }
+
+  override fun <T> CompilerConfiguration.appendList(
+    option: CompilerConfigurationKey<List<T>>,
+    values: List<T>,
+  ) {
+    val paths = getList(option).toMutableList()
+    paths.addAll(values)
+    put(option, paths)
   }
 }


### PR DESCRIPTION
```
SEVERE: Compilation failure: compile phase failed:
exception: java.lang.AbstractMethodError: Receiver class io.bazel.kotlin.plugin.jdeps.JdepsGenCommandLineProcessor does not define or inherit an implementation of the resolved method 'abstract void appendList(org.jetbrains.kotlin.config.CompilerConfiguration, org.jetbrains.kotlin.config.CompilerConfigurationKey, java.lang.Object)' of interface org.jetbrains.kotlin.compiler.plugin.CommandLineProcessor.
at io.bazel.kotlin.plugin.jdeps.JdepsGenCommandLineProcessor.processOption(JdepsGenCommandLineProcessor.kt:47)
at org.jetbrains.kotlin.cli.jvm.plugins.PluginCliParserKt.processCompilerPluginsOptions(PluginCliParser.kt:125)
at org.jetbrains.kotlin.cli.jvm.plugins.PluginCliParser.processPluginOptions(PluginCliParser.kt:83)
at org.jetbrains.kotlin.cli.jvm.plugins.PluginCliParser.loadPlugins(PluginCliParser.kt:72)
at org.jetbrains.kotlin.cli.jvm.plugins.PluginCliParser.loadPluginsSafe(PluginCliParser.kt:44)
at org.jetbrains.kotlin.cli.common.CLICompiler.loadPlugins(CLICompiler.kt:183)
at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:69)
at org.jetbrains.kotlin.cli.jvm.K2JVMCompiler.doExecute(K2JVMCompiler.kt:52)
at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:92)
at org.jetbrains.kotlin.cli.common.CLICompiler.execImpl(CLICompiler.kt:44)
at org.jetbrains.kotlin.cli.common.CLITool.exec(CLITool.kt:98)
at io.bazel.kotlin.compiler.BazelK2JVMCompiler.exec(BazelK2JVMCompiler.kt:32)
at jdk.internal.reflect.GeneratedMethodAccessor92.invoke(Unknown Source)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:566)
at io.bazel.kotlin.builder.toolchain.KotlinToolchain$KotlinCliToolInvoker.compile(KotlinToolchain.kt:183)
at io.bazel.kotlin.builder.tasks.jvm.CompilationTaskKt$compileKotlin$1$2.invoke(CompilationTask.kt:328)
at io.bazel.kotlin.builder.tasks.jvm.CompilationTaskKt$compileKotlin$1$2.invoke(CompilationTask.kt:328)
at io.bazel.kotlin.builder.toolchain.CompilationTaskContext.executeCompilerTask(CompilationTaskContext.kt:126)
at io.bazel.kotlin.builder.toolchain.CompilationTaskContext.executeCompilerTask$default(CompilationTaskContext.kt:118)
at io.bazel.kotlin.builder.tasks.jvm.CompilationTaskKt.compileKotlin(CompilationTask.kt:328)
at io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor$execute$1$1$1$1.invoke(KotlinJvmTaskExecutor.kt:60)
at io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor$execute$1$1$1$1.invoke(KotlinJvmTaskExecutor.kt:58)
at io.bazel.kotlin.builder.toolchain.CompilationTaskContext.execute(CompilationTaskContext.kt:153)
at io.bazel.kotlin.builder.toolchain.CompilationTaskContext.execute(CompilationTaskContext.kt:145)
at io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor$execute$1.invoke(KotlinJvmTaskExecutor.kt:58)
at io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor$execute$1.invoke(KotlinJvmTaskExecutor.kt:54)
at io.bazel.kotlin.builder.toolchain.CompilationTaskContext.execute(CompilationTaskContext.kt:153)
at io.bazel.kotlin.builder.toolchain.CompilationTaskContext.execute(CompilationTaskContext.kt:145)
at io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor.execute(KotlinJvmTaskExecutor.kt:54)
at io.bazel.kotlin.builder.tasks.KotlinBuilder.executeJvmTask(KotlinBuilder.kt:212)
at io.bazel.kotlin.builder.tasks.KotlinBuilder.build(KotlinBuilder.kt:105)
at io.bazel.kotlin.builder.tasks.CompileKotlin.invoke(CompileKotlin.kt:27)
at io.bazel.worker.PersistentWorker$workTo$1.invoke(PersistentWorker.kt:97)
at io.bazel.worker.PersistentWorker$workTo$1.invoke(PersistentWorker.kt:97)
at io.bazel.worker.WorkerContext$TaskContext.resultOf(WorkerContext.kt:128)
at io.bazel.worker.WorkerContext.doTask(WorkerContext.kt:156)
at io.bazel.worker.PersistentWorker$start$1$1$producer$1$1.invoke$lambda$0(PersistentWorker.kt:70)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
```