### PR TITLE
Support -Xenable-incremental-compilation

### DIFF
--- a/src/main/starlark/core/options/opts.kotlinc.bzl
+++ b/src/main/starlark/core/options/opts.kotlinc.bzl
@@ -297,17 +297,6 @@ _KOPTS_ALL = {
             True: ["-Xreport-perf"],
         },
     ),
-    "x_report_perf": struct(
-        flag = "-Xreport-perf",
-        args = dict(
-            default = False,
-            doc = "Report detailed performance statistics",
-        ),
-        type = attr.bool,
-        value_to_flag = {
-            True: ["-Xreport-perf"],
-        },
-    ),
     "jvm_target": struct(
         args = dict(
             default = "",

--- a/src/main/starlark/core/options/opts.kotlinc.bzl
+++ b/src/main/starlark/core/options/opts.kotlinc.bzl
@@ -276,6 +276,27 @@ _KOPTS_ALL = {
         value_to_flag = None,
         map_value_to_flag = _map_backend_threads_to_flag,
     ),
+    "x_enable_incremental_compilation": struct(
+        args = dict(
+            default = False,
+            doc = "Enable incremental compilation",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xenable-incremental-compilation"],
+        },
+    ),
+    "x_report_perf": struct(
+        flag = "-Xreport-perf",
+        args = dict(
+            default = False,
+            doc = "Report detailed performance statistics",
+        ),
+        type = attr.bool,
+        value_to_flag = {
+            True: ["-Xreport-perf"],
+        },
+    ),
     "x_report_perf": struct(
         flag = "-Xreport-perf",
         args = dict(


### PR DESCRIPTION
There have been reports that this causes performance issues in Gradle 1.8.x so best to have a way to disable this in case we see these issues in Bazel builds as well.