### PR TITLE
Add missing 1.8 language_version to toolchains.bzl

### DIFF
--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -128,6 +128,7 @@ _kt_toolchain = rule(
                 "1.5",
                 "1.6",
                 "1.7",
+                "1.8",
             ],
         ),
         "api_version": attr.string(


### PR DESCRIPTION
Back filling a missing field here for 1.8 support before we cut the 1.8 RC release.