### PR TITLE
Support setting kotlin_jvm_target at the target level

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -38,6 +38,7 @@ test_suite(
     tests = [
         "//src/test/kotlin/io/bazel/kotlin:assertion_tests",
         "//src/test/kotlin/io/bazel/kotlin/builder:builder_tests",
+        "//src/test/starlark:convert_tests",
     ],
 )
 
@@ -47,6 +48,7 @@ test_suite(
     tests = [
         ":all_tests",
         "//src/test/kotlin/io/bazel/kotlin:local_assertion_tests",
+        "//src/test/starlark:convert_tests",
     ],
 )
 

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -338,14 +338,14 @@ def _run_kt_builder_action(
         build_kotlin = True,
         mnemonic = "KotlinCompile"):
     """Creates a KotlinBuilder action invocation."""
-    args = _utils.init_args(ctx, rule_kind, associates.module_name)
+    kotlinc_options = ctx.attr.kotlinc_opts[KotlincOptions] if ctx.attr.kotlinc_opts else toolchains.kt.kotlinc_options
+    javac_options = ctx.attr.javac_opts[JavacOptions] if ctx.attr.javac_opts else toolchains.kt.javac_options
+    args = _utils.init_args(ctx, rule_kind, associates.module_name, kotlinc_options)
 
     for f, path in outputs.items():
         args.add("--" + f, path)
 
     # Unwrap kotlinc_options/javac_options options or default to the ones being provided by the toolchain
-    kotlinc_options = ctx.attr.kotlinc_opts[KotlincOptions] if ctx.attr.kotlinc_opts else toolchains.kt.kotlinc_options
-    javac_options = ctx.attr.javac_opts[JavacOptions] if ctx.attr.javac_opts else toolchains.kt.javac_options
     args.add_all("--kotlin_passthrough_flags", kotlinc_options_to_flags(kotlinc_options))
     args.add_all("--javacopts", javac_options_to_flags(javac_options))
     args.add_all("--direct_dependencies", _java_infos_to_compile_jars(compile_deps.deps))

--- a/kotlin/internal/utils/utils.bzl
+++ b/kotlin/internal/utils/utils.bzl
@@ -19,7 +19,7 @@ def _derive_module_name(ctx):
         module_name = (ctx.label.package.lstrip("/").replace("/", "_") + "-" + ctx.label.name.replace("/", "_"))
     return module_name
 
-def _init_builder_args(ctx, rule_kind, module_name, kotlinc_options):
+def _init_builder_args(ctx, rule_kind, module_name, kotlinc_options = None):
     """Initialize an arg object for a task that will be executed by the Kotlin Builder."""
     toolchain = ctx.toolchains[_TOOLCHAIN_TYPE]
 
@@ -31,7 +31,8 @@ def _init_builder_args(ctx, rule_kind, module_name, kotlinc_options):
     args.add("--rule_kind", rule_kind)
     args.add("--kotlin_module_name", module_name)
 
-    args.add("--kotlin_jvm_target", kotlinc_options.jvm_target or toolchain.jvm_target)
+    kotlin_jvm_target = kotlinc_options.jvm_target if (kotlinc_options and kotlinc_options.jvm_target) else toolchain.jvm_target
+    args.add("--kotlin_jvm_target", kotlin_jvm_target)
     args.add("--kotlin_api_version", toolchain.api_version)
     args.add("--kotlin_language_version", toolchain.language_version)
 

--- a/kotlin/internal/utils/utils.bzl
+++ b/kotlin/internal/utils/utils.bzl
@@ -19,7 +19,7 @@ def _derive_module_name(ctx):
         module_name = (ctx.label.package.lstrip("/").replace("/", "_") + "-" + ctx.label.name.replace("/", "_"))
     return module_name
 
-def _init_builder_args(ctx, rule_kind, module_name):
+def _init_builder_args(ctx, rule_kind, module_name, kotlinc_options):
     """Initialize an arg object for a task that will be executed by the Kotlin Builder."""
     toolchain = ctx.toolchains[_TOOLCHAIN_TYPE]
 
@@ -31,7 +31,7 @@ def _init_builder_args(ctx, rule_kind, module_name):
     args.add("--rule_kind", rule_kind)
     args.add("--kotlin_module_name", module_name)
 
-    args.add("--kotlin_jvm_target", toolchain.jvm_target)
+    args.add("--kotlin_jvm_target", kotlinc_options.jvm_target or toolchain.jvm_target)
     args.add("--kotlin_api_version", toolchain.api_version)
     args.add("--kotlin_language_version", toolchain.language_version)
 

--- a/src/legacy/starlark/kotlin/opts.bzl
+++ b/src/legacy/starlark/kotlin/opts.bzl
@@ -1,3 +1,10 @@
+load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+
+def _map_jvm_target_to_flag(version):
+    if not version:
+        return None
+    return ["-jvm-target=%s" % version]
+
 _KOPTS = {
     "warn": struct(
         args = dict(
@@ -114,6 +121,16 @@ _KOPTS = {
             "strict": ["-Xexplicit-api=strict"],
         },
     ),
+    "jvm_target": struct(
+        args = dict(
+            default = "",
+            doc = "The -jvm_target flag. This is only tested at 1.8.",
+            values = ["1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", "17"],
+        ),
+        type = attr.string,
+        value_to_flag = None,
+        map_value_to_flag = _map_jvm_target_to_flag,
+    ),
 }
 
 KotlincOptions = provider(
@@ -134,10 +151,7 @@ kt_kotlinc_options = rule(
     implementation = _kotlinc_options_impl,
     doc = "Define kotlin compiler options.",
     provides = [KotlincOptions],
-    attrs = {
-        n: o.type(**o.args)
-        for n, o in _KOPTS.items()
-    },
+    attrs = {n: o.type(**o.args) for n, o in _KOPTS.items()},
 )
 
 def kotlinc_options_to_flags(kotlinc_options):
@@ -148,13 +162,4 @@ def kotlinc_options_to_flags(kotlinc_options):
     Returns:
         list of flags to add to the command line.
     """
-    if not kotlinc_options:
-        return ""
-
-    flags = []
-    for n, o in _KOPTS.items():
-        value = getattr(kotlinc_options, n, None)
-        flag = o.value_to_flag.get(value, None)
-        if flag:
-            flags.extend(flag)
-    return flags
+    return convert.kotlinc_options_to_flags(_KOPTS, kotlinc_options)

--- a/src/main/starlark/core/options/convert.bzl
+++ b/src/main/starlark/core/options/convert.bzl
@@ -1,33 +1,5 @@
 load("//src/main/starlark/core/options:derive.bzl", "derive")
 
-def _javac_options_to_flags(jopts, javac_options):
-    """Translate JavacOptions to worker flags
-
-    Args:
-        jopts dict of name to struct
-        javac_options of type JavacOptions or None
-    Returns:
-        list of flags to add to the command line.
-    """
-    if not javac_options:
-        return ""
-
-    return _to_flags(opts = jopts, attr_provider = javac_options)
-
-def _kotlinc_options_to_flags(kopts, kotlinc_options):
-    """Translate KotlincOptions to worker flags
-
-    Args:
-        kopts list of kotlin options.
-        kotlinc_options maybe containing KotlincOptions
-    Returns:
-        list of flags to add to the command line.
-    """
-    if not kotlinc_options:
-        return ""
-
-    return _to_flags(opts = kopts, attr_provider = kotlinc_options)
-
 def _to_flags(opts, attr_provider):
     """Translate options to flags
 
@@ -37,10 +9,13 @@ def _to_flags(opts, attr_provider):
     Returns:
         list of flags to add to the command line.
     """
+    if not attr_provider:
+        return ""
+
     flags = []
     for n, o in opts.items():
         value = getattr(attr_provider, n, None)
-        if o.value_to_flag and derive.info in o.value_to_flag:
+        if o.value_to_flag and o.value_to_flag.get(derive.info, None):
             info = o.value_to_flag[derive.info]
             flag = info.derive(info.ctx, value)
         elif o.value_to_flag:
@@ -52,6 +27,6 @@ def _to_flags(opts, attr_provider):
     return flags
 
 convert = struct(
-    kotlinc_options_to_flags = _kotlinc_options_to_flags,
-    javac_options_to_flags = _javac_options_to_flags,
+    kotlinc_options_to_flags = _to_flags,
+    javac_options_to_flags = _to_flags,
 )

--- a/src/main/starlark/core/options/convert.bzl
+++ b/src/main/starlark/core/options/convert.bzl
@@ -12,16 +12,7 @@ def _javac_options_to_flags(jopts, javac_options):
     if not javac_options:
         return ""
 
-    flags = []
-    for n, o in jopts.items():
-        value = getattr(javac_options, n, None)
-        if derive.info in o.value_to_flag:
-            info = o.value_to_flag[derive.info]
-            flags.extend(info.derive(info.ctx, value))
-        elif o.value_to_flag.get(value, None):
-            flags.extend(o.value_to_flag[value])
-
-    return flags
+    return _to_flags(opts = jopts, attr_provider = javac_options)
 
 def _kotlinc_options_to_flags(kopts, kotlinc_options):
     """Translate KotlincOptions to worker flags
@@ -35,10 +26,27 @@ def _kotlinc_options_to_flags(kopts, kotlinc_options):
     if not kotlinc_options:
         return ""
 
+    return _to_flags(opts = kopts, attr_provider = kotlinc_options)
+
+def _to_flags(opts, attr_provider):
+    """Translate options to flags
+
+    Args:
+        opts dict of name to struct
+        attr options provider
+    Returns:
+        list of flags to add to the command line.
+    """
     flags = []
-    for n, o in kopts.items():
-        value = getattr(kotlinc_options, n, None)
-        flag = o.value_to_flag.get(value, None) if o.value_to_flag else o.map_value_to_flag(value)
+    for n, o in opts.items():
+        value = getattr(attr_provider, n, None)
+        if o.value_to_flag and derive.info in o.value_to_flag:
+            info = o.value_to_flag[derive.info]
+            flag = info.derive(info.ctx, value)
+        elif o.value_to_flag:
+            flag = o.value_to_flag.get(value, None)
+        else:
+            flag = o.map_value_to_flag(value)
         if flag:
             flags.extend(flag)
     return flags

--- a/src/rkt_1_4/starlark/jvm/opts.bzl
+++ b/src/rkt_1_4/starlark/jvm/opts.bzl
@@ -75,7 +75,4 @@ def javac_options_to_flags(javac_options):
     Returns:
         list of flags to add to the command line.
     """
-    if not javac_options:
-        return ""
-
     return convert.javac_options_to_flags(_JOPTS, javac_options)

--- a/src/rkt_1_4/starlark/kotlin/opts.bzl
+++ b/src/rkt_1_4/starlark/kotlin/opts.bzl
@@ -1,3 +1,10 @@
+load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+
+def _map_jvm_target_to_flag(version):
+    if not version:
+        return None
+    return ["-jvm-target=%s" % version]
+
 _KOPTS = {
     "warn": struct(
         args = dict(
@@ -174,6 +181,16 @@ _KOPTS = {
             "strict": ["-Xexplicit-api=strict"],
         },
     ),
+    "jvm_target": struct(
+        args = dict(
+            default = "",
+            doc = "The -jvm_target flag. This is only tested at 1.8.",
+            values = ["1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", "17"],
+        ),
+        type = attr.string,
+        value_to_flag = None,
+        map_value_to_flag = _map_jvm_target_to_flag,
+    ),
 }
 
 KotlincOptions = provider(
@@ -194,10 +211,7 @@ kt_kotlinc_options = rule(
     implementation = _kotlinc_options_impl,
     doc = "Define kotlin compiler options.",
     provides = [KotlincOptions],
-    attrs = {
-        n: o.type(**o.args)
-        for n, o in _KOPTS.items()
-    },
+    attrs = {n: o.type(**o.args) for n, o in _KOPTS.items()},
 )
 
 def kotlinc_options_to_flags(kotlinc_options):
@@ -208,13 +222,4 @@ def kotlinc_options_to_flags(kotlinc_options):
     Returns:
         list of flags to add to the command line.
     """
-    if not kotlinc_options:
-        return ""
-
-    flags = []
-    for n, o in _KOPTS.items():
-        value = getattr(kotlinc_options, n, None)
-        flag = o.value_to_flag.get(value, None)
-        if flag:
-            flags.extend(flag)
-    return flags
+    return convert.kotlinc_options_to_flags(_KOPTS, kotlinc_options)

--- a/src/rkt_1_5/starlark/jvm/opts.bzl
+++ b/src/rkt_1_5/starlark/jvm/opts.bzl
@@ -89,7 +89,4 @@ def javac_options_to_flags(javac_options):
     Returns:
         list of flags to add to the command line.
     """
-    if not javac_options:
-        return ""
-
     return convert.javac_options_to_flags(_JOPTS, javac_options)

--- a/src/rkt_1_5/starlark/kotlin/opts.bzl
+++ b/src/rkt_1_5/starlark/kotlin/opts.bzl
@@ -3,10 +3,10 @@ load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "
 def _map_optin_class_to_flag(values):
     return ["-Xopt-in=%s" % v for v in values]
 
-def _map_backend_threads_to_flag(n):
-    if n == 1:
+def _map_jvm_target_to_flag(version):
+    if not version:
         return None
-    return ["-Xbackend-threads=%d" % n]
+    return ["-jvm-target=%s" % version]
 
 _KOPTS = {
     "warn": struct(
@@ -216,6 +216,16 @@ _KOPTS = {
         value_to_flag = {
             True: ["-Xreport-perf"],
         },
+    ),
+    "jvm_target": struct(
+        args = dict(
+            default = "",
+            doc = "The -jvm_target flag. This is only tested at 1.8.",
+            values = ["1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", "17"],
+        ),
+        type = attr.string,
+        value_to_flag = None,
+        map_value_to_flag = _map_jvm_target_to_flag,
     ),
 }
 

--- a/src/rkt_1_5/starlark/kotlin/opts.bzl
+++ b/src/rkt_1_5/starlark/kotlin/opts.bzl
@@ -1,5 +1,12 @@
+load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+
 def _map_optin_class_to_flag(values):
     return ["-Xopt-in=%s" % v for v in values]
+
+def _map_backend_threads_to_flag(n):
+    if n == 1:
+        return None
+    return ["-Xbackend-threads=%d" % n]
 
 _KOPTS = {
     "warn": struct(
@@ -230,10 +237,7 @@ kt_kotlinc_options = rule(
     implementation = _kotlinc_options_impl,
     doc = "Define kotlin compiler options.",
     provides = [KotlincOptions],
-    attrs = {
-        n: o.type(**o.args)
-        for n, o in _KOPTS.items()
-    },
+    attrs = {n: o.type(**o.args) for n, o in _KOPTS.items()},
 )
 
 def kotlinc_options_to_flags(kotlinc_options):
@@ -244,13 +248,4 @@ def kotlinc_options_to_flags(kotlinc_options):
     Returns:
         list of flags to add to the command line.
     """
-    if not kotlinc_options:
-        return ""
-
-    flags = []
-    for n, o in _KOPTS.items():
-        value = getattr(kotlinc_options, n, None)
-        flag = o.value_to_flag.get(value, None) if o.value_to_flag else o.map_value_to_flag(value)
-        if flag:
-            flags.extend(flag)
-    return flags
+    return convert.kotlinc_options_to_flags(_KOPTS, kotlinc_options)

--- a/src/rkt_1_6/starlark/jvm/opts.bzl
+++ b/src/rkt_1_6/starlark/jvm/opts.bzl
@@ -89,7 +89,4 @@ def javac_options_to_flags(javac_options):
     Returns:
         list of flags to add to the command line.
     """
-    if not javac_options:
-        return ""
-
     return convert.javac_options_to_flags(_JOPTS, javac_options)

--- a/src/rkt_1_6/starlark/kotlin/opts.bzl
+++ b/src/rkt_1_6/starlark/kotlin/opts.bzl
@@ -8,6 +8,11 @@ def _map_backend_threads_to_flag(n):
         return None
     return ["-Xbackend-threads=%d" % n]
 
+def _map_jvm_target_to_flag(version):
+    if not version:
+        return None
+    return ["-jvm-target=%s" % version]
+
 _KOPTS = {
     "warn": struct(
         args = dict(

--- a/src/rkt_1_6/starlark/kotlin/opts.bzl
+++ b/src/rkt_1_6/starlark/kotlin/opts.bzl
@@ -236,6 +236,16 @@ _KOPTS = {
             True: ["-Xreport-perf"],
         },
     ),
+    "jvm_target": struct(
+        args = dict(
+            default = "",
+            doc = "The -jvm_target flag. This is only tested at 1.8.",
+            values = ["1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", "17"],
+        ),
+        type = attr.string,
+        value_to_flag = None,
+        map_value_to_flag = _map_jvm_target_to_flag,
+    ),
 }
 
 KotlincOptions = provider(
@@ -256,10 +266,7 @@ kt_kotlinc_options = rule(
     implementation = _kotlinc_options_impl,
     doc = "Define kotlin compiler options.",
     provides = [KotlincOptions],
-    attrs = {
-        n: o.type(**o.args)
-        for n, o in _KOPTS.items()
-    },
+    attrs = {n: o.type(**o.args) for n, o in _KOPTS.items()},
 )
 
 def kotlinc_options_to_flags(kotlinc_options):
@@ -270,6 +277,4 @@ def kotlinc_options_to_flags(kotlinc_options):
     Returns:
         list of flags to add to the command line.
     """
-    if not kotlinc_options:
-        return ""
     return convert.kotlinc_options_to_flags(_KOPTS, kotlinc_options)

--- a/src/rkt_1_7/starlark/jvm/opts.bzl
+++ b/src/rkt_1_7/starlark/jvm/opts.bzl
@@ -89,7 +89,4 @@ def javac_options_to_flags(javac_options):
     Returns:
         list of flags to add to the command line.
     """
-    if not javac_options:
-        return ""
-
     return convert.javac_options_to_flags(_JOPTS, javac_options)

--- a/src/rkt_1_7/starlark/kotlin/opts.bzl
+++ b/src/rkt_1_7/starlark/kotlin/opts.bzl
@@ -1,3 +1,5 @@
+load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+
 def _map_optin_class_to_flag(values):
     return ["-opt-in=%s" % v for v in values]
 
@@ -5,6 +7,11 @@ def _map_backend_threads_to_flag(n):
     if n == 1:
         return None
     return ["-Xbackend-threads=%d" % n]
+
+def _map_jvm_target_to_flag(version):
+    if not version:
+        return None
+    return ["-jvm-target=%s" % version]
 
 _KOPTS = {
     "warn": struct(
@@ -234,6 +241,16 @@ _KOPTS = {
             True: ["-Xreport-perf"],
         },
     ),
+    "jvm_target": struct(
+        args = dict(
+            default = "",
+            doc = "The -jvm_target flag. This is only tested at 1.8.",
+            values = ["1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", "17"],
+        ),
+        type = attr.string,
+        value_to_flag = None,
+        map_value_to_flag = _map_jvm_target_to_flag,
+    ),
 }
 
 KotlincOptions = provider(
@@ -254,10 +271,7 @@ kt_kotlinc_options = rule(
     implementation = _kotlinc_options_impl,
     doc = "Define kotlin compiler options.",
     provides = [KotlincOptions],
-    attrs = {
-        n: o.type(**o.args)
-        for n, o in _KOPTS.items()
-    },
+    attrs = {n: o.type(**o.args) for n, o in _KOPTS.items()},
 )
 
 def kotlinc_options_to_flags(kotlinc_options):
@@ -268,13 +282,4 @@ def kotlinc_options_to_flags(kotlinc_options):
     Returns:
         list of flags to add to the command line.
     """
-    if not kotlinc_options:
-        return ""
-
-    flags = []
-    for n, o in _KOPTS.items():
-        value = getattr(kotlinc_options, n, None)
-        flag = o.value_to_flag.get(value, None) if o.value_to_flag else o.map_value_to_flag(value)
-        if flag:
-            flags.extend(flag)
-    return flags
+    return convert.javac_options_to_flags(_KOPTS, kotlinc_options)

--- a/src/test/starlark/BUILD.bazel
+++ b/src/test/starlark/BUILD.bazel
@@ -1,0 +1,3 @@
+load(":convert_test.bzl", "convert_test_suite")
+
+convert_test_suite(name = "convert_tests")

--- a/src/test/starlark/convert_test.bzl
+++ b/src/test/starlark/convert_test.bzl
@@ -1,0 +1,84 @@
+load(
+    "@bazel_skylib//lib:unittest.bzl",
+    "asserts",
+    "unittest",
+)
+load("//src/main/starlark/core/options:convert.bzl", "convert")
+load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
+
+def _test_map_value_to_flag(value):
+    return ["-flag={}".format(value)]
+
+def _test_map_value_to_flag_repeated(values):
+    return ["-flag-repeated={}".format(v) for v in values]
+
+_TEST_OPTS = {
+    "value_to_flag_test": struct(value_to_flag = {
+        "options1": ["-foo-options"],
+    }),
+    "value_to_flag_derive_test": struct(value_to_flag = {
+        derive.info: derive.repeated_values_for("-bar:"),
+    }),
+    "map_value_to_flag_test": struct(
+        value_to_flag = None,
+        map_value_to_flag = _test_map_value_to_flag,
+    ),
+    "map_value_to_flag_repeated_test": struct(
+        value_to_flag = None,
+        map_value_to_flag = _test_map_value_to_flag_repeated,
+    ),
+}
+
+def _convert_options_to_flags_empty_options_test(ctx):
+    """Asserts that the converts return None when the
+    attr_provider doesn't exist
+    """
+    env = unittest.begin(ctx)
+
+    asserts.true(env, not convert.kotlinc_options_to_flags({}, None))
+    asserts.true(env, not convert.javac_options_to_flags({}, None))
+
+    return unittest.end(env)
+
+convert_options_to_flags_empty_options_test = unittest.make(
+    _convert_options_to_flags_empty_options_test,
+)
+
+def _convert_options_to_flags_test(ctx):
+    """Tests the _to_flags mapper paths
+    """
+    env = unittest.begin(ctx)
+
+    attrs = struct(
+        value_to_flag_test = "options1",
+        value_to_flag_derive_test = ["1", "2", "3"],
+        map_value_to_flag_test = "1",
+        map_value_to_flag_repeated_test = ["1", "2", "3"],
+    )
+    asserts.equals(
+        env,
+        expected = convert.kotlinc_options_to_flags(_TEST_OPTS, attrs),
+        actual = [
+            "-foo-options",
+            "-bar:1",
+            "-bar:2",
+            "-bar:3",
+            "-flag=1",
+            "-flag-repeated=1",
+            "-flag-repeated=2",
+            "-flag-repeated=3",
+        ],
+    )
+
+    return unittest.end(env)
+
+convert_options_to_flags_test = unittest.make(
+    _convert_options_to_flags_test,
+)
+
+def convert_test_suite(name):
+    unittest.suite(
+        name,
+        convert_options_to_flags_empty_options_test,
+        convert_options_to_flags_test,
+    )


### PR DESCRIPTION
Adding target level support for providing a custom `jvm_target` version.