### PR TITLE
Update Dagger from 2.43.2 -> 2.44.2

### DIFF
--- a/examples/dagger/WORKSPACE
+++ b/examples/dagger/WORKSPACE
@@ -28,9 +28,9 @@ load("@rules_jvm_external//:defs.bzl", "maven_install")
 
 maven_install(
     artifacts = [
-        "com.google.dagger:dagger:2.43.2",
-        "com.google.dagger:dagger-compiler:2.43.2",
-        "com.google.dagger:dagger-producers:2.43.2",
+        "com.google.dagger:dagger:2.44.2",
+        "com.google.dagger:dagger-compiler:2.44.2",
+        "com.google.dagger:dagger-producers:2.44.2",
         "javax.inject:javax.inject:1",
         "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2",
     ],


### PR DESCRIPTION
Pulling in the latest Dagger releases before we update rules_kotlin to Kotlin 1.8