### PR TITLE
Disable strict deps for Android example

### DIFF
--- a/examples/android/bzl/BUILD.bazel
+++ b/examples/android/bzl/BUILD.bazel
@@ -12,10 +12,6 @@ kt_javac_options(
 define_kt_toolchain(
     name = "experimental_toolchain",
     api_version = "1.5",
-    # TODO(630): enable when the reduced classpath can correctly manage transitive maven dependencies.
-    # experimental_reduce_classpath_mode = "KOTLINBUILDER_REDUCED",
-    experimental_report_unused_deps = "warn",
-    experimental_strict_kotlin_deps = "warn",
     experimental_use_abi_jars = True,
     javac_options = ":default_javac_options",
     kotlinc_options = ":default_kotlinc_options",


### PR DESCRIPTION
This experimental feature doesn't work super well for Android projects at the moment and should just be disabled until someone has more time to invest in getting things in better shape.