### PR TITLE
Update Kotlin to 1.7.21

### DIFF
--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -40,11 +40,11 @@ versions = struct(
         sha256 = "a333ad0172369a5cd973aea83e02e8b698c06a2daac6f32925da03049aa3dce7",
     ),
     KOTLIN_CURRENT_COMPILER_RELEASE = version(
-        version = "1.7.20",
+        version = "1.7.21",
         url_templates = [
             "https://github.com/JetBrains/kotlin/releases/download/v{version}/kotlin-compiler-{version}.zip",
         ],
-        sha256 = "5e3c8d0f965410ff12e90d6f8dc5df2fc09fd595a684d514616851ce7e94ae7d",
+        sha256 = "8412b31b808755f0c0d336dbb8c8443fa239bf32ddb3cdb81b305b25f0ad279e",
     ),
     ANDROID = struct(
         VERSION = "0.1.1",


### PR DESCRIPTION
https://github.com/JetBrains/kotlin/releases/tag/v1.7.21