### PR TITLE
Remove repository mapping

### DIFF
--- a/WORKSPACE.dev.bazel
+++ b/WORKSPACE.dev.bazel
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-workspace(name = "dev_io_bazel_rules_kotlin")
+workspace(name = "io_bazel_rules_kotlin")
 
 load("//src/main/starlark/core/repositories:download.bzl", "kt_download_local_dev_dependencies")
 
@@ -21,4 +21,4 @@ load("//kotlin:repositories.bzl", "kotlin_repositories")
 
 kotlin_repositories()
 
-register_toolchains("@dev_io_bazel_rules_kotlin//kotlin/internal:default_toolchain")
+register_toolchains("@io_bazel_rules_kotlin//kotlin/internal:default_toolchain")

--- a/kotlin/dependencies.bzl
+++ b/kotlin/dependencies.bzl
@@ -26,7 +26,7 @@ local_repository(
     path = "<path/to/rules_kotlin>",
 )
 
-load("@dev_io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_dependencies")
+load("@io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_dependencies")
 kt_download_local_dev_dependencies()
 
 To:

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -23,10 +23,10 @@ git_repository(
     remote = "https://github.com/bazelbuild/rules_kotlin.git",
     commit = "<COMMIT_HASH>",
 )
-load("@dev_io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
 kotlin_repositories(kotlin_release_version = "1.4.0")
 
-load("@dev_io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 kt_register_toolchains()
 ```
 

--- a/src/legacy/BUILD.bazel
+++ b/src/legacy/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 
 release_archive(
     name = "pkg",

--- a/src/legacy/starlark/jvm/BUILD.bazel
+++ b/src/legacy/starlark/jvm/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(
@@ -19,6 +19,6 @@ bzl_library(
     srcs = glob(["*.bzl"]),
     visibility = ["//visibility:public"],
     deps = [
-        "@dev_io_bazel_rules_kotlin//src/main/starlark",
+        "@io_bazel_rules_kotlin//src/main/starlark",
     ],
 )

--- a/src/legacy/starlark/jvm/opts.bzl
+++ b/src/legacy/starlark/jvm/opts.bzl
@@ -1,5 +1,5 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
 
 _JOPTS = {
     "warn": struct(

--- a/src/legacy/starlark/kotlin/BUILD.bazel
+++ b/src/legacy/starlark/kotlin/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(

--- a/src/legacy/starlark/kotlin/opts.bzl
+++ b/src/legacy/starlark/kotlin/opts.bzl
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
 
 def _map_jvm_target_to_flag(version):
     if not version:

--- a/src/main/starlark/core/repositories/BUILD.com_github_jetbrains_kotlin.bazel
+++ b/src/main/starlark/core/repositories/BUILD.com_github_jetbrains_kotlin.bazel
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# dev_io_bazel_rules_kotlin
+# io_bazel_rules_kotlin
 load("@{{.KotlinRulesRepository}}//kotlin:jvm.bzl", "kt_jvm_import")
 load("@{{.KotlinRulesRepository}}//kotlin:js.bzl", "kt_js_import")
 load("@rules_java//java:defs.bzl", "java_import")

--- a/src/main/starlark/core/repositories/initialize.release.bzl
+++ b/src/main/starlark/core/repositories/initialize.release.bzl
@@ -110,7 +110,7 @@ def kotlin_repositories(
             archive = Label("//:%s.tgz" % selected_version),
             parent = RULES_KOTLIN,
             repo_mapping = {
-                "@dev_io_bazel_rules_kotlin": "@%s" % RULES_KOTLIN.workspace_name,
+                "@io_bazel_rules_kotlin": "@%s" % RULES_KOTLIN.workspace_name,
             },
         )
 

--- a/src/main/starlark/core/repositories/initialize.release.bzl
+++ b/src/main/starlark/core/repositories/initialize.release.bzl
@@ -109,9 +109,6 @@ def kotlin_repositories(
             name = configured_repository_name,
             archive = Label("//:%s.tgz" % selected_version),
             parent = RULES_KOTLIN,
-            repo_mapping = {
-                "@io_bazel_rules_kotlin": "@%s" % RULES_KOTLIN.workspace_name,
-            },
         )
 
 def kotlinc_version(release, sha256):

--- a/src/rkt_1_4/BUILD.bazel
+++ b/src/rkt_1_4/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 
 release_archive(
     name = "pkg",

--- a/src/rkt_1_4/starlark/jvm/BUILD.bazel
+++ b/src/rkt_1_4/starlark/jvm/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(
@@ -19,6 +19,6 @@ bzl_library(
     srcs = glob(["*.bzl"]),
     visibility = ["//visibility:public"],
     deps = [
-        "@dev_io_bazel_rules_kotlin//src/main/starlark",
+        "@io_bazel_rules_kotlin//src/main/starlark",
     ],
 )

--- a/src/rkt_1_4/starlark/jvm/opts.bzl
+++ b/src/rkt_1_4/starlark/jvm/opts.bzl
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
 
 _JOPTS = {
     "warn": struct(

--- a/src/rkt_1_4/starlark/kotlin/BUILD.bazel
+++ b/src/rkt_1_4/starlark/kotlin/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(

--- a/src/rkt_1_4/starlark/kotlin/opts.bzl
+++ b/src/rkt_1_4/starlark/kotlin/opts.bzl
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
 
 def _map_jvm_target_to_flag(version):
     if not version:

--- a/src/rkt_1_5/BUILD.bazel
+++ b/src/rkt_1_5/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 
 release_archive(
     name = "pkg",

--- a/src/rkt_1_5/starlark/jvm/BUILD.bazel
+++ b/src/rkt_1_5/starlark/jvm/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(
@@ -19,6 +19,6 @@ bzl_library(
     srcs = glob(["*.bzl"]),
     visibility = ["//visibility:public"],
     deps = [
-        "@dev_io_bazel_rules_kotlin//src/main/starlark",
+        "@io_bazel_rules_kotlin//src/main/starlark",
     ],
 )

--- a/src/rkt_1_5/starlark/jvm/opts.bzl
+++ b/src/rkt_1_5/starlark/jvm/opts.bzl
@@ -1,5 +1,5 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
 
 _JOPTS = {
     "warn": struct(

--- a/src/rkt_1_5/starlark/kotlin/BUILD.bazel
+++ b/src/rkt_1_5/starlark/kotlin/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(

--- a/src/rkt_1_5/starlark/kotlin/opts.bzl
+++ b/src/rkt_1_5/starlark/kotlin/opts.bzl
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
 
 def _map_optin_class_to_flag(values):
     return ["-Xopt-in=%s" % v for v in values]

--- a/src/rkt_1_6/BUILD.bazel
+++ b/src/rkt_1_6/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 
 release_archive(
     name = "pkg",

--- a/src/rkt_1_6/starlark/jvm/BUILD.bazel
+++ b/src/rkt_1_6/starlark/jvm/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(
@@ -19,6 +19,6 @@ bzl_library(
     srcs = glob(["*.bzl"]),
     visibility = ["//visibility:public"],
     deps = [
-        "@dev_io_bazel_rules_kotlin//src/main/starlark",
+        "@io_bazel_rules_kotlin//src/main/starlark",
     ],
 )

--- a/src/rkt_1_6/starlark/jvm/opts.bzl
+++ b/src/rkt_1_6/starlark/jvm/opts.bzl
@@ -1,5 +1,5 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
 
 _JOPTS = {
     "warn": struct(

--- a/src/rkt_1_6/starlark/kotlin/BUILD.bazel
+++ b/src/rkt_1_6/starlark/kotlin/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(

--- a/src/rkt_1_6/starlark/kotlin/opts.bzl
+++ b/src/rkt_1_6/starlark/kotlin/opts.bzl
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
 
 def _map_optin_class_to_flag(values):
     return ["-opt-in=%s" % v for v in values]

--- a/src/rkt_1_7/BUILD.bazel
+++ b/src/rkt_1_7/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 
 release_archive(
     name = "pkg",

--- a/src/rkt_1_7/starlark/jvm/BUILD.bazel
+++ b/src/rkt_1_7/starlark/jvm/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(
@@ -19,6 +19,6 @@ bzl_library(
     srcs = glob(["*.bzl"]),
     visibility = ["//visibility:public"],
     deps = [
-        "@dev_io_bazel_rules_kotlin//src/main/starlark",
+        "@io_bazel_rules_kotlin//src/main/starlark",
     ],
 )

--- a/src/rkt_1_7/starlark/jvm/opts.bzl
+++ b/src/rkt_1_7/starlark/jvm/opts.bzl
@@ -1,5 +1,5 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
 
 _JOPTS = {
     "warn": struct(

--- a/src/rkt_1_7/starlark/kotlin/BUILD.bazel
+++ b/src/rkt_1_7/starlark/kotlin/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
+load("@io_bazel_rules_kotlin//src/main/starlark/release:packager.bzl", "release_archive")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 exports_files(

--- a/src/rkt_1_7/starlark/kotlin/opts.bzl
+++ b/src/rkt_1_7/starlark/kotlin/opts.bzl
@@ -1,4 +1,4 @@
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:convert.bzl", "convert")
 
 def _map_optin_class_to_flag(values):
     return ["-opt-in=%s" % v for v in values]

--- a/src/test/starlark/convert_test.bzl
+++ b/src/test/starlark/convert_test.bzl
@@ -4,7 +4,7 @@ load(
     "unittest",
 )
 load("//src/main/starlark/core/options:convert.bzl", "convert")
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
 
 def _test_map_value_to_flag(value):
     return ["-flag={}".format(value)]


### PR DESCRIPTION
Rename all `dev_io_bazel_rules_kotlin` to `io_bazel_rules_kotlin` and remove `repo_mapping`.

bzlmod takes over full control of `repo_mapping`, uses it to control "strict repo dependencies" and thus removes the parameter from repository rule

This undo-es some of the previous work done to prevent mixing of development repository and released repos.

Works toward: https://github.com/bazelbuild/rules_kotlin/issues/660