### PR TITLE
Remove print warning from kt_download_local_dev_dependencies

### DIFF
--- a/kotlin/dependencies.bzl
+++ b/kotlin/dependencies.bzl
@@ -18,30 +18,4 @@ load(
 )
 
 def kt_download_local_dev_dependencies():
-<<<<<<< HEAD
-    print("""kt_download_local_dev_dependencies is deprecated. To use rules_kotlin locally, change
-the WORKSPACE loading from:
-
-local_repository(
-    name = "io_bazel_rules_kotlin",
-    path = "<path/to/rules_kotlin>",
-)
-
-load("@dev_io_bazel_rules_kotlin//kotlin:dependencies.bzl", "kt_download_local_dev_dependencies")
-kt_download_local_dev_dependencies()
-
-To:
-
-local_repository(
-    name = "release_archive",
-    path = "<path/to/rules_kotlin>/src/main/starlark/release_archive",
-)
-load("@release_archive//:repository.bzl", "archive_repository")
-
-
-archive_repository(
-    name = "io_bazel_rules_kotlin",
-)""")
-=======
->>>>>>> 76554453 (Remove print warning from kt_download_local_dev_dependencies)
     _kt_download_local_dev_dependencies()

--- a/kotlin/dependencies.bzl
+++ b/kotlin/dependencies.bzl
@@ -18,6 +18,7 @@ load(
 )
 
 def kt_download_local_dev_dependencies():
+<<<<<<< HEAD
     print("""kt_download_local_dev_dependencies is deprecated. To use rules_kotlin locally, change
 the WORKSPACE loading from:
 
@@ -41,4 +42,6 @@ load("@release_archive//:repository.bzl", "archive_repository")
 archive_repository(
     name = "io_bazel_rules_kotlin",
 )""")
+=======
+>>>>>>> 76554453 (Remove print warning from kt_download_local_dev_dependencies)
     _kt_download_local_dev_dependencies()


### PR DESCRIPTION
When using as a local override you need to call into `kt_download_local_dev_dependencies` to sync the dependencies.