### PR TITLE
Get rid of duplicates in the --processors and --processorpath arguments.

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -363,12 +363,14 @@ def _run_kt_builder_action(
         annotation_processors,
         map_each = _plugin_mappers.kt_plugin_to_processor,
         omit_if_empty = True,
+        uniquify = True,
     )
     args.add_all(
         "--processorpath",
         annotation_processors,
         map_each = _plugin_mappers.kt_plugin_to_processorpath,
         omit_if_empty = True,
+        uniquify = True,
     )
 
     compiler_plugins = [


### PR DESCRIPTION
Since annotation_processors is (roughly) a depset<struct(depset<string>)>, calling `map_each` on it will not deduplicate strings across structs. We need `uniquify = True` to remove duplicates across the entire `add_all`.

It's possible that other arguments suffer from the same issue; I'm only trying to fix a specific problem that's currently preventing http://github.com/oppia/oppia-android.git from upgrading to a newer rules_kotlin.