### PR TITLE
Restore neverlink on compiler.

### DIFF
--- a/src/main/starlark/core/repositories/kotlin/BUILD.com_github_jetbrains_kotlin.bazel
+++ b/src/main/starlark/core/repositories/kotlin/BUILD.com_github_jetbrains_kotlin.bazel
@@ -47,6 +47,7 @@ kt_jvm_import(
 kt_jvm_import(
     name = "kotlin-compiler",
     jar = "lib/kotlin-compiler.jar",
+    neverlink = 1,
     deps = [
         ":annotations",
         ":kotlin-reflect",


### PR DESCRIPTION
The lack of a `neverlink` here is causing the entire `kotlin-compiler` classpath into the worker implementations resuting in a 250+ mb `rules_kotlin` release.