### PR TITLE
Bug: No compilation occurs when module only contains resources + no sources

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -216,7 +216,7 @@ def kt_jvm_library_impl(ctx):
         )
     return _make_providers(
         ctx,
-        _kt_jvm_produce_jar_actions(ctx, "kt_jvm_library") if ctx.attr.srcs else export_only_providers(
+        _kt_jvm_produce_jar_actions(ctx, "kt_jvm_library") if ctx.attr.srcs or ctx.attr.resources else export_only_providers(
             ctx = ctx,
             actions = ctx.actions,
             outputs = ctx.outputs,


### PR DESCRIPTION
When a module has no sources but only resources, the rules will symlink to empty_jars in an effort to avoid compilation. In reality, a resource.jar and a source.jar should still be provided in this case.

Therefore, if a downstream dependency references a resource that is provided in that module, a runtime error will occur.