### PR TITLE
Expose ksp_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,20 @@ kt_jvm_library(
 )
 ```
 
+To choose a different `ksp_version` distribution,
+do the following in your `WORKSPACE` file (or import from a `.bzl` file):
+
+```python
+load("@io_bazel_rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "ksp_version")
+
+kotlin_repositories(
+    ksp_compiler_release = ksp_version(
+        release = "1.8.22-1.0.11",
+        sha256 = "2ce5a08fddd20ef07ac051615905453fe08c3ba3ce5afa5dc43a9b77aa64507d",
+    ),
+)
+```
+
 # Kotlin compiler plugins
 
 The `kt_compiler_plugin` rule allows running Kotlin compiler plugins, such as no-arg, sam-with-receiver and allopen.

--- a/kotlin/repositories.bzl
+++ b/kotlin/repositories.bzl
@@ -2,9 +2,11 @@ load(
     "//src/main/starlark/core/repositories:initialize.bzl",
     _kotlin_repositories = "kotlin_repositories",
     _kotlinc_version = "kotlinc_version",
+    _ksp_version = "ksp_version",
     _versions = "versions",
 )
 
 kotlin_repositories = _kotlin_repositories
 versions = _versions
 kotlinc_version = _kotlinc_version
+ksp_version = _ksp_version


### PR DESCRIPTION
### What has changed?
- Exposed `ksp_version` so it can be loaded and used to override `ksp_compiler_release` in `kotlin_repositories`