### PR TITLE
Remove kt_jvm_plugin_aspect now that all versions of Bazel support JavaPluginInfo

### DIFF
--- a/kotlin/internal/defs.bzl
+++ b/kotlin/internal/defs.bzl
@@ -19,6 +19,9 @@ TOOLCHAIN_TYPE = "%s" % Label("//kotlin/internal:kt_toolchain_type")
 JAVA_TOOLCHAIN_TYPE = "@bazel_tools//tools/jdk:toolchain_type"
 JAVA_RUNTIME_TOOLCHAIN_TYPE = "@bazel_tools//tools/jdk:runtime_toolchain_type"
 
+# Upstream provider for Java plugins
+JavaPluginInfo = getattr(java_common, "JavaPluginInfo")
+
 # The name of the Kotlin compiler workspace.
 KT_COMPILER_REPO = "com_github_jetbrains_kotlin"
 

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -102,10 +102,6 @@ load(
     _TOOLCHAIN_TYPE = "TOOLCHAIN_TYPE",
 )
 load(
-    "//kotlin/internal/jvm:plugins.bzl",
-    _kt_jvm_plugin_aspect = "kt_jvm_plugin_aspect",
-)
-load(
     "//kotlin/internal:opts.bzl",
     _JavacOptions = "JavacOptions",
     _KotlincOptions = "KotlincOptions",
@@ -168,7 +164,6 @@ _common_attr = utils.add_dicts(
         "deps": attr.label_list(
             doc = """A list of dependencies of this rule.See general comments about `deps` at
         [Attributes common to all build rules](https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes).""",
-            aspects = [] if hasattr(java_common, "JavaPluginInfo") else [_kt_jvm_plugin_aspect],
             providers = [
                 [JavaInfo],
             ],
@@ -209,7 +204,6 @@ _common_attr = utils.add_dicts(
         ),
         "plugins": attr.label_list(
             default = [],
-            aspects = [] if hasattr(java_common, "JavaPluginInfo") else [_kt_jvm_plugin_aspect],
             cfg = "exec",
         ),
         "module_name": attr.string(

--- a/kotlin/internal/jvm/plugins.bzl
+++ b/kotlin/internal/jvm/plugins.bzl
@@ -13,14 +13,6 @@
 # limitations under the License.
 _JavaPluginInfo = getattr(java_common, "JavaPluginInfo")
 
-KtJvmPluginInfo = provider(
-    doc = "This provider contains the plugin info for the JVM aspect",
-    fields = {
-        "annotation_processors": "depset of structs containing annotation processor definitions",
-        "transitive_runtime_jars": "depset of transitive_runtime_jars for this plugin and deps",
-    },
-)
-
 # Mapping functions for args.add_all.
 # These preserve the transitive depsets until needed.
 def _kt_plugin_to_processor(processor):

--- a/kotlin/internal/jvm/plugins.bzl
+++ b/kotlin/internal/jvm/plugins.bzl
@@ -19,8 +19,6 @@ KtJvmPluginInfo = provider(
     },
 )
 
-_EMPTY_PLUGIN_INFO = [KtJvmPluginInfo(annotation_processors = depset(), transitive_runtime_jars = depset())]
-
 # Mapping functions for args.add_all.
 # These preserve the transitive depsets until needed.
 def _kt_plugin_to_processor(processor):

--- a/kotlin/internal/jvm/plugins.bzl
+++ b/kotlin/internal/jvm/plugins.bzl
@@ -61,12 +61,3 @@ mappers = struct(
     kt_plugin_to_processor = _kt_plugin_to_processor,
     kt_plugin_to_processorpath = _kt_plugin_to_processorpath,
 )
-
-def merge_plugin_infos(attrs):
-    """Merge all of the plugin infos found in the provided sequence of attributes.
-    Returns:
-        A KtJvmPluginInfo provider, Each of the entries is serializable."""
-    return KtJvmPluginInfo(
-        annotation_processors = _targets_to_annotation_processors(attrs),
-        transitive_runtime_jars = _targets_to_transitive_runtime_jars(attrs),
-    )

--- a/kotlin/internal/jvm/plugins.bzl
+++ b/kotlin/internal/jvm/plugins.bzl
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-_JavaPluginInfo = getattr(java_common, "JavaPluginInfo")
+load("//kotlin/internal:defs.bzl", _JavaPluginInfo = "JavaPluginInfo")
 
 # Mapping functions for args.add_all.
 # These preserve the transitive depsets until needed.

--- a/kotlin/internal/jvm/plugins.bzl
+++ b/kotlin/internal/jvm/plugins.bzl
@@ -11,11 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-load(
-    "//kotlin/internal/utils:utils.bzl",
-    _utils = "utils",
-)
-
 KtJvmPluginInfo = provider(
     doc = "This provider contains the plugin info for the JVM aspect",
     fields = {

--- a/kotlin/internal/jvm/plugins.bzl
+++ b/kotlin/internal/jvm/plugins.bzl
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+_JavaPluginInfo = getattr(java_common, "JavaPluginInfo")
+
 KtJvmPluginInfo = provider(
     doc = "This provider contains the plugin info for the JVM aspect",
     fields = {
@@ -22,49 +24,35 @@ KtJvmPluginInfo = provider(
 # Mapping functions for args.add_all.
 # These preserve the transitive depsets until needed.
 def _kt_plugin_to_processor(processor):
-    if hasattr(java_common, "JavaPluginInfo"):
-        return processor.processor_classes.to_list()
-    return processor.processor_class
+    return processor.processor_classes.to_list()
 
 def _kt_plugin_to_processorpath(processor):
-    if hasattr(java_common, "JavaPluginInfo"):
-        return [j.path for j in processor.processor_jars.to_list()]
-    return [j.path for j in processor.classpath.to_list()]
+    return [j.path for j in processor.processor_jars.to_list()]
 
 def _targets_to_annotation_processors(targets):
-    if hasattr(java_common, "JavaPluginInfo"):
-        _JavaPluginInfo = getattr(java_common, "JavaPluginInfo")
-        plugins = []
-        for t in targets:
-            if _JavaPluginInfo in t:
-                p = t[_JavaPluginInfo].plugins
-                if p.processor_jars:
-                    plugins.append(p)
-            elif JavaInfo in t:
-                p = t[JavaInfo].plugins
-                if p.processor_jars:
-                    plugins.append(p)
-        return depset(plugins)
-
-    return depset(transitive = [t[KtJvmPluginInfo].annotation_processors for t in targets if KtJvmPluginInfo in t])
+    plugins = []
+    for t in targets:
+        if _JavaPluginInfo in t:
+            p = t[_JavaPluginInfo].plugins
+            if p.processor_jars:
+                plugins.append(p)
+        elif JavaInfo in t:
+            p = t[JavaInfo].plugins
+            if p.processor_jars:
+                plugins.append(p)
+    return depset(plugins)
 
 def _targets_to_annotation_processors_java_plugin_info(targets):
-    if hasattr(java_common, "JavaPluginInfo"):
-        _JavaPluginInfo = getattr(java_common, "JavaPluginInfo")
-        return [t[_JavaPluginInfo] for t in targets if _JavaPluginInfo in t]
-    return [t[JavaInfo] for t in targets if JavaInfo in t]
+    return [t[_JavaPluginInfo] for t in targets if _JavaPluginInfo in t]
 
 def _targets_to_transitive_runtime_jars(targets):
-    if hasattr(java_common, "JavaPluginInfo"):
-        _JavaPluginInfo = getattr(java_common, "JavaPluginInfo")
-        return depset(
-            transitive = [
-                (t[_JavaPluginInfo] if _JavaPluginInfo in t else t[JavaInfo]).plugins.processor_jars
-                for t in targets
-                if _JavaPluginInfo in t or JavaInfo in t
-            ],
-        )
-    return depset(transitive = [t[KtJvmPluginInfo].transitive_runtime_jars for t in targets if KtJvmPluginInfo in t])
+    return depset(
+        transitive = [
+            (t[_JavaPluginInfo] if _JavaPluginInfo in t else t[JavaInfo]).plugins.processor_jars
+            for t in targets
+            if _JavaPluginInfo in t or JavaInfo in t
+        ],
+    )
 
 mappers = struct(
     targets_to_annotation_processors = _targets_to_annotation_processors,


### PR DESCRIPTION
`JavaPluginInfo` was added in Bazel 5.x which means that it exists by default for all versions of Bazel that we officially support in `rules_kotlin` which means that we should no longer be applying the `kt_jvm_plugin_aspect` aspect. It should be safe to remove now.

This also defaults the rest plugins.bzl over to using `JavaPluginInfo` directly.