### PR TITLE
[WIP][POC] Starlark implementation of kt_android_* rules

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 build --strategy=KotlinCompile=worker
 build --test_output=all
 build --verbose_failures
+build --experimental_google_legacy_api
 

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,8 @@
 build --strategy=KotlinCompile=worker
 build --test_output=all
 build --verbose_failures
+
+# Expose (not really) experimental Android providers need by rules_android-
+# AndroidLibraryResourceClassJarProvider, AndroidIdeInfo, ...
 build --experimental_google_legacy_api
 

--- a/examples/android/.bazelrc
+++ b/examples/android/.bazelrc
@@ -1,0 +1,1 @@
+build --experimental_google_legacy_api

--- a/examples/android/.bazelrc
+++ b/examples/android/.bazelrc
@@ -1,1 +1,3 @@
+# Expose (not really) experimental Android providers need by rules_android-
+# AndroidLibraryResourceClassJarProvider, AndroidIdeInfo, ...
 build --experimental_google_legacy_api

--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -60,6 +60,8 @@ maven_install(
     aar_import_bzl_label = "@io_bazel_rules_android//rules:rules.bzl",
 )
 
+# Pulling from personal branch since we need a few fixes in rules_android
+# A non complete list can be seen here https://github.com/bazelbuild/rules_android/pulls
 http_archive(
     name = "io_bazel_rules_android",
     sha256 = versions.ANDROID.SHA,

--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -56,18 +56,24 @@ maven_install(
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
+    use_starlark_android_rules = True,
+    aar_import_bzl_label = "@io_bazel_rules_android//rules:rules.bzl",
 )
 
 http_archive(
-    name = "build_bazel_rules_android",
+    name = "io_bazel_rules_android",
     sha256 = versions.ANDROID.SHA,
     strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
-    urls = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % versions.ANDROID.VERSION],
+    urls = ["https://github.com/mauriciogg/rules_android/archive/refs/tags/pre-alpha-01-11-2022-3.zip"],
 )
 
