### PR TITLE
Check all dependency jars before marking unused

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMerger.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMerger.kt
@@ -96,7 +96,8 @@ class JdepsMerger {
         // unless all of the jars are unused.
         dependencyMap.values.forEach {
           val label = readJarOwnerFromManifest(Paths.get(it.path)).label
-          if (label != null && kindMap.getOrDefault(label, Deps.Dependency.Kind.UNUSED) >= it.kind) {
+          if (label != null &&
+              kindMap.getOrDefault(label, Deps.Dependency.Kind.UNUSED) >= it.kind) {
               kindMap.put(label, it.kind)
           }
         }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMerger.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMerger.kt
@@ -88,11 +88,22 @@ class JdepsMerger {
       BufferedOutputStream(File(output).outputStream()).use {
         it.write(rootBuilder.build().toByteArray())
       }
-
       if (reportUnusedDeps != "off") {
-        val unusedLabels = dependencyMap.values
-          .filter { it.kind == Deps.Dependency.Kind.UNUSED }
-          .mapNotNull { readJarOwnerFromManifest(Paths.get(it.path)).label }
+        val kindMap = mutableMapOf<String, Deps.Dependency.Kind>()
+
+        // A target might produce multiple jars (Android produces _resources.jar)
+        // so we need to make sure wedon't mart the dependency as unused
+        // unless all of the jars are unused.
+        dependencyMap.values.forEach {
+          val label = readJarOwnerFromManifest(Paths.get(it.path)).label
+          if (label != null && kindMap.getOrDefault(label, Deps.Dependency.Kind.UNUSED) >= it.kind) {
+              kindMap.put(label, it.kind)
+          }
+        }
+
+        val unusedLabels = kindMap.entries
+          .filter { it.value == Deps.Dependency.Kind.UNUSED }
+          .map { it.key }
           .filter { it != label }
 
         if (unusedLabels.isNotEmpty()) {

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMerger.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMerger.kt
@@ -72,21 +72,8 @@ class JdepsMerger {
           val deps: Deps.Dependencies = Deps.Dependencies.parseFrom(it)
           deps.getDependencyList().forEach {
             val dependency = dependencyMap.get(it.path)
-            if (dependency != null) {
-              // Replace dependency if it has a stronger kind than one we encountered before, and
-              // merge used classes list.
-              if (dependency.kind > it.kind) {
-                dependencyMap.put(
-                  it.path,
-                  it.toBuilder().addAllUsedClasses(dependency.getUsedClassesList()).build(),
-                )
-              } else {
-                dependencyMap.put(
-                  it.path,
-                  dependency.toBuilder().addAllUsedClasses(it.getUsedClassesList()).build(),
-                )
-              }
-            } else {
+            // Replace dependency if it has a stronger kind than one we encountered before.
+            if (dependency == null || dependency.kind > it.kind) {
               dependencyMap.put(it.path, it)
             }
           }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMergerTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/JdepsMergerTest.kt
@@ -303,20 +303,20 @@ class JdepsMergerTest {
   fun `used deps multiple jars for label`() {
     val merger = DaggerJdepsMergerTestComponent.builder().build().jdepsMerger()
 
-    val unusedKotlinDepA = ktJvmLibrary("kotlin_dep", "_a")
-    val unusedKotlinDepB = ktJvmLibrary("kotlin_dep", "_b")
+    val unusedKotlinDep = ktJvmLibrary("kotlin_dep", "_a")
+    val usedKotlinDep = ktJvmLibrary("kotlin_dep", "_b")
     val kotlinJdeps = jdeps("kt.jdeps") {
       addDependency(
         with(Dependency.newBuilder()) {
           kind = Dependency.Kind.UNUSED
-          path = unusedKotlinDepA
+          path = unusedKotlinDep
           build()
         },
       )
       addDependency(
         with(Dependency.newBuilder()) {
           kind = Dependency.Kind.EXPLICIT
-          path = unusedKotlinDepB
+          path = usedKotlinDep
           build()
         },
       )
@@ -344,7 +344,7 @@ class JdepsMergerTest {
       depsProto.dependencyList
         .filter { it.kind == Dependency.Kind.EXPLICIT }
         .map { it.path },
-    ).containsExactly(unusedKotlinDepB)
+    ).containsExactly(usedKotlinDep)
   }
 
   private fun depsProto(mergedJdeps: Path) =


### PR DESCRIPTION
A dependency might produce more than one jar (e.g. android targets produce a library jar and a resources jar). If one of those jars is unused, the current logic will mark the dependency as unused.  This change only marks the dependency unused if none of the jars are used.

- Also ran ktlint