### PR TITLE
Use rules_kotlin 1.7.1 in readme install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ this:
 ```python
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-rules_kotlin_version = "1.6.0"
-rules_kotlin_sha = "a57591404423a52bd6b18ebba7979e8cd2243534736c5c94d35c89718ea38f94"
+rules_kotlin_version = "1.7.1"
+rules_kotlin_sha = "fd92a98bd8a8f0e1cdcb490b93f5acef1f1727ed992571232d33de42395ca9b3"
 http_archive(
     name = "io_bazel_rules_kotlin",
     urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v%s/rules_kotlin_release.tgz" % rules_kotlin_version],


### PR DESCRIPTION
Now that 1.7.x is released, it's advisable to have that in the readme for people being able to copy&paste the most recent release.