-load(
-    "@build_bazel_rules_android//android:rules.bzl",
-    "android_sdk_repository",
+load("@io_bazel_rules_android//:defs.bzl", "rules_android_workspace")
+
+rules_android_workspace()
+
+register_toolchains(
+    "@io_bazel_rules_android//toolchains/android:android_default_toolchain",
+    "@io_bazel_rules_android//toolchains/android_sdk:android_sdk_tools",
 )
 
 android_sdk_repository(

--- a/examples/android/app/BUILD.bazel
+++ b/examples/android/app/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@io_bazel_rules_android//rules:rules.bzl", "android_binary")
 
 # An app that consumes android-kt deps
 android_binary(

--- a/examples/android/app/BUILD.bazel
+++ b/examples/android/app/BUILD.bazel
@@ -19,9 +19,11 @@ android_binary(
 android_application(
     name = "application",
     custom_package = "examples.android.app",
+    bundle_config_file = "bundleConfig.pb.json",
     manifest = "src/main/AndroidManifest.xml",
     manifest_values = {
         "lib_name": "lib",
+        "applicationId": "examples.android.app",
     },
     multidex = "native",
     deps = [

--- a/examples/android/app/BUILD.bazel
+++ b/examples/android/app/BUILD.bazel
@@ -1,11 +1,24 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@io_bazel_rules_android//rules:rules.bzl", "android_binary")
+load("@io_bazel_rules_android//rules:rules.bzl", "android_binary", "android_application")
 
 # An app that consumes android-kt deps
 android_binary(
     name = "app",
     custom_package = "examples.android.app",
     incremental_dexing = 0,
+    manifest = "src/main/AndroidManifest.xml",
+    manifest_values = {
+        "lib_name": "lib",
+    },
+    multidex = "native",
+    deps = [
+        "//libKtAndroid:my_kt",
+    ],
+)
+
+android_application(
+    name = "application",
+    custom_package = "examples.android.app",
     manifest = "src/main/AndroidManifest.xml",
     manifest_values = {
         "lib_name": "lib",

--- a/examples/android/app/bundleConfig.pb.json
+++ b/examples/android/app/bundleConfig.pb.json
@@ -1,0 +1,46 @@
+{
+  "optimizations": {
+    "uncompressNativeLibraries": { "enabled": false },
+    "standaloneConfig": {
+      "dexMergingStrategy": "NEVER_MERGE"
+    }
+  },
+  "compression": {
+    "uncompressedGlob": [
+      "**/*.3g2",
+      "**/*.3gp",
+      "**/*.3gpp",
+      "**/*.3gpp2",
+      "**/*.aac",
+      "**/*.amr",
+      "**/*.awb",
+      "**/*.gif",
+      "**/*.imy",
+      "**/*.jet",
+      "**/*.jpeg",
+      "**/*.jpg",
+      "**/*.m4a",
+      "**/*.m4v",
+      "**/*.mid",
+      "**/*.midi",
+      "**/*.mkv",
+      "**/*.mp2",
+      "**/*.mp3",
+      "**/*.mp4",
+      "**/*.mpeg",
+      "**/*.mpg",
+      "**/*.ogg",
+      "**/*.png",
+      "**/*.rtttl",
+      "**/*.smf",
+      "**/*.so.xz",
+      "**/*.so.zst",
+      "**/*.wav",
+      "**/*.webm",
+      "**/*.wma",
+      "**/*.wmv",
+      "**/*.xmf",
+      "**/*.zst.so"
+    ]
+  }
+}

--- a/examples/android/app/src/main/AndroidManifest.xml
+++ b/examples/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:versionCode="1"
     package="examples.android.app">
   <uses-sdk
       android:minSdkVersion="23"

--- a/examples/android/libAndroid/BUILD.bazel
+++ b/examples/android/libAndroid/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("@io_bazel_rules_android//rules:rules.bzl", "android_library")
 load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 android_library(

--- a/examples/android/libKtAndroid/BUILD.bazel
+++ b/examples/android/libKtAndroid/BUILD.bazel
@@ -32,16 +32,8 @@ kt_android_library(
     tags = ["trace"],
     visibility = ["//visibility:public"],
     deps = [
-        ":res2",
         "@maven//:androidx_appcompat_appcompat",
         "@maven//:com_google_auto_value_auto_value_annotations",
         "@maven//:org_jetbrains_kotlinx_kotlinx_serialization_runtime",
     ],
-)
-
-android_library(
-    name = "res2",
-    custom_package = "examples.android.lib",
-    manifest = "src/main/AndroidManifest.xml",
-    resource_files = glob(["res2/**"]),
 )

--- a/examples/android/libKtAndroid/BUILD.bazel
+++ b/examples/android/libKtAndroid/BUILD.bazel
@@ -37,3 +37,15 @@ kt_android_library(
         "@maven//:org_jetbrains_kotlinx_kotlinx_serialization_runtime",
     ],
 )
+
+# Commenting out- rules_android resource processing wil produce
+# two resource classes with the same package and upstream targets
+# that depend on res and res2 will only see definitions from
+# the jar that appears firs in the classpaht resulting in
+# field not found exceptions.
+#android_library(
+#    name = "res2",
+#    custom_package = "examples.android.lib",
+#    manifest = "src/main/AndroidManifest.xml",
+#    resource_files = glob(["res2/**"]),
+#)

--- a/examples/android/libKtAndroid/res/values/strings.xml
+++ b/examples/android/libKtAndroid/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
   <string name="where_you_at">Where you at?</string>
+  <string name="hello">hello?</string>
 </resources>

--- a/examples/android/libKtAndroid/res2/values/strings.xml
+++ b/examples/android/libKtAndroid/res2/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="hello">hello?</string>
-</resources>

--- a/examples/android/libKtAndroid/src/test/java/examples/android/lib/BUILD.bazel
+++ b/examples/android/libKtAndroid/src/test/java/examples/android/lib/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_kotlin//kotlin:android.bzl", "kt_android_local_test")
 kt_android_local_test(
     name = "SomeTest",
     srcs = ["SomeTest.kt"],
-    associates = ["//libKtAndroid:my_kt_kt"],
+    associates = ["//libKtAndroid:my_kt"],
     custom_package = "examples.android.lib",
     manifest = "AndroidManifest.xml",
     deps = [

--- a/examples/anvil/.bazelrc
+++ b/examples/anvil/.bazelrc
@@ -1,0 +1,1 @@
+common --experimental_google_legacy_api

--- a/examples/anvil/.bazelrc
+++ b/examples/anvil/.bazelrc
@@ -1,1 +1,3 @@
+# Expose (not really) experimental Android providers need by rules_android-
+# AndroidLibraryResourceClassJarProvider, AndroidIdeInfo, ...
 common --experimental_google_legacy_api

--- a/examples/anvil/WORKSPACE
+++ b/examples/anvil/WORKSPACE
@@ -17,23 +17,6 @@ register_toolchains("//:kotlin_toolchain")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "build_bazel_rules_android",
-    sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-    strip_prefix = "rules_android-0.1.1",
-    urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
-)
-
-load(
-    "@build_bazel_rules_android//android:rules.bzl",
-    "android_sdk_repository",
-)
-
-android_sdk_repository(
-    name = "androidsdk",
-    build_tools_version = versions.ANDROID.BUILD_TOOLS,
-)
-
 # Skylib, for build_test, so don't bother initializing the unit test infrastructure.
 http_archive(
     name = "bazel_skylib",
@@ -115,4 +98,26 @@ maven_install(
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
+    use_starlark_android_rules = True,
+    aar_import_bzl_label = "@io_bazel_rules_android//rules:rules.bzl",
+)
+
+http_archive(
+    name = "io_bazel_rules_android",
+    sha256 = versions.ANDROID.SHA,
+    strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
+    urls = ["https://github.com/mauriciogg/rules_android/archive/refs/tags/pre-alpha-01-11-2022-3.zip"],
+)
+
+load("@io_bazel_rules_android//:defs.bzl", "rules_android_workspace")
+
+rules_android_workspace()
+
+register_toolchains(
+    "@io_bazel_rules_android//toolchains/android:android_default_toolchain",
+    "@io_bazel_rules_android//toolchains/android_sdk:android_sdk_tools",
+)
+android_sdk_repository(
+    name = "androidsdk",
+    build_tools_version = versions.ANDROID.BUILD_TOOLS,
 )

--- a/examples/anvil/app/BUILD.bazel
+++ b/examples/anvil/app/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@io_bazel_rules_android//rules:rules.bzl", "android_binary")
 
 android_binary(
     name = "app",

--- a/examples/associates/.bazelrc
+++ b/examples/associates/.bazelrc
@@ -1,0 +1,1 @@
+common --experimental_google_legacy_api

--- a/examples/associates/WORKSPACE
+++ b/examples/associates/WORKSPACE
@@ -20,13 +20,6 @@ kt_register_toolchains()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "build_bazel_rules_android",
-    sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-    strip_prefix = "rules_android-0.1.1",
-    urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],
-)
-
-http_archive(
     name = "bazel_skylib",
     sha256 = versions.SKYLIB_SHA,
     urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/%s/bazel-skylib-%s.tar.gz" % (
@@ -51,6 +44,22 @@ maven_install(
     repositories = [
         "https://repo1.maven.org/maven2",
     ],
+)
+
+http_archive(
+    name = "io_bazel_rules_android",
+    sha256 = versions.ANDROID.SHA,
+    strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
+    urls = ["https://github.com/mauriciogg/rules_android/archive/refs/tags/pre-alpha-01-11-2022-3.zip"],
+)
+
+load("@io_bazel_rules_android//:defs.bzl", "rules_android_workspace")
+
+rules_android_workspace()
+
+register_toolchains(
+    "@io_bazel_rules_android//toolchains/android:android_default_toolchain",
+    "@io_bazel_rules_android//toolchains/android_sdk:android_sdk_tools",
 )
 
 http_archive(

--- a/examples/jetpack_compose/.bazelrc
+++ b/examples/jetpack_compose/.bazelrc
@@ -5,3 +5,6 @@ build --define=android_dexmerger_tool=d8_dexmerger
 build --define=android_incremental_dexing_tool=d8_dexbuilder
 build --define=android_standalone_dexing_tool=d8_compat_dx
 build --nouse_workers_with_dexbuilder
+
+common --experimental_google_legacy_api
+

--- a/examples/jetpack_compose/.bazelrc
+++ b/examples/jetpack_compose/.bazelrc
@@ -6,5 +6,7 @@ build --define=android_incremental_dexing_tool=d8_dexbuilder
 build --define=android_standalone_dexing_tool=d8_compat_dx
 build --nouse_workers_with_dexbuilder
 
+# Expose (not really) experimental Android providers need by rules_android-
+# AndroidLibraryResourceClassJarProvider, AndroidIdeInfo, ...
 common --experimental_google_legacy_api
 

--- a/examples/jetpack_compose/BUILD
+++ b/examples/jetpack_compose/BUILD
@@ -33,11 +33,16 @@ kt_compiler_plugin(
 # Used in 'override_targets' by referencing @//:kotlinx_coroutines_core_jvm
 kt_jvm_import(
     name = "kotlinx_coroutines_core_jvm",
-    jars = ["@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.3/kotlinx-coroutines-core-jvm-1.6.3.jar"],
-    srcjar = "@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.3/kotlinx-coroutines-core-jvm-1.6.3-sources.jar",
+    jars = [":kotlinx_coroutines_core_jvm_jar"],
     visibility = ["//visibility:public"],
     deps = [
         "//stub:sun_misc",
         "@maven//:org_jetbrains_kotlin_kotlin_stdlib",
     ],
+)
+
+# HACK: for some reason the underlying jar is not visible when using starlark rules
+filegroup(
+    name = "kotlinx_coroutines_core_jvm_jar",
+    srcs =  ["@maven_secondary//:org_jetbrains_kotlinx_kotlinx_coroutines_core_jvm_1_6_3"],
 )

--- a/examples/jetpack_compose/WORKSPACE
+++ b/examples/jetpack_compose/WORKSPACE
@@ -1,4 +1,5 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 _COMPOSE_VERSION = "1.2.1"
 
@@ -62,6 +63,8 @@ maven_install(
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
+    use_starlark_android_rules = True,
+    aar_import_bzl_label = "@io_bazel_rules_android//rules:rules.bzl",
 )
 
 # Secondary maven repository used mainly for workarounds
@@ -74,6 +77,8 @@ maven_install(
     ],
     fetch_sources = True,
     repositories = ["https://repo1.maven.org/maven2"],
+    use_starlark_android_rules = True,
+    aar_import_bzl_label = "@io_bazel_rules_android//rules:rules.bzl",
 )
 
 http_archive(
@@ -88,13 +93,20 @@ http_archive(
 ## Android
 
 http_archive(
-    name = "build_bazel_rules_android",
+    name = "io_bazel_rules_android",
     sha256 = versions.ANDROID.SHA,
     strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
-    urls = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % versions.ANDROID.VERSION],
+    urls = ["https://github.com/mauriciogg/rules_android/archive/refs/tags/pre-alpha-01-11-2022-3.zip"],
 )
 
-load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
+load("@io_bazel_rules_android//:defs.bzl", "rules_android_workspace")
+
+rules_android_workspace()
+
+register_toolchains(
+    "@io_bazel_rules_android//toolchains/android:android_default_toolchain",
+    "@io_bazel_rules_android//toolchains/android_sdk:android_sdk_tools",
+)
 
 android_sdk_repository(
     name = "androidsdk",

--- a/examples/jetpack_compose/app/AndroidManifest.xml
+++ b/examples/jetpack_compose/app/AndroidManifest.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          xmlns:tools="http://schemas.android.com/tools"
           package="cm.ben.android.bazel.compose.example">
 
     <uses-sdk android:minSdkVersion="24" android:targetSdkVersion="29" />
+    <application>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            tools:node="remove" />
+    </application>
 </manifest>

--- a/examples/jetpack_compose/app/BUILD
+++ b/examples/jetpack_compose/app/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@io_bazel_rules_android//rules:rules.bzl", "android_binary")
 
 # An app that consumes android-kt deps
 android_binary(

--- a/examples/plugin/.bazelrc
+++ b/examples/plugin/.bazelrc
@@ -1,0 +1,1 @@
+common --experimental_google_legacy_api

--- a/examples/plugin/.bazelrc
+++ b/examples/plugin/.bazelrc
@@ -1,1 +1,3 @@
+# Expose (not really) experimental Android providers need by rules_android-
+# AndroidLibraryResourceClassJarProvider, AndroidIdeInfo, ...
 common --experimental_google_legacy_api

--- a/examples/plugin/WORKSPACE
+++ b/examples/plugin/WORKSPACE
@@ -53,8 +53,6 @@ load("@io_bazel_rules_android//:defs.bzl", "rules_android_workspace")
 
 rules_android_workspace()
 
-#register_toolchains("//bzl/android:android_default_toolchain")
-
 # Setup a custom toolchain from //bzl/kotlin:kotlin_toolchain
 register_toolchains(
     "@io_bazel_rules_android//toolchains/android:android_default_toolchain",

--- a/examples/plugin/WORKSPACE
+++ b/examples/plugin/WORKSPACE
@@ -1,3 +1,5 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 local_repository(
     name = "release_archive",
     path = "../../src/main/starlark/release_archive",
@@ -36,9 +38,30 @@ maven_install(
     repositories = [
         "https://repo1.maven.org/maven2",
     ],
+    use_starlark_android_rules = True,
+    aar_import_bzl_label = "@io_bazel_rules_android//rules:rules.bzl",
 )
 
-load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
+http_archive(
+    name = "io_bazel_rules_android",
+    sha256 = versions.ANDROID.SHA,
+    strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
+    urls = ["https://github.com/mauriciogg/rules_android/archive/refs/tags/pre-alpha-01-11-2022-3.zip"],
+)
+
+load("@io_bazel_rules_android//:defs.bzl", "rules_android_workspace")
+
+rules_android_workspace()
+
+#register_toolchains("//bzl/android:android_default_toolchain")
+
+# Setup a custom toolchain from //bzl/kotlin:kotlin_toolchain
+register_toolchains(
+    "@io_bazel_rules_android//toolchains/android:android_default_toolchain",
+    "@io_bazel_rules_android//toolchains/android_sdk:android_sdk_tools",
+)
+
+
 
 android_sdk_repository(
     name = "androidsdk",

--- a/kotlin/internal/jvm/BUILD
+++ b/kotlin/internal/jvm/BUILD
@@ -32,7 +32,7 @@ bzl_library(
     deps = [
         "//third_party:bzl",
         "@bazel_skylib//rules:common_settings",
-        "@build_bazel_rules_android//android",
+        "@build_bazel_rules_android//rules",
     ],
 )
 

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -167,6 +167,9 @@ kt_android_local_test = rule(
             allow_files = True,
         ),
         # TODO(mgalindo): unify with android_sdk (BUILD-3813)
+        # rules_android uses ctx._android_sdk rules_kotlin uses ctx.android_sdk
+        # rules_android should just use ctx.android_sdk and then this should
+        # be deleted.
         "_android_sdk": attr.label(
             default = Label("@bazel_tools//tools/android:sdk"),
             allow_files = True,

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -12,117 +12,175 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 load(
+    "//kotlin/internal:defs.bzl",
+    _JAVA_RUNTIME_TOOLCHAIN_TYPE = "JAVA_RUNTIME_TOOLCHAIN_TYPE",
+    _JAVA_TOOLCHAIN_TYPE = "JAVA_TOOLCHAIN_TYPE",
+    _KtJvmInfo = "KtJvmInfo",
+    _TOOLCHAIN_TYPE = "TOOLCHAIN_TYPE",
+)
+load(
     "//kotlin/internal/jvm:jvm.bzl",
     _kt_jvm_library = "kt_jvm_library",
+    _kt_lib_common_attr = "lib_common_attr_exposed",
+    _kt_lib_common_outputs_exposed = "common_outputs_exposed",
+    _kt_android_local_test_runnable_common_attr_exposed = "runnable_common_attr_exposed"
+)
+load(
+    "//kotlin/internal/jvm:android_impl.bzl",
+    _kt_android_library_impl = "kt_android_library_impl",
+    _kt_android_local_test_impl = "kt_android_local_test_impl",
+)
+load("//kotlin/internal/utils:utils.bzl", "utils")
+
+_common_toolchains = [
+    "@io_bazel_rules_android//toolchains/android:toolchain_type",
+    _TOOLCHAIN_TYPE,
+    _JAVA_TOOLCHAIN_TYPE,
+    _JAVA_RUNTIME_TOOLCHAIN_TYPE,
+]
+
+
+kt_android_library = rule(
+    doc = """This rule compiles and links Kotlin and Java sources into a .jar file.""",
+    attrs = dict(_kt_lib_common_attr.items() + {
+        "manifest": attr.label(
+            doc = """The name of the Android manifest file, normally `AndroidManifest.xml`.
+                Must be defined if resource_files or assets are defined.""",
+            default = None,
+            allow_single_file = True,
+        ),
+        "exports_manifest": attr.int(
+            doc = """Whether to export manifest entries to `android_binary` targets
+                that depend on this target. `uses-permissions` attributes are never exported.""",
+            default = 1,
+        ),
+        "custom_package": attr.string(
+            doc = """Java package for which java sources will be generated. By default the package
+             is inferred from the directory where the BUILD file containing the rule is. You can
+             specify a different package but this is highly discouraged since it can introduce
+             classpath conflicts with other libraries that will only be detected at runtime.""",
+        ),
+        "resource_files": attr.label_list(
+            doc = """The list of resources to be packaged. This is typically a glob of all files
+                under the res directory. Generated files (from genrules) can be referenced by Label
+                here as well. The only restriction is that the generated outputs must be under the
+                same "res" directory as any other resource files that are included.""",
+            default = [],
+            allow_files = True,
+        ),
+        "assets": attr.label_list(
+            doc = """The list of assets to be packaged. This is typically a `glob` of all files
+                under the `assets` directory. You can also reference other rules (any rule that
+                produces files) or exported files in the other packages, as long as all those files
+                are under the `assets_dir` directory in the corresponding package.""",
+            default = [],
+            allow_files = True,
+        ),
+        "assets_dir": attr.string(
+            doc = """The string giving the path to the files in assets. The pair assets and
+                `assets_dir` describe packaged assets and either both attributes should be provided
+                or none of them.""",
+        ),
+        "friends": attr.label_list(
+                    doc = """A single Kotlin dep which allows the test code access to internal members. Currently uses the output
+                    jar of the module -- i.e., exported deps won't be included.""",
+                    default = [],
+                    providers = [JavaInfo],
+        ),
+        "_android_resources_busybox": attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@bazel_tools//tools/android:busybox"),
+            allow_files = True,
+        ),
+        "android_sdk": attr.label(
+            default = Label("@bazel_tools//tools/android:sdk"),
+            allow_files = True,
+        ),
+        "proguard_specs": attr.label_list(
+            doc = """Files to be used as Proguard specification.
+
+        These will describe the set of specifications to be used by Proguard. If specified,
+        they will be added to any android_binary target depending on this library.
+
+        The files included here must only have idempotent rules, namely -dontnote, -dontwarn,
+        assumenosideeffects, and rules that start with -keep. Other options can only appear in
+        android_binary's proguard_specs, to ensure non-tautological merges.""",
+            default = [],
+            allow_files = True,
+        ),
+    }.items()),
+    outputs = _kt_lib_common_outputs_exposed,
+    toolchains = _common_toolchains,
+    fragments = ["android", "java"], # Required fragments of the target configuration
+    host_fragments = ["java"], # Required fragments of the host configuration
+    implementation = _kt_android_library_impl,
+    provides = [JavaInfo, _KtJvmInfo],
 )
 
-_ANDROID_SDK_JAR = "%s" % Label("//third_party:android_sdk")
+kt_android_local_test = rule(
+    doc = """Setup a simple kotlin_test.
 
-def _kt_android_artifact(
-        name,
-        srcs = [],
-        deps = [],
-        resources = [],
-        plugins = [],
-        associates = [],
-        kotlinc_opts = None,
-        javac_opts = None,
-        enable_data_binding = False,
-        tags = [],
-        exec_properties = None,
-        **kwargs):
-    """Delegates Android related build attributes to the native rules but uses the Kotlin builder to compile Java and
-    Kotlin srcs. Returns a sequence of labels that a wrapping macro should export.
-    """
-    base_name = name + "_base"
-    kt_name = name + "_kt"
-
-    # TODO(bazelbuild/rules_kotlin/issues/273): This should be retrieved from a provider.
-    base_deps = [_ANDROID_SDK_JAR] + deps
-
-    # TODO(bazelbuild/rules_kotlin/issues/556): replace with starlark
-    # buildifier: disable=native-android
-    native.android_library(
-        name = base_name,
-        visibility = ["//visibility:private"],
-        exports = base_deps,
-        deps = deps if enable_data_binding else [],
-        enable_data_binding = enable_data_binding,
-        tags = tags,
-        exec_properties = exec_properties,
-        **kwargs
-    )
-    _kt_jvm_library(
-        name = kt_name,
-        srcs = srcs,
-        deps = [base_name] + base_deps,
-        resources = resources,
-        plugins = plugins,
-        associates = associates,
-        testonly = kwargs.get("testonly", default = False),
-        visibility = ["//visibility:public"],
-        kotlinc_opts = kotlinc_opts,
-        javac_opts = javac_opts,
-        tags = tags,
-        exec_properties = exec_properties,
-    )
-    return [base_name, kt_name]
-
-def kt_android_library(name, exports = [], visibility = None, exec_properties = None, **kwargs):
-    """Creates an Android sandwich library.
-
-    `srcs`, `deps`, `plugins` are routed to `kt_jvm_library` the other android
-    related attributes are handled by the native `android_library` rule.
-    """
-
-    # TODO(bazelbuild/rules_kotlin/issues/556): replace with starlark
-    # buildifier: disable=native-android
-    native.android_library(
-        name = name,
-        exports = exports + _kt_android_artifact(name, exec_properties = exec_properties, **kwargs),
-        visibility = visibility,
-        tags = kwargs.get("tags", default = None),
-        testonly = kwargs.get("testonly", default = 0),
-        exec_properties = exec_properties,
-    )
-
-def kt_android_local_test(
-        name,
-        jvm_flags = None,
-        manifest = None,
-        manifest_values = None,
-        test_class = None,
-        size = None,
-        timeout = None,
-        flaky = False,
-        shard_count = None,
-        visibility = None,
-        testonly = True,
-        exec_properties = None,
-        **kwargs):
-    """Creates a testable Android sandwich library.
-
-    `srcs`, `deps`, `plugins`, `associates` are routed to `kt_jvm_library` the other android
-    related attributes are handled by the native `android_library` rule while the test attributes
-    are picked out and handled by the `android_local_test` rule.
-    """
-
-    # TODO(556): replace with starlark
-    # buildifier: disable=native-android
-    native.android_local_test(
-        name = name,
-        deps = kwargs.get("deps", []) + _kt_android_artifact(name = name, testonly = testonly, exec_properties = exec_properties, **kwargs),
-        jvm_flags = jvm_flags,
-        test_class = test_class,
-        visibility = visibility,
-        size = size,
-        timeout = timeout,
-        flaky = flaky,
-        shard_count = shard_count,
-        custom_package = kwargs.get("custom_package", default = None),
-        manifest = manifest,
-        manifest_values = manifest_values,
-        tags = kwargs.get("tags", default = None),
-        testonly = testonly,
-        exec_properties = exec_properties,
-    )
+    **Notes:**
+    * The kotlin test library is not added implicitly, it is available with the label
+    `@com_github_jetbrains_kotlin//:kotlin-test`.
+    """,
+    attrs = utils.add_dicts(_kt_android_local_test_runnable_common_attr_exposed, {
+        "_bazel_test_runner": attr.label(
+            default = Label("@bazel_tools//tools/jdk:TestRunner_deploy.jar"),
+            allow_files = True,
+        ),
+        "friends": attr.label_list(
+            doc = """A single Kotlin dep which allows the test code access to internal members. Currently uses the output
+            jar of the module -- i.e., exported deps won't be included.""",
+            default = [],
+            providers = [JavaInfo, _KtJvmInfo],
+        ),
+        "test_class": attr.string(
+            doc = "The Java class to be loaded by the test runner.",
+            default = "",
+        ),
+        "main_class": attr.string(default = "com.google.testing.junit.runner.BazelTestRunner"),
+        "manifest": attr.label(
+            doc = """The name of the Android manifest file, normally `AndroidManifest.xml`.
+                Must be defined if resource_files or assets are defined.""",
+            default = None,
+            allow_single_file = True,
+        ),
+        "manifest_values": attr.string_dict(
+            doc = """A dictionary of values to be overridden in the manifest.""",
+            default = {}),
+        "custom_package": attr.string(
+            doc = """Java package for which java sources will be generated. By default the package
+             is inferred from the directory where the BUILD file containing the rule is. You can
+             specify a different package but this is highly discouraged since it can introduce
+             classpath conflicts with other libraries that will only be detected at runtime.""",
+        ),
+        "_android_resources_busybox": attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@bazel_tools//tools/android:busybox"),
+            allow_files = True,
+        ),
+        "android_sdk": attr.label(
+            default = Label("@bazel_tools//tools/android:sdk"),
+            allow_files = True,
+        ),
+        # TODO(mgalindo): unify with android_sdk (BUILD-3813)
+        "_android_sdk": attr.label(
+            default = Label("@bazel_tools//tools/android:sdk"),
+            allow_files = True,
+        ),
+        "_enable_jdeps": attr.label(default = ":kotlin_deps"),
+        "_lcov_merger": attr.label(
+            default = Label("@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"),
+        ),
+    }),
+    outputs = _kt_lib_common_outputs_exposed,
+    executable = True,
+    test = True,
+    toolchains = _common_toolchains,
+    fragments = ["android", "java"], # Required fragments of the target configuration
+    host_fragments = ["java"], # Required fragments of the host configuration
+    implementation = _kt_android_local_test_impl,
+)

--- a/kotlin/internal/jvm/android_impl.bzl
+++ b/kotlin/internal/jvm/android_impl.bzl
@@ -1,0 +1,327 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+load(
+    "//kotlin/internal/jvm:compile.bzl",
+    "export_only_providers",
+    _compiler_toolchains = "compiler_toolchains_exposed",
+    _get_kt_dep_infos = "get_kt_dep_infos",
+    _jvm_deps = "jvm_deps_exposed",
+    _kt_jvm_produce_output_jar_actions = "kt_jvm_produce_output_jar_actions",
+)
+load(
+    "//kotlin/internal:defs.bzl",
+    _TOOLCHAIN_TYPE = "TOOLCHAIN_TYPE",
+)
+load(
+    "//kotlin/internal/jvm:impl.bzl",
+    _write_launcher_action_exposed = "write_launcher_action_exposed",
+)
+load(
+    "//kotlin/internal/jvm:external_java_utils.bzl",
+    _resolve_package_from_label = "resolve_package_from_label",
+)
+load(
+    "//kotlin/internal/jvm:associates.bzl",
+    _associate_utils = "associate_utils",
+)
+
+load(
+    ":android_resources.bzl",
+    _process_resources = "process_resources",
+    _process_resources_for_android_local_test  = "process_resources_for_android_local_test",
+)
+load(
+    ":utils.bzl",
+    "get_transitive_prerequisites",
+    "utils"
+)
+
+
+def _collect_transitive_native_libs(ctx):
+    infos = get_transitive_prerequisites(ctx, AndroidNativeLibsInfo)
+
+    return depset(transitive = [
+        i.native_libs
+        for i in infos
+    ])
+
+def _collect_proguard_configs(ctx):
+    """
+    Collect transitive proguard configurations from dependencies
+    """
+    infos = get_transitive_prerequisites(ctx, ProguardSpecProvider, ["deps", "exports", "runtime_deps", "plugins"])
+
+    return depset(ctx.files.proguard_specs, transitive = [
+        i.specs
+        for i in infos
+    ])
+
+def _make_legacy_android_provider(android_ide_info):
+    # Create the ClassJar "object" for the target.android.idl.output field.
+    if android_ide_info.idl_class_jar:
+        idl_class_jar = struct(
+            class_jar = android_ide_info.idl_class_jar,
+            ijar = None,
+            source_jar = android_ide_info.idl_source_jar,
+        )
+    else:
+        idl_class_jar = None
+
+    return struct(
+        aar = android_ide_info.aar,
+        apk = android_ide_info.signed_apk,
+        apks_under_test = android_ide_info.apks_under_test,
+        defines_resources = android_ide_info.defines_android_resources,
+        idl = struct(
+            import_root = android_ide_info.idl_import_root,
+            sources = android_ide_info.idl_srcs,
+            generated_java_files = android_ide_info.idl_generated_java_files,
+            output = idl_class_jar,
+        ),
+        java_package = android_ide_info.java_package,
+        manifest = android_ide_info.manifest,
+        merged_manifest = android_ide_info.generated_manifest,
+        native_libs = android_ide_info.native_libs,
+        resource_apk = android_ide_info.resource_apk,
+        resource_jar = android_ide_info.resource_jar,
+    )
+
+def kt_android_library_impl(ctx):
+    java_package = _resolve_package_from_label(ctx.label, ctx.attr.custom_package, fallback = False)
+
+    resources = None
+    localRClass = None
+    generated_manifest = None
+
+    resources = _process_resources(ctx, java_package)
+
+    if ctx.attr.resource_files and resources.r_java:
+        localRClass = utils.only(utils.list_or_depset_to_list(resources.r_java.compile_jars))
+
+    if resources.merged_manifest:
+        generated_manifest = resources.merged_manifest
+
+    resources_providers = resources.providers
+
+    # Setup the compile action.
+    providers = kt_android_produce_jar_actions(ctx, "kt_jvm_library", localRClass)
+
+    defines_resources = bool(
+        ctx.attr.manifest or
+        ctx.attr.resource_files or
+        ctx.attr.assets or
+        ctx.attr.assets_dir or
+        ctx.attr.exports_manifest,
+    )
+
+    resource_jar = None
+    if localRClass:
+        resource_jar = _getLocalRClass(localRClass).outputs.jars[0]
+
+    # TODO Add the rest of the missing fields to further improve IDE experience
+    android_ide_info = AndroidIdeInfo(
+        java_package,  # java_package
+        ctx.file.manifest,  # manifest
+        generated_manifest,  # generated_manifest
+        # TODO add AIDL support: https://jira.sc-corp.net/browse/BUILD-707
+        None,  # idl_import_root
+        [],  # idl_srcs
+        [],  # idl_generated_java_files
+        None,  # idl_source_jar
+        None,  # idl_class_jar
+        defines_resources,  # defines_android_resources
+        resource_jar,  # resource_jar
+        None,  # resources_apk
+        None,  # signed_apk, always empty for kt_android_library.
+        None,  # aar
+        [],  # apks_under_test, always empty for kt_android_library
+        dict(),  # nativelibs, always empty for kt_android_library
+    )
+
+    files = [ctx.outputs.jar]
+    if  providers.java.outputs.jdeps:
+        files.append(providers.java.outputs.jdeps)
+
+    result = struct(
+        kt = providers.kt,
+        android = _make_legacy_android_provider(android_ide_info),
+        providers = resources_providers + [
+            providers.java,
+            providers.kt,
+            providers.instrumented_files,
+            AndroidNativeLibsInfo(_collect_transitive_native_libs(ctx)),
+            ProguardSpecProvider(_collect_proguard_configs(ctx)),
+            DefaultInfo(
+                files = depset(files),
+                runfiles = ctx.runfiles(
+                    # explicitly include data files, otherwise they appear to be missing
+                    files = ctx.files.data,
+                    transitive_files = depset(order = "default"),
+                    # continue to use collect_default until proper transitive data collecting is
+                    # implemented.
+                    collect_default = True,
+                ),
+            ),
+        ],
+    )
+    return result
+
+def _getAndroidSdkJar(ctx):
+    android_jar = ctx.attr.android_sdk[AndroidSdkInfo].android_jar
+    return JavaInfo(output_jar = android_jar, compile_jar = android_jar, neverlink = True)
+
+def _getLocalRClass(rClass):
+    return JavaInfo(output_jar = rClass, compile_jar = rClass, neverlink = True)
+
+
+_SPLIT_STRINGS = [
+    "src/test/java/",
+    "src/test/kotlin/",
+    "javatests/",
+    "kotlin/",
+    "java/",
+    "test/",
+]
+
+def kt_android_local_test_impl(ctx):
+    # Android resource processing
+    java_package = _resolve_package_from_label(ctx.label, ctx.attr.custom_package, fallback = False)
+
+    resources_ctx = _process_resources_for_android_local_test(ctx, java_package)
+    resources_apk = resources_ctx.resources_apk
+    resources_jar = resources_ctx.class_jar
+
+    # Generate properties file telling Robolectric from where to load resources.
+    test_config_file = ctx.actions.declare_file("_robolectric/" + ctx.label.name + "_test_config.properties")
+    ctx.actions.write(
+        test_config_file,
+        content = "android_resource_apk=" + resources_apk.short_path,
+    )
+
+    # Setup the compile action.
+    providers = kt_android_produce_jar_actions(
+        ctx,
+        "kt_jvm_library",
+        extra_resources = {"com/android/tools/test_config.properties": test_config_file},
+    )
+
+    # Create test run action
+    runtime_jars = depset(
+        ctx.files._bazel_test_runner + [resources_jar] + [ctx.attr.android_sdk[AndroidSdkInfo].android_jar],
+        transitive = [providers.java.transitive_runtime_jars],
+    )
+    coverage_runfiles = []
+    if ctx.configuration.coverage_enabled:
+        jacocorunner = ctx.toolchains[_TOOLCHAIN_TYPE].jacocorunner
+        coverage_runfiles = jacocorunner.files.to_list()
+
+    test_class = ctx.attr.test_class
+
+    # If no test_class, do a best-effort attempt to infer one.
+    if not bool(ctx.attr.test_class):
+        for file in ctx.files.srcs:
+            package_relative_path = file.path.replace(ctx.label.package + "/", "")
+            if package_relative_path.split(".")[0] == ctx.attr.name:
+                for splitter in _SPLIT_STRINGS:
+                    elements = file.short_path.split(splitter, 1)
+                    if len(elements) == 2:
+                        test_class = elements[1].split(".")[0].replace("/", ".")
+                        break
+
+    coverage_metadata = _write_launcher_action_exposed(
+        ctx,
+        runtime_jars,
+        main_class = ctx.attr.main_class,
+        jvm_flags = [
+            "-ea",
+            "-Dbazel.test_suite=%s" % test_class,
+            "-Drobolectric.offline=true",
+            "-Drobolectric-deps.properties=" + _get_android_all_jars_properties_file(ctx).short_path,
+        ] + ctx.attr.jvm_flags,
+    )
+
+    files = [ctx.outputs.jar]
+    if  providers.java.outputs.jdeps:
+        files.append(providers.java.outputs.jdeps)
+
+    return struct(
+        kt = providers.kt,
+        providers = [
+            providers.java,
+            providers.kt,
+            providers.instrumented_files,
+            DefaultInfo(
+                files = depset(files),
+                runfiles = ctx.runfiles(
+                    # Explicitly include data files, otherwise they appear to be missing
+                    # Include resources apk required by Robolectric
+                    files = ctx.files.data + [resources_apk],
+                    transitive_files = depset(
+                        order = "default",
+                        transitive = [runtime_jars, depset(coverage_runfiles), depset(coverage_metadata)],
+                        direct = ctx.files._java_runtime,
+                    ),
+                    # continue to use collect_default until proper transitive data collecting is
+                    # implmented.
+                    collect_default = True,
+                ),
+            ),
+        ],
+    )
+
+def _get_android_all_jars_properties_file(ctx):
+    runfiles = ctx.runfiles(collect_data = True).files.to_list()
+    for run_file in runfiles:
+        if run_file.basename == "robolectric-deps.properties":
+            return run_file
+    fail("'robolectric-deps.properties' not found in the deps of the rule.")
+
+def kt_android_produce_jar_actions(ctx, rule_kind, rClass = None, extra_resources = {}):
+    """Setup The actions to compile a jar and if any resources or resource_jars were provided to merge these in with the
+    compilation output.
+
+    Returns:
+        see `kt_jvm_compile_action`.
+    """
+
+    toolchains = _compiler_toolchains(ctx)
+    associates = _associate_utils.get_associates(ctx)
+    dep_infos = _get_kt_dep_infos(
+        toolchains,
+        associates.targets,
+        deps = ctx.attr.deps,
+    )
+    android_dep_infos = [_getAndroidSdkJar(ctx)]
+    if rClass:
+        android_dep_infos.append(_getLocalRClass(rClass))
+
+    compile_deps = _jvm_deps(ctx, android_dep_infos + dep_infos, ctx.attr.runtime_deps)
+
+    # Reset the field used to populate the returned JavaInfo provider as we don't want to include
+    # other jars from AndroidResourceClassProvider.
+    compile_deps.provided_deps.clear()
+    compile_deps.provided_deps.extend(dep_infos)
+
+    # Setup the compile action.
+    return _kt_jvm_produce_output_jar_actions(
+        ctx,
+        rule_kind = rule_kind,
+        compile_deps = compile_deps,
+        extra_resources = extra_resources,
+    ) if ctx.attr.srcs else export_only_providers(
+        ctx = ctx,
+        actions = ctx.actions,
+        outputs = ctx.outputs,
+        attr = ctx.attr,
+    )

--- a/kotlin/internal/jvm/android_resources.bzl
+++ b/kotlin/internal/jvm/android_resources.bzl
@@ -1,0 +1,79 @@
+load(
+     ":utils.bzl",
+     "get_transitive_prerequisites",
+     "get_android_sdk",
+     "get_android_toolchain",
+     "get_host_javabase",
+     "get_java_toolchain",
+     "utils")
+load("@io_bazel_rules_android//rules:resources.bzl", _rules_android_resources = "resources")
+load("@io_bazel_rules_android//rules/android_local_test:resources.bzl", _rules_android_local_test_processors = "PROCESSORS_FOR_ANDROID_LOCAL_TEST")
+
+TRISTATE_AUTO = -1
+TRISTATE_YES = 1
+
+MANIFEST_PROCESSOR = "ManifestProcessor" # this is not really needed but using it to simplify integration
+RESOURCE_PROCESSOR = "ResourceProcessor"
+
+# Executes the starlark rules_android resource processing pipeline
+def process_resources(ctx, java_package):
+
+    """Collects the transitive dependencies from passed attributes.
+
+    Args:
+      ctx: The context.
+      java_package: the java package of the target
+
+    Returns:
+      A resource_ctx dict of resources_providers.
+    """
+    # exports_manifest can be overridden by a bazel flag.
+    if ctx.attr.exports_manifest == TRISTATE_AUTO:
+        exports_manifest = ctx.fragments.android.get_exports_manifest_default
+    else:
+        exports_manifest = ctx.attr.exports_manifest == TRISTATE_YES
+
+    return _rules_android_resources.process(
+        ctx,
+        manifest = ctx.file.manifest,
+        resource_files = ctx.attr.resource_files,
+        assets = ctx.attr.assets,
+        assets_dir = ctx.attr.assets_dir,
+        exports_manifest = exports_manifest,
+        java_package = java_package,
+        custom_package = ctx.attr.custom_package,
+        neverlink = ctx.attr.neverlink,
+        enable_data_binding = False, #ctx.attr.enable_data_binding,
+        deps = ctx.attr.deps,
+        exports = ctx.attr.exports,
+
+        # Processing behavior changing flags.
+        enable_res_v3 = False, #_flags.get(ctx).android_enable_res_v3,
+        # TODO(b/144163743): remove fix_resource_transitivity, which was only added to emulate
+        # misbehavior on the Java side.
+        fix_resource_transitivity = bool(ctx.attr.srcs),
+        fix_export_exporting = True, #acls.in_fix_export_exporting_rollout(str(ctx.label)),
+        propagate_resources = True, # not ctx.attr._android_test_migration,
+
+        # Tool and Processing related inputs
+        aapt = get_android_toolchain(ctx).aapt2.files_to_run,
+        android_jar = get_android_sdk(ctx).android_jar,
+        android_kit = get_android_toolchain(ctx).android_kit.files_to_run,
+        busybox = get_android_toolchain(ctx).android_resources_busybox.files_to_run,
+        java_toolchain = get_java_toolchain(ctx),
+        host_javabase = get_host_javabase(ctx),
+        instrument_xslt = False, #utils.only(get_android_toolchain(ctx).add_g3itr_xslt.files.to_list()),
+        res_v3_dummy_manifest = utils.only(
+            get_android_toolchain(ctx).res_v3_dummy_manifest.files.to_list(),
+        ),
+        res_v3_dummy_r_txt = utils.only(
+            get_android_toolchain(ctx).res_v3_dummy_r_txt.files.to_list(),
+        ),
+        xsltproc = None, #get_android_toolchain(ctx).xsltproc_tool.files_to_run,
+        zip_tool = get_android_toolchain(ctx).zip_tool.files_to_run,
+    )
+
+def process_resources_for_android_local_test(ctx, java_package):
+    manifest_ctx = _rules_android_local_test_processors[MANIFEST_PROCESSOR](ctx).value
+    return _rules_android_local_test_processors[RESOURCE_PROCESSOR](ctx, manifest_ctx, java_package).value
+

--- a/kotlin/internal/jvm/external_java_utils.bzl
+++ b/kotlin/internal/jvm/external_java_utils.bzl
@@ -1,0 +1,110 @@
+# Copyright 2018 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Various Java utils that were copied from pre-alpha branch of rules_android repo
+
+   See:
+   https://github.com/bazelbuild/rules_android/blob/pre-alpha/rules/java.bzl
+"""
+
+# TODO(djwhang): Get the path separator in a platform agnostic manner.
+_PATH_SEP = "/"
+
+def _is_absolute(path):
+    # TODO(djwhang): This is not cross platform safe. Windows absolute paths
+    # do not start with "//", rather "C:\".
+    return path.startswith(_PATH_SEP)
+
+def _segment_idx(path_segments):
+    """Finds the index of the segment in the path that preceeds the source root.
+    Args:
+      path_segments: A list of strings, where each string is the segment of a
+        filesystem path.
+    Returns:
+      An index to the path segment that represents the Java segment or -1 if
+      none found.
+    """
+    if _is_absolute(path_segments[0]):
+        fail("ERROR: path must not be absolute: %s" % "/".join(path_segments))
+
+    root_idx = -1
+    for idx, segment in enumerate(path_segments):
+        if segment in ["java", "javatests", "src", "testsrc"]:
+            root_idx = idx
+            break
+    if root_idx < 0:
+        return root_idx
+
+    is_src = path_segments[root_idx] == "src"
+    check_maven_idx = root_idx if is_src else -1
+    if root_idx == 0 or is_src:
+        # Check for a nested root directory.
+        for idx in range(root_idx + 1, len(path_segments) - 2):
+            segment = path_segments[idx]
+            if segment == "src" or (is_src and segment in ["java", "javatests"]):
+                next_segment = path_segments[idx + 1]
+                if next_segment in ["com", "org", "net"]:
+                    root_idx = idx
+                elif segment == "src":
+                    check_maven_idx = idx
+                break
+
+    if check_maven_idx >= 0 and check_maven_idx + 2 < len(path_segments):
+        next_segment = path_segments[check_maven_idx + 1]
+        if next_segment in ["main", "test"]:
+            next_segment = path_segments[check_maven_idx + 2]
+            if next_segment in ["java", "resources"]:
+                root_idx = check_maven_idx + 2
+    return root_idx
+
+def _resolve_package(path):
+    """Determines the Java package name from the given path.
+    Examples:
+        "{workspace}/java/foo/bar/wiz" -> "foo.bar.wiz"
+        "{workspace}/javatests/foo/bar/wiz" -> "foo.bar.wiz"
+    Args:
+      path: A string, representing a file path.
+    Returns:
+      A string representing a Java package name or None if could not be
+      determined.
+    """
+    path_segments = path.partition(":")[0].split("/")
+    java_idx = _segment_idx(path_segments)
+    if java_idx < 0:
+        return None
+    else:
+        return ".".join(path_segments[java_idx + 1:])
+
+def resolve_package_from_label(
+        label,
+        custom_package = None,
+        fallback = True):
+    """Resolves the Java package from a Label.
+    When no legal Java package can be resolved from the label, None will be
+    returned unless fallback is specified.
+    When a fallback is requested, a not safe for Java compilation package will
+    be returned. The fallback value will be derrived by taking the label.package
+    and replacing all path separators with ".".
+    """
+    if custom_package:
+        return custom_package
+
+    java_package = _resolve_package(str(label))
+    if java_package != None:  # "" is a valid result.
+        return java_package
+
+    if fallback:
+        return label.package.replace("/", ".")
+
+    return None

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -126,6 +126,9 @@ def _write_launcher_action(ctx, rjars, main_class, jvm_flags):
     )
     return []
 
+# Exposed for kt_android_* rules
+write_launcher_action_exposed = _write_launcher_action
+
 # buildifier: disable=unused-variable
 def _is_source_jar_stub(jar):
     """Workaround for intellij plugin expecting a source jar"""

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -559,3 +559,10 @@ Supports the following template values:
     implementation = _kt_compiler_plugin_impl,
     provides = [_KtCompilerPluginInfo],
 )
+
+#
+# Exposed for kt_android_* rules.
+#
+lib_common_attr_exposed = _lib_common_attr
+runnable_common_attr_exposed = _runnable_common_attr
+common_outputs_exposed = _common_outputs

--- a/kotlin/internal/jvm/utils.bzl
+++ b/kotlin/internal/jvm/utils.bzl
@@ -1,0 +1,68 @@
+load(
+    "//kotlin/internal:defs.bzl",
+    _TOOLCHAIN_TYPE = "TOOLCHAIN_TYPE",
+)
+
+def get_transitive_prerequisites(ctx, provider, attributes = ["deps", "exports"]):
+    """Collects the transitive dependencies from passed attributes.
+
+    Args:
+      ctx: The context.
+      provider: the provider to collect from the attributes.
+      attributes: the list of attributes from context.
+
+    Returns:
+        A list of all the collected providers
+    """
+    result = []
+    for attribute in attributes:
+        for target in getattr(ctx.attr, attribute):
+            if provider in target:
+                result.append(target[provider])
+    return result
+
+def get_java_toolchain(ctx):
+    if not hasattr(ctx.attr, "_java_toolchain"):
+        fail("Missing _java_toolchain attr")
+    return ctx.attr._java_toolchain
+
+def get_host_javabase(ctx):
+    if not hasattr(ctx.attr, "_host_javabase"):
+        fail("Missing _host_javabase attr")
+    return ctx.attr._host_javabase
+
+def get_android_toolchain(ctx):
+    return ctx.toolchains["@io_bazel_rules_android//toolchains/android:toolchain_type"]
+
+def get_android_sdk(ctx):
+    if getattr(ctx.fragments.android, "incompatible_use_toolchain_resolution", False):
+        return ctx.toolchains["@io_bazel_rules_android//toolchains/android_sdk:toolchain_type"].android_sdk_info
+    else:
+        return ctx.attr.android_sdk[AndroidSdkInfo]
+
+def _only(collection):
+    """Returns the only item in the collection."""
+    if len(collection) != 1:
+        fail("Expected one element, has %s." % len(collection))
+    return _first(collection)
+
+def _first(collection):
+    """Returns the first item in the collection."""
+    for i in collection:
+        return i
+    return fail("The collection is empty.")
+
+def _list_or_depset_to_list(list_or_depset):
+    if type(list_or_depset) == "list":
+        return list_or_depset
+    elif type(list_or_depset) == "depset":
+        return list_or_depset.to_list()
+    else:
+        return fail("Expected a list or a depset. Got %s" % type(list_or_depset))
+
+utils = struct(
+    only = _only,
+    first = _first,
+    list_or_depset_to_list = _list_or_depset_to_list,
+)
+

--- a/src/main/starlark/core/repositories/download.bzl
+++ b/src/main/starlark/core/repositories/download.bzl
@@ -104,7 +104,10 @@ def kt_download_local_dev_dependencies():
         strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
         urls = versions.ANDROID.URLS,
         starlark_packages = [
-            "android",
+            "src",
+            "rules",
+            "toolchains",
+            "tools",
         ],
     )
 

--- a/src/main/starlark/core/repositories/setup.bzl
+++ b/src/main/starlark/core/repositories/setup.bzl
@@ -16,7 +16,7 @@ load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
+load("@build_bazel_rules_android//rules:rules.bzl", "android_sdk_repository")
 load("//src/main/starlark/core/repositories:versions.bzl", "versions")
 
 def kt_configure():

--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -25,8 +25,8 @@ versions = struct(
     PROTOBUF_SHA = "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
     BAZEL_DEPS_VERSION = "0.1.0",
     BAZEL_DEPS_SHA = "05498224710808be9687f5b9a906d11dd29ad592020246d4cd1a26eeaed0735e",
-    RULES_JVM_EXTERNAL_TAG = "4.2",
-    RULES_JVM_EXTERNAL_SHA = "cd1a77b7b02e8e008439ca76fd34f5b07aecb8c752961f9640dea15e9e5ba1ca",
+    RULES_JVM_EXTERNAL_TAG = "4.4.2",
+    RULES_JVM_EXTERNAL_SHA = "735602f50813eb2ea93ca3f5e43b1959bd80b213b836a07a62a29d757670b77b",
     RULES_PROTO_GIT_COMMIT = "f6b8d89b90a7956f6782a4a3609b2f0eee3ce965",
     RULES_PROTO_SHA = "4d421d51f9ecfe9bf96ab23b55c6f2b809cbaf0eea24952683e397decfbd0dd0",
     IO_BAZEL_STARDOC_VERSION = "0.5.1",
@@ -47,9 +47,9 @@ versions = struct(
         sha256 = "5e3c8d0f965410ff12e90d6f8dc5df2fc09fd595a684d514616851ce7e94ae7d",
     ),
     ANDROID = struct(
-        VERSION = "0.1.1",
-        SHA = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
-        URLS = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % "0.1.1"],
+        VERSION = "pre-alpha-01-11-2022-3",
+        SHA = "2f5c455937d647065f31d83e3b760d087bbf6e433e9291dbe3b62c999e2991be",
+        URLS = ["https://github.com/mauriciogg/rules_android/archive/refs/tags/pre-alpha-01-11-2022-3.zip"],
         BUILD_TOOLS = "30.0.3",
     ),
     PYTHON = struct(


### PR DESCRIPTION
This PR is intended to be a proof of concept of integrating `rules_kotlin` with the Starlark version for `rules_android`.
This PR uses the pre-alpha version of [rules_android](https://github.com/mauriciogg/rules_android/tree/pre-alpha) with some additional fixes to integrate with `rules_kotlin` [here](https://github.com/mauriciogg/rules_android/commits/pre-alpha) (Note that `rules_android` is not officially supported and this is just a private fork).

The most interesting bits of these PR are in the `android.bzl`, `android_impl.bzl` and `android_resources.bzl` files. Additionally, `examples/android` contains an example usage of `android_application` with a very simple configuration.

There are several benefits of integrating with `rules_android`:
- `kt_android_*` rules can be implemented natively in this repo without the use of sandwich rules.
    This means that `${target}_kt` targets no longer exist only the original `${target}`
-  Decoupled from Bazel binary. Enhancements to the resource processing (the main pice of functionality we use from `rules_android` here) pipeline can happen without needing to wait for Bazel updates.
- Enable use of app bundles and dynamic features via [android_application](https://github.com/mauriciogg/rules_android/blob/pre-alpha/rules/android_application/android_application.bzl#L23) rule. This rule will not be implemented in native Bazel.
- Future proofing `rules_kotlin`- native rules_android will be deprecated at some point.

This PR does the following:
- Implements `kt_android_library` and `kt_android_local_test` by using the resource processing pipeline implemented by `rules_android`. This enables these targets to provide the [StarlarkAndroidResourcesInfo provider](https://sourcegraph.com/github.com/bazelbuild/rules_android@pre-alpha/-/blob/rules/providers.bzl?L82:9&subtree=true) which is the provider collected by the Starlark rules and need in order to use the `android_application` rule.
- Toggles the usage of starlark `rules_android` in `rules_jvm_external` by setting `use_starlark_android_rules = True` in `maven_install`
- Migrates the examples to load the pre-alpha `rules_android`.
- Adds an `android_application` target that generates an App Bundle under `examples/android`

The performance of this implementation is very close to the current implementation (tested on our internal repo). The build graph is mostly the same as what currently exist. In addition multiplex workers are enabled for the resources actions (same as current implementation). We are experimentally building our Android project internally using this implementation and all our builds and tests are green, but your milage may vary (fixes were tailored to problems I encountered in our repo).

The main objective of this PR is to start the conversation towards an official migration, move the `rules_android` repo to a more official home and create a shared stewardship of the repo.

**Some caveats**
- This was only tested with our internal repo so YMMV. The upstream `rules_android` repo is not yet officially supported. See https://github.com/bazelbuild/bazel/issues/5354
- dynamic features work only with targets that contain native libs and assets (not sources and not resources)
- fetching sources in `maven_install` is not possible (this is a simple filename extension issue)
- depending on concrete files from a external maven targets will fail since for whatever reason the visibility of those artifacts is private when using starlak rules_android`
- Changes are required in the intellij plugin for these rules to play nice with the IDE