### PR TITLE
Update Kotlin compiler to 1.8.10

### DIFF
--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -60,11 +60,11 @@ versions = struct(
         sha256 = "5f6412986b351cc569baa6cfde2e8ff8bc527a7bc15af4fe5a49cfd76b73b569",
     ),
     KOTLIN_CURRENT_COMPILER_RELEASE = version(
-        version = "1.8.0",
+        version = "1.8.10",
         url_templates = [
             "https://github.com/JetBrains/kotlin/releases/download/v{version}/kotlin-compiler-{version}.zip",
         ],
-        sha256 = "0bb9419fac9832a56a3a19cad282f8f2d6f1237d2d467dc8dfe9bd4a2a43c42e",
+        sha256 = "4c3fa7bc1bb9ef3058a2319d8bcc3b7196079f88e92fdcd8d304a46f4b6b5787",
     ),
     ANDROID = struct(
         VERSION = "0.1.1",


### PR DESCRIPTION
https://github.com/JetBrains/kotlin/releases/tag/v1.8.10