### PR TITLE
[KSP] Support disabling Kapt in _run_kt_builder_action

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -660,7 +660,7 @@ def _run_kt_java_builder_actions(
             associates = associates,
             compile_deps = compile_deps,
             deps_artifacts = deps_artifacts,
-            annotation_processors = [],
+            annotation_processors = annotation_processors,
             transitive_runtime_jars = transitive_runtime_jars,
             plugins = plugins,
             outputs = outputs,

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -311,6 +311,7 @@ def _run_kapt_builder_actions(
             "kapt_generated_class_jar": kapt_generated_class_jar,
         },
         build_kotlin = False,
+        build_using_kapt = True,
         mnemonic = "KotlinKapt",
     )
 
@@ -334,6 +335,7 @@ def _run_kt_builder_action(
         plugins,
         outputs,
         build_kotlin = True,
+        build_using_kapt = False,
         mnemonic = "KotlinCompile"):
     """Creates a KotlinBuilder action invocation."""
     kotlinc_options = ctx.attr.kotlinc_opts[KotlincOptions] if ctx.attr.kotlinc_opts else toolchains.kt.kotlinc_options

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -420,6 +420,7 @@ def _run_kt_builder_action(
     )
 
     args.add("--build_kotlin", build_kotlin)
+    args.add("--build_using_kapt", build_using_kapt)
 
     progress_message = "%s %%{label} { kt: %d, java: %d, srcjars: %d } for %s" % (
         mnemonic,
@@ -664,6 +665,7 @@ def _run_kt_java_builder_actions(
             plugins = plugins,
             outputs = outputs,
             build_kotlin = True,
+            build_using_kapt = False,
             mnemonic = "KotlinCompile",
         )
 

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -83,6 +83,7 @@ class KotlinBuilder @Inject internal constructor(
       GENERATED_JAVA_STUB_JAR("--kapt_generated_stub_jar"),
       GENERATED_CLASS_JAR("--kapt_generated_class_jar"),
       BUILD_KOTLIN("--build_kotlin"),
+      BUILD_USING_KAPT("--build_using_kapt"),
       STRICT_KOTLIN_DEPS("--strict_kotlin_deps"),
       REDUCED_CLASSPATH_MODE("--reduced_classpath_mode"),
       INSTRUMENT_COVERAGE("--instrument_coverage"),
@@ -218,6 +219,7 @@ class KotlinBuilder @Inject internal constructor(
       root.info = info
 
       root.compileKotlin = argMap.mandatorySingle(KotlinBuilderFlags.BUILD_KOTLIN).toBoolean()
+      root.compileWithKapt = argMap.mandatorySingle(KotlinBuilderFlags.BUILD_USING_KAPT).toBoolean()
       root.instrumentCoverage = argMap.mandatorySingle(
         KotlinBuilderFlags.INSTRUMENT_COVERAGE,
       ).toBoolean()

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
@@ -182,7 +182,7 @@ internal fun JvmCompilationTask.runPlugins(
       inputs.processorsList.isEmpty() &&
         inputs.stubsPluginClasspathList.isEmpty()
       ) ||
-    inputs.kotlinSourcesList.isEmpty()
+    inputs.kotlinSourcesList.isEmpty() || !this.compileWithKapt
   ) {
     return this
   } else {

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -164,6 +164,7 @@ message JvmCompilationTask {
   Inputs inputs = 4;
   bool compile_kotlin = 6;
   bool instrument_coverage = 7;
+  bool compile_with_kapt = 8;
 }
 
 message JsCompilationTask {

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -240,6 +240,11 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
             return this;
         }
 
+        public TaskBuilder compileWithKapt() {
+            taskBuilder.setCompileWithKapt(true);
+            return this;
+        }
+
         public TaskBuilder useK2() {
             taskBuilder.getInfoBuilder().addPassthroughFlags("-Xuse-k2");
             return this;

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmKaptTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmKaptTest.java
@@ -74,8 +74,10 @@ public class KotlinBuilderJvmKaptTest {
                                     + "        abstract fun build(): TestKtValue\n"
                                     + "    }\n"
                                     + "}");
+                    c.outputJar();
                     c.generatedSourceJar();
                     c.ktStubsJar();
+                    c.compileWithKapt();
                     c.incrementalData();
                 }
         );
@@ -133,7 +135,11 @@ public class KotlinBuilderJvmKaptTest {
                                     + "    }\n"
                                     + "\n"
                                     + "}");
+                    ctx.generatedSourceJar();
+                    ctx.ktStubsJar();
                     ctx.outputJar();
+                    ctx.compileWithKapt();
+                    ctx.incrementalData();
                 });
         ctx.assertFilesExist(
                 DirectoryType.JAVA_SOURCE_GEN,


### PR DESCRIPTION
Makes invoking Kapt using `_run_kt_builder_action` more explicit so that we aren't unintentionally running Kapt in other actions.