### PR TITLE
Pass nocompress_extensions to base android_local_test rule

### DIFF
--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -99,6 +99,7 @@ def kt_android_local_test(
         visibility = None,
         testonly = True,
         exec_properties = None,
+        nocompress_extensions = None,
         **kwargs):
     """Creates a testable Android sandwich library.
 
@@ -125,4 +126,5 @@ def kt_android_local_test(
         tags = kwargs.get("tags", default = None),
         testonly = testonly,
         exec_properties = exec_properties,
+        nocompress_extensions = nocompress_extensions,
     )


### PR DESCRIPTION
`nocompress_extensions` is useful on `android_local_test` to avoid compressing certain resource types. Without this change, this argument isn't recognized as it is passed to `_kt_android_artifact`