### PR TITLE
Append additional plugins after Kapt execution

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
@@ -198,6 +198,12 @@ internal fun JvmCompilationTask.runPlugins(
           .plus(
             kaptArgs(context, plugins, "stubsAndApt"),
           )
+          .plus(
+            plugins(
+              options = inputs.stubsPluginOptionsList,
+              classpath = inputs.stubsPluginClasspathList,
+            ),
+          )
         )
         .flag("-d", directories.generatedClasses)
         .values(inputs.kotlinSourcesList)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
@@ -190,12 +190,6 @@ internal fun JvmCompilationTask.runPlugins(
       (
         baseArgs()
           .plus(
-            plugins(
-              options = inputs.stubsPluginOptionsList,
-              classpath = inputs.stubsPluginClasspathList,
-            ),
-          )
-          .plus(
             kaptArgs(context, plugins, "stubsAndApt"),
           )
           .plus(


### PR DESCRIPTION
Compilation fails when using KSP if the plugins are appended before Kapt.