### PR TITLE
Group the all_tests jobs together in presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -12,6 +12,9 @@ tasks:
       - "//:all_tests"
     build_targets:
       - "//:rules_kotlin_release"
+  macos:
+    test_targets:
+      - "//:all_tests"
   rbe_ubuntu1604:
     test_targets:
       - "--"
@@ -24,9 +27,6 @@ tasks:
       # Override the default worker strategy for remote builds (worker strategy
       # cannot be used with remote builds)
       - "--strategy=KotlinCompile=remote"
-  macos:
-    test_targets:
-      - "//:all_tests"
   example-android:
     name: "Example - Android"
     platform: ubuntu1804


### PR DESCRIPTION
Just some minor book keeping to keep relevant jobs grouped together.