### PR TITLE
Update android.bzl to call into the repo rules

### DIFF
--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -15,6 +15,11 @@ load(
     "//kotlin/internal/jvm:jvm.bzl",
     _kt_jvm_library = "kt_jvm_library",
 )
+load(
+    "@build_bazel_rules_android//android:rules.bzl",
+    _android_library = "android_library",
+    _android_local_test = "android_local_test",
+)
 
 _ANDROID_SDK_JAR = "%s" % Label("//third_party:android_sdk")
 
@@ -40,9 +45,7 @@ def _kt_android_artifact(
     # TODO(bazelbuild/rules_kotlin/issues/273): This should be retrieved from a provider.
     base_deps = [_ANDROID_SDK_JAR] + deps
 
-    # TODO(bazelbuild/rules_kotlin/issues/556): replace with starlark
-    # buildifier: disable=native-android
-    native.android_library(
+    android_library(
         name = base_name,
         visibility = ["//visibility:private"],
         exports = base_deps,
@@ -75,9 +78,7 @@ def kt_android_library(name, exports = [], visibility = None, exec_properties = 
     related attributes are handled by the native `android_library` rule.
     """
 
-    # TODO(bazelbuild/rules_kotlin/issues/556): replace with starlark
-    # buildifier: disable=native-android
-    native.android_library(
+    _android_library(
         name = name,
         exports = exports + _kt_android_artifact(name, exec_properties = exec_properties, **kwargs),
         visibility = visibility,
@@ -109,9 +110,7 @@ def kt_android_local_test(
     are picked out and handled by the `android_local_test` rule.
     """
 
-    # TODO(556): replace with starlark
-    # buildifier: disable=native-android
-    native.android_local_test(
+    _android_local_test(
         name = name,
         deps = kwargs.get("deps", []) + _kt_android_artifact(name = name, testonly = testonly, exec_properties = exec_properties, **kwargs),
         jvm_flags = jvm_flags,


### PR DESCRIPTION
This makes migrating over to the Starlark rules_android easier.