### PR TITLE
Add missing rules_proto calls for deps, etc.

### DIFF
--- a/src/main/starlark/core/repositories/download.bzl
+++ b/src/main/starlark/core/repositories/download.bzl
@@ -22,16 +22,6 @@ def kt_download_local_dev_dependencies():
 
     Must be called before setup_dependencies in the versions.WORKSPACE.
     """
-    maybe(
-        http_archive,
-        name = "com_google_protobuf",
-        sha256 = versions.PROTOBUF_SHA,
-        strip_prefix = "protobuf-%s" % versions.PROTOBUF_VERSION,
-        urls = [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v%s.tar.gz" % versions.PROTOBUF_VERSION,
-            "https://github.com/protocolbuffers/protobuf/archive/v%s.tar.gz" % versions.PROTOBUF_VERSION,
-        ],
-    )
 
     # bazel_skylib is initialized twice during developement. This is intentional, as development
     # needs to be able to run the starlark unittests, while production does not.
@@ -83,11 +73,10 @@ def kt_download_local_dev_dependencies():
         url = "https://github.com/bazelbuild/rules_jvm_external/archive/%s.zip" % versions.RULES_JVM_EXTERNAL_TAG,
     )
 
-    maybe(
-        http_archive,
+    versions.use_repository(
         name = "rules_pkg",
-        url = "https://github.com/bazelbuild/rules_pkg/releases/download/0.7.0/rules_pkg-0.7.0.tar.gz",
-        sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
+        rule = http_archive,
+        version = versions.PKG,
     )
 
     maybe(
@@ -108,14 +97,10 @@ def kt_download_local_dev_dependencies():
         ],
     )
 
-    rules_stardoc_repository(
+    versions.use_repository(
         name = "rules_proto",
-        sha256 = versions.RULES_PROTO_SHA,
-        strip_prefix = "rules_proto-%s" % versions.RULES_PROTO_GIT_COMMIT,
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/%s.tar.gz" % versions.RULES_PROTO_GIT_COMMIT,
-            "https://github.com/bazelbuild/rules_proto/archive/%s.tar.gz" % versions.RULES_PROTO_GIT_COMMIT,
-        ],
+        version = versions.RULES_PROTO,
+        rule = rules_stardoc_repository,
         starlark_packages = [
             "proto",
             "proto/private",

--- a/src/main/starlark/core/repositories/initialize.release.bzl
+++ b/src/main/starlark/core/repositories/initialize.release.bzl
@@ -77,18 +77,10 @@ def kotlin_repositories(
         urls = versions.ANDROID.URLS,
     )
 
-    maybe(
-        http_archive,
+    versions.use_repository(
         name = "rules_python",
-        sha256 = "778197e26c5fbeb07ac2a2c5ae405b30f6cb7ad1f5510ea6fdac03bded96cc6f",
-        urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/rules_python/releases/download/{version}/rules_python-{version}.tar.gz".format(
-                version = versions.PYTHON.VERSION,
-            ),
-            "https://github.com/bazelbuild/rules_python/releases/download/{version}/rules_python-{version}.tar.gz".format(
-                version = versions.PYTHON.VERSION,
-            ),
-        ],
+        rule = http_archive,
+        version = versions.RULES_PYTHON,
     )
 
     # See note in versions.bzl before updating bazel_skylib

--- a/src/main/starlark/core/repositories/setup.bzl
+++ b/src/main/starlark/core/repositories/setup.bzl
@@ -20,8 +20,29 @@ load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
 load("//src/main/starlark/core/repositories:versions.bzl", "versions")
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
+# Workaround for https://github.com/bazelbuild/rules_proto/commit/f371ed34ed7f1a8b83cc34ae96db277e0ba4fcb0
+load("@rules_proto//proto/private:dependencies.bzl", "maven_dependencies")
+load("@bazel_tools//tools/build_defs/repo:java.bzl", "java_import_external")
+
+CORRECTED_RULES_PROTO_SHAS = {
+    # bad -> good
+    "ad275e75ee79e6c6388198dcb9acf0db2edee64782e11b508f379c3a2a17d168": "51febfb24af6faa7eb729c880b8ba011cbab8ce55920656a450740b73d343ee2",
+    "0b16133638b1455bea3449c002c7769c75962007d55e9a39c0bed55128da7f70": "34dc0c5bc98416e95a28b3b18caf74816eaa083b2f9c5702b2300a3763970c7b",
+}
+
 def kt_configure():
     """Setup dependencies. Must be called AFTER kt_download_local_dev_dependencies() """
+
+    # workaround for https://github.com/bazelbuild/rules_proto/commit/f371ed34ed7f1a8b83cc34ae96db277e0ba4fcb0
+    for (name, arguments) in maven_dependencies.items():
+        java_import_external(
+            name = name,
+            **{
+                n: CORRECTED_RULES_PROTO_SHAS.get(str(a), a)
+                for n, a in arguments.items()
+            }
+        )
+
     maven_install(
         name = "kotlin_rules_maven",
         fetch_sources = True,

--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -1,11 +1,23 @@
 # All versions for development and release
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
 version = provider(
     fields = {
         "url_templates": "list of string templates with the placeholder {version}",
         "version": "the version in the form \\D+.\\D+.\\D+(.*)",
         "sha256": "sha256 checksum for the version being downloaded.",
+        "strip_prefix_template": "string template with the placeholder {version}.",
     },
 )
+
+def _use_repository(name, version, rule, **kwargs):
+    http_archive_arguments = dict(kwargs)
+    http_archive_arguments["sha256"] = version.sha256
+    http_archive_arguments["urls"] = [u.format(version = version.version) for u in version.url_templates]
+    if (hasattr(version, "strip_prefix_template")):
+        http_archive_arguments["strip_prefix"] = version.strip_prefix_template.format(version = version.version)
+
+    maybe(rule, name = name, **http_archive_arguments)
 
 versions = struct(
     RULES_NODEJS_VERSION = "5.5.3",
@@ -27,8 +39,16 @@ versions = struct(
     BAZEL_DEPS_SHA = "05498224710808be9687f5b9a906d11dd29ad592020246d4cd1a26eeaed0735e",
     RULES_JVM_EXTERNAL_TAG = "4.4.2",
     RULES_JVM_EXTERNAL_SHA = "735602f50813eb2ea93ca3f5e43b1959bd80b213b836a07a62a29d757670b77b",
-    RULES_PROTO_GIT_COMMIT = "fcad4680fee127dbd8344e6a961a28eef5820ef4",
-    RULES_PROTO_SHA = "36476f17a78a4c495b9a9e70bd92d182e6e78db476d90c74bac1f5f19f0d6d04",
+    RULES_PROTO = version(
+        version = "5.3.0-21.5",
+        sha256 = "80d3a4ec17354cccc898bfe32118edd934f851b03029d63ef3fc7c8663a7415c",
+        strip_prefix_template = "rules_proto-{version}",
+        url_templates = [
+            "https://github.com/bazelbuild/rules_proto/archive/refs/tags/{version}.tar.gz",
+        ],
+    ),
+    MAVEN_PROTO_FIX_GIT_COMMIT = "fcad4680fee127dbd8344e6a961a28eef5820ef4",
+    MAVEN_PROTO_FIX_SHA = "36476f17a78a4c495b9a9e70bd92d182e6e78db476d90c74bac1f5f19f0d6d04",
     IO_BAZEL_STARDOC_VERSION = "0.5.1",
     IO_BAZEL_STARDOC_SHA = "5bcd62378fc5ea87936169b49245d0595c690bde41ef695ce319752cc9929c34",
     BAZEL_JAVA_LAUNCHER_VERSION = "5.0.0",
@@ -51,9 +71,6 @@ versions = struct(
         SHA = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
         URLS = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % "0.1.1"],
     ),
-    PYTHON = struct(
-        VERSION = "0.2.0",
-    ),
     CORE = {
         "rkt_1_7": struct(
             prefix = "1.7",
@@ -75,4 +92,21 @@ versions = struct(
         # For more context: https://github.com/bazelbuild/bazel-toolchains/blob/0c1f7c3c5f9e63f1e0ee91738b964937eea2d3e0/WORKSPACE#L28-L32
         URLS = ["https://storage.googleapis.com/rbe-toolchain/bazel-configs/rbe-ubuntu1604/latest/rbe_default.tar"],
     ),
+    PKG = version(
+        version = "0.7.0",
+        url_templates = [
+            "https://github.com/bazelbuild/rules_pkg/releases/download/{version}/rules_pkg-{version}.tar.gz",
+        ],
+        sha256 = "8a298e832762eda1830597d64fe7db58178aa84cd5926d76d5b744d6558941c2",
+    ),
+    # needed for rules_pkg and java
+    RULES_PYTHON = version(
+        version = "0.16.1",
+        strip_prefix_template = "rules_python-{version}",
+        url_templates = [
+            "https://github.com/bazelbuild/rules_python/archive/refs/tags/{version}.tar.gz",
+        ],
+        sha256 = "497ca47374f48c8b067d786b512ac10a276211810f4a580178ee9b9ad139323a",
+    ),
+    use_repository = _use_repository,
 )


### PR DESCRIPTION
# Changes
* Download `rules_proto` dependencies
* Fix shas in `rules_proto` dependencies as the new version is broken
* Update `rules_python` for the new `rules_pkg`
* Some steps to simplify version management.

# Notes
* We can probably remove the python dependency entirely -- it appears to do some small archive manipulation. that toolchain needs some love.
* Hey, ho, `rules_proto` has got to go! We should move to json for the worker chatter and away from the using it as a compilation model.