### PR TITLE
Remove Jetpack Compose hacks now that we are on Bazel 6

### DIFF
--- a/examples/jetpack_compose/BUILD
+++ b/examples/jetpack_compose/BUILD
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_kotlin//kotlin:core.bzl", "define_kt_toolchain", "kt_compiler_plugin")
-load("@io_bazel_rules_kotlin//kotlin:jvm.bzl", "kt_jvm_import")
 load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
 
 # Java Toolchain

--- a/examples/jetpack_compose/BUILD
+++ b/examples/jetpack_compose/BUILD
@@ -28,16 +28,3 @@ kt_compiler_plugin(
         "@maven//:androidx_compose_compiler_compiler",
     ],
 )
-
-# Add missing 'sun.misc' files to coroutines artifact
-# Used in 'override_targets' by referencing @//:kotlinx_coroutines_core_jvm
-kt_jvm_import(
-    name = "kotlinx_coroutines_core_jvm",
-    jars = ["@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.3/kotlinx-coroutines-core-jvm-1.6.3.jar"],
-    srcjar = "@maven_secondary//:v1/https/repo1.maven.org/maven2/org/jetbrains/kotlinx/kotlinx-coroutines-core-jvm/1.6.3/kotlinx-coroutines-core-jvm-1.6.3-sources.jar",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//stub:sun_misc",
-        "@maven//:org_jetbrains_kotlin_kotlin_stdlib",
-    ],
-)

--- a/examples/jetpack_compose/WORKSPACE
+++ b/examples/jetpack_compose/WORKSPACE
@@ -55,25 +55,10 @@ maven_install(
         "androidx.compose.compiler:compiler:{}".format(_COMPOSE_COMPILER_VERSION),
         "androidx.compose.runtime:runtime:{}".format(_COMPOSE_VERSION),
     ],
-    override_targets = {
-        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm": "@//:kotlinx_coroutines_core_jvm",
-    },
     repositories = [
         "https://maven.google.com",
         "https://repo1.maven.org/maven2",
     ],
-)
-
-# Secondary maven repository used mainly for workarounds
-maven_install(
-    name = "maven_secondary",
-    artifacts = [
-        # Workaround to add missing 'sun.misc' dependencies to 'kotlinx-coroutines-core-jvm' artifact
-        # Check root BUILD file and 'override_targets' arg of a primary 'maven_install'
-        "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.6.3",
-    ],
-    fetch_sources = True,
-    repositories = ["https://repo1.maven.org/maven2"],
 )
 
 http_archive(
@@ -96,8 +81,4 @@ http_archive(
 
 load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
 
-android_sdk_repository(
-    name = "androidsdk",
-    api_level = 31,
-    build_tools_version = versions.ANDROID.BUILD_TOOLS,  # versions > 30.0.3 do not have the dx.jar anymore.
-)
+android_sdk_repository(name = "androidsdk")


### PR DESCRIPTION
These hacks are no longer needed with Bazel 6 and can be removed.