### PR TITLE
Rename dev_io_bazel_rules_kotlin -> io_bazel_rules_kotlin

### DIFF
--- a/WORKSPACE.dev.bazel
+++ b/WORKSPACE.dev.bazel
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-workspace(name = "dev_io_bazel_rules_kotlin")
+workspace(name = "io_bazel_rules_kotlin")
 
 load("//src/main/starlark/core/repositories:download.bzl", "kt_download_local_dev_dependencies")
 
@@ -21,4 +21,4 @@ load("//kotlin:repositories.bzl", "kotlin_repositories")
 
 kotlin_repositories()
 
-register_toolchains("@dev_io_bazel_rules_kotlin//kotlin/internal:default_toolchain")
+register_toolchains("@io_bazel_rules_kotlin//kotlin/internal:default_toolchain")

--- a/WORKSPACE.dev.bazel
+++ b/WORKSPACE.dev.bazel
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-workspace(name = "io_bazel_rules_kotlin")
+workspace(name = "dev_io_bazel_rules_kotlin")
 
 load("//src/main/starlark/core/repositories:download.bzl", "kt_download_local_dev_dependencies")
 
@@ -21,4 +21,4 @@ load("//kotlin:repositories.bzl", "kotlin_repositories")
 
 kotlin_repositories()
 
-register_toolchains("@io_bazel_rules_kotlin//kotlin/internal:default_toolchain")
+register_toolchains("@dev_io_bazel_rules_kotlin//kotlin/internal:default_toolchain")

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -23,10 +23,10 @@ git_repository(
     remote = "https://github.com/bazelbuild/rules_kotlin.git",
     commit = "<COMMIT_HASH>",
 )
-load("@dev_io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
 kotlin_repositories(kotlin_release_version = "1.4.0")
 
-load("@dev_io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
+load("@io_bazel_rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
 kt_register_toolchains()
 ```
 

--- a/src/main/starlark/core/repositories/BUILD.com_github_google_ksp.bazel
+++ b/src/main/starlark/core/repositories/BUILD.com_github_google_ksp.bazel
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# dev_io_bazel_rules_kotlin
+# io_bazel_rules_kotlin
 load("@{{.KotlinRulesRepository}}//kotlin:jvm.bzl", "kt_jvm_import")
 
 package(default_visibility = ["//visibility:public"])

--- a/src/main/starlark/core/repositories/kotlin/BUILD.com_github_jetbrains_kotlin.bazel
+++ b/src/main/starlark/core/repositories/kotlin/BUILD.com_github_jetbrains_kotlin.bazel
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# dev_io_bazel_rules_kotlin
+# io_bazel_rules_kotlin
 load("@{{.KotlinRulesRepository}}//kotlin:jvm.bzl", "kt_jvm_import")
 load("@{{.KotlinRulesRepository}}//kotlin:js.bzl", "kt_js_import")
 load("@rules_java//java:defs.bzl", "java_import")

--- a/src/test/starlark/convert_test.bzl
+++ b/src/test/starlark/convert_test.bzl
@@ -4,7 +4,7 @@ load(
     "unittest",
 )
 load("//src/main/starlark/core/options:convert.bzl", "convert")
-load("@io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
+load("//src/main/starlark/core/options:derive.bzl", "derive")
 
 def _test_map_value_to_flag(value):
     return ["-flag={}".format(value)]

--- a/src/test/starlark/convert_test.bzl
+++ b/src/test/starlark/convert_test.bzl
@@ -4,7 +4,7 @@ load(
     "unittest",
 )
 load("//src/main/starlark/core/options:convert.bzl", "convert")
-load("@dev_io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
+load("@io_bazel_rules_kotlin//src/main/starlark/core/options:derive.bzl", "derive")
 
 def _test_map_value_to_flag(value):
     return ["-flag={}".format(value)]


### PR DESCRIPTION
The `dev_io_bazel_rules_kotlin` workspace name doesn't exist anymore and can just be replaced with the default `io_bazel_rules_kotlin` one.