### PR TITLE
Remove unused dependency in example

### DIFF
--- a/examples/plugin/src/serialization/BUILD
+++ b/examples/plugin/src/serialization/BUILD
@@ -37,7 +37,6 @@ kt_jvm_test(
     test_class = "plugin.serialization.SerializationTest",
     deps = [
         ":data",
-        "@com_github_jetbrains_kotlin//:kotlin-reflect",
         "@maven//:junit_junit",
     ],
 )


### PR DESCRIPTION
This was confusing me since I didn't understand why that was added to the deps, and it turns out it isn't needed.