### PR TITLE
Fix reference to java_infos in compile.bzl

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -748,7 +748,7 @@ def _run_kt_java_builder_actions(
     if annotation_processors:
         annotation_processing = _create_annotation_processing(
             annotation_processors = annotation_processors,
-            ap_class_jar = [jars.class_jar for jars in java_info.outputs.jars][0],
+            ap_class_jar = [jars.class_jar for jars in java_infos.outputs.jars][0],
             ap_source_jar = ap_generated_src_jar,
         )
 

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -746,9 +746,10 @@ def _run_kt_java_builder_actions(
 
     annotation_processing = None
     if annotation_processors:
+        jars_list = [java_info.outputs.jars for java_info in java_infos]
         annotation_processing = _create_annotation_processing(
             annotation_processors = annotation_processors,
-            ap_class_jar = [jars.class_jar for jars in [java_info.outputs.jars for java_info in java_infos]][0],
+            ap_class_jar = [jars.class_jar for jars in jars_list][0],
             ap_source_jar = ap_generated_src_jar,
         )
 

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -746,10 +746,10 @@ def _run_kt_java_builder_actions(
 
     annotation_processing = None
     if annotation_processors:
-        jars_list = [java_info.outputs.jars for java_info in java_infos]
+        outputs_list = [java_info.outputs for java_info in java_infos]
         annotation_processing = _create_annotation_processing(
             annotation_processors = annotation_processors,
-            ap_class_jar = [jars.class_jar for jars in jars_list][0],
+            ap_class_jar = [jars.class_jar for outputs in outputs_list for jars in outputs.jars][0],
             ap_source_jar = ap_generated_src_jar,
         )
 

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -748,7 +748,7 @@ def _run_kt_java_builder_actions(
     if annotation_processors:
         annotation_processing = _create_annotation_processing(
             annotation_processors = annotation_processors,
-            ap_class_jar = [jars.class_jar for jars in java_infos.outputs.jars][0],
+            ap_class_jar = [jars.class_jar for jars in [java_info.outputs.jars for java_info in java_infos]][0],
             ap_source_jar = ap_generated_src_jar,
         )
 


### PR DESCRIPTION
`compile.bzl` was incorrectly referencing the variable `java_info` in cases where annotation processors were found, causing compilation to fail as this variable had not been assigned yet. We must first get the `outputs` from each `java_info` inside `java_infos`, and then use a nested list comprehension to get the `jars` list from each `outputs`, flatten the resulting list, and get the `class_jar` field of each `jars` object inside the flattened list.

Fixes #877 