### PR TITLE
More Bazel 6.0 cleanup

### DIFF
--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -70,10 +70,7 @@ load(
     "android_sdk_repository",
 )
 
-android_sdk_repository(
-    name = "androidsdk",
-    build_tools_version = versions.ANDROID.BUILD_TOOLS,  # versions > 30.0.3 do not have the dx.jar anymore.
-)
+android_sdk_repository(name = "androidsdk")
 
 http_archive(
     name = "robolectric",

--- a/examples/anvil/WORKSPACE
+++ b/examples/anvil/WORKSPACE
@@ -29,10 +29,7 @@ load(
     "android_sdk_repository",
 )
 
-android_sdk_repository(
-    name = "androidsdk",
-    build_tools_version = versions.ANDROID.BUILD_TOOLS,
-)
+android_sdk_repository(name = "androidsdk")
 
 # Skylib, for build_test, so don't bother initializing the unit test infrastructure.
 http_archive(

--- a/examples/plugin/WORKSPACE
+++ b/examples/plugin/WORKSPACE
@@ -40,7 +40,4 @@ maven_install(
 
 load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
 
-android_sdk_repository(
-    name = "androidsdk",
-    build_tools_version = versions.ANDROID.BUILD_TOOLS,
-)
+android_sdk_repository(name = "androidsdk")

--- a/src/main/starlark/core/repositories/setup.bzl
+++ b/src/main/starlark/core/repositories/setup.bzl
@@ -58,10 +58,7 @@ def kt_configure():
 
     bazel_skylib_workspace()
 
-    android_sdk_repository(
-        name = "androidsdk",
-        build_tools_version = versions.ANDROID.BUILD_TOOLS,
-    )
+    android_sdk_repository(name = "androidsdk")
 
     [
         native.local_repository(

--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -50,7 +50,6 @@ versions = struct(
         VERSION = "0.1.1",
         SHA = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
         URLS = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % "0.1.1"],
-        BUILD_TOOLS = "30.0.3",
     ),
     PYTHON = struct(
         VERSION = "0.2.0",


### PR DESCRIPTION
Bazel 6 no longer caps the build tools version to 30.0.x with it's coupling to `dx.jar`.