### PR TITLE
Use placeholders in progress messages

### DIFF
--- a/kotlin/internal/js/impl.bzl
+++ b/kotlin/internal/js/impl.bzl
@@ -89,7 +89,7 @@ def kt_js_library_impl(ctx):
         executable = toolchain.kotlinbuilder.files_to_run.executable,
         execution_requirements = {"supports-workers": "1"},
         arguments = [args],
-        progress_message = "Compiling Kotlin to JS %s { kt: %d }" % (ctx.label, len(ctx.files.srcs)),
+        progress_message = "Compiling Kotlin to JS %%{label} { kt: %d }" % len(ctx.files.srcs),
         input_manifests = input_manifests,
         env = {
             "REPOSITORY_NAME": _utils.builder_workspace_name(ctx),

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -191,8 +191,7 @@ def _fold_jars_action(ctx, rule_kind, toolchains, output_jar, input_jars, action
         outputs = [output_jar],
         executable = toolchains.java.single_jar,
         arguments = [args],
-        progress_message = "Merging Kotlin output jar %s%s from %d inputs" % (
-            ctx.label,
+        progress_message = "Merging Kotlin output jar %%{label}%s from %d inputs" % (
             "" if not action_type else " (%s)" % action_type,
             len(input_jars),
         ),
@@ -230,7 +229,7 @@ def _build_resourcejar_action(ctx):
             resources_jar_output = resources_jar_output.path,
             zipper = ctx.executable._zipper.path,
         ),
-        progress_message = "Creating intermediate resource jar %s" % ctx.label,
+        progress_message = "Creating intermediate resource jar %{label}",
     )
     return resources_jar_output
 
@@ -249,9 +248,8 @@ def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps):
     args.add("--report_unused_deps", toolchains.kt.experimental_report_unused_deps)
 
     mnemonic = "JdepsMerge"
-    progress_message = "%s %s { jdeps: %d }" % (
+    progress_message = "%s %%{label} { jdeps: %d }" % (
         mnemonic,
-        ctx.label,
         len(jdeps),
     )
 
@@ -428,9 +426,8 @@ def _run_kt_builder_action(
 
     args.add("--build_kotlin", build_kotlin)
 
-    progress_message = "%s %s { kt: %d, java: %d, srcjars: %d } for %s" % (
+    progress_message = "%s %%{label} { kt: %d, java: %d, srcjars: %d } for %s" % (
         mnemonic,
-        ctx.label,
         len(srcs.kt),
         len(srcs.java),
         len(srcs.src_jars),

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -363,7 +363,6 @@ def _deshade_embedded_kotlinc_jars(target, ctx, jars, deps):
         jarjar_action(
             actions = ctx.actions,
             jarjar = ctx.executable._jarjar,
-            label = ctx.label,
             rules = ctx.file._jetbrains_deshade_rules,
             input = jar,
             output = ctx.actions.declare_file(

--- a/kotlin/internal/utils/generate_jvm_service.bzl
+++ b/kotlin/internal/utils/generate_jvm_service.bzl
@@ -43,7 +43,7 @@ def _generate_jvm_service_impl(ctx):
         inputs = zipper_inputs,
         outputs = [jar],
         arguments = [zipper_args],
-        progress_message = "JVM service info jar for %s" % ctx.label,
+        progress_message = "JVM service info jar for %%{label}",
     )
     return struct(
         providers = [

--- a/third_party/jarjar.bzl
+++ b/third_party/jarjar.bzl
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-def jarjar_action(actions, label, rules, input, output, jarjar):
+def jarjar_action(actions, rules, input, output, jarjar):
     actions.run(
         inputs = [rules, input],
         outputs = [output],
         executable = jarjar,
-        progress_message = "jarjar %s" % label,
+        progress_message = "jarjar %%{label}",
         arguments = ["process", rules.path, input.path, output.path],
     )
     return output
@@ -25,7 +25,6 @@ def jarjar_action(actions, label, rules, input, output, jarjar):
 def _jar_jar_impl(ctx):
     jar = jarjar_action(
         actions = ctx.actions,
-        label = ctx.label,
         rules = ctx.file.rules,
         input = ctx.file.input_jar,
         output = ctx.outputs.jar,


### PR DESCRIPTION
This allows Bazel to render the labels in progress messages in a more user-friendly way by unmapping mapped repository names to the names used by the main repository, which is especially relevant with Bzlmod.