### PR TITLE
Avoid creating duplicate android_sdk_repositories

### DIFF
--- a/src/main/starlark/core/repositories/setup.bzl
+++ b/src/main/starlark/core/repositories/setup.bzl
@@ -60,5 +60,3 @@ def kt_configure():
     stardoc_repositories()
 
     bazel_skylib_workspace()
-
-    android_sdk_repository(name = "androidsdk")

--- a/src/main/starlark/core/repositories/setup.bzl
+++ b/src/main/starlark/core/repositories/setup.bzl
@@ -16,7 +16,6 @@ load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_
 load("@rules_jvm_external//:defs.bzl", "maven_install")
 load("@io_bazel_stardoc//:setup.bzl", "stardoc_repositories")
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
 load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 
 def kt_configure():


### PR DESCRIPTION
This causes duplicate `android_sdk_repositories` to be created when using rules_kotlin in as a `local_repository` override