### PR TITLE
Update rules_python version

### DIFF
--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -100,12 +100,12 @@ versions = struct(
     ),
     # needed for rules_pkg and java
     RULES_PYTHON = version(
-        version = "0.16.1",
+        version = "0.20.0",
         strip_prefix_template = "rules_python-{version}",
         url_templates = [
             "https://github.com/bazelbuild/rules_python/archive/refs/tags/{version}.tar.gz",
         ],
-        sha256 = "497ca47374f48c8b067d786b512ac10a276211810f4a580178ee9b9ad139323a",
+        sha256 = "a644da969b6824cc87f8fe7b18101a8a6c57da5db39caa6566ec6109f37d2141",
     ),
     use_repository = _use_repository,
 )


### PR DESCRIPTION
This is needed to correctly load py_proto_library from @bazel tools.

Addresses: https://github.com/bazelbuild/bazel/issues/17874