### PR TITLE
Add -Xdebug option added in 1.8 to make debugging better

### DIFF
--- a/src/rkt_1_8/starlark/kotlin/opts.bzl
+++ b/src/rkt_1_8/starlark/kotlin/opts.bzl
@@ -251,6 +251,16 @@ _KOPTS = {
         value_to_flag = None,
         map_value_to_flag = _map_jvm_target_to_flag,
     ),
+    "x_debug": struct(
+        args = dict(
+            default = False,
+            doc = "Enable debugging, this option allows for a better debugging experience, especially when using coroutines, but should not be used in production",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xdebug"],
+        },
+    ),
 }
 
 KotlincOptions = provider(


### PR DESCRIPTION
Kotlin 1.8 added a compiler flag to make coroutine debugging a bit easier, as currently certain variables are optimized out between suspension points, making debugging more annoying in certain cases.

Release documentation:
https://kotlinlang.org/docs/whatsnew18.html#a-new-compiler-option-for-disabling-optimizations

Without `x_debug = True`:
![without](https://user-images.githubusercontent.com/64495/220765746-e890ab20-d141-4e18-8a36-5bbc3501fbd8.png)

With `x_debug = True`
![with](https://user-images.githubusercontent.com/64495/220765836-dac2d29a-dace-4e4d-8ccd-8ea1583a3dee.png)
