### PR TITLE
Pass through kotlinc options to JS compile

### DIFF
--- a/kotlin/internal/js/impl.bzl
+++ b/kotlin/internal/js/impl.bzl
@@ -17,6 +17,11 @@ load(
     _TOOLCHAIN_TYPE = "TOOLCHAIN_TYPE",
 )
 load(
+    "//kotlin/internal:opts.bzl",
+    "KotlincOptions",
+    "kotlinc_options_to_flags",
+)
+load(
     "//kotlin/internal/utils:utils.bzl",
     _utils = "utils",
 )
@@ -42,9 +47,11 @@ def kt_js_library_impl(ctx):
         _utils.derive_module_name(ctx),
     )
 
+    kotlinc_options = ctx.attr.kotlinc_opts[KotlincOptions] if ctx.attr.kotlinc_opts else toolchain.kotlinc_options
+
     args.add_all(
         "--kotlin_js_passthrough_flags",
-        [
+        kotlinc_options_to_flags(kotlinc_options) + [
             "-source-map",
             "-Xir-produce-klib-dir",
             "-no-stdlib",

--- a/kotlin/internal/js/js.bzl
+++ b/kotlin/internal/js/js.bzl
@@ -18,6 +18,10 @@ load(
     _TOOLCHAIN_TYPE = "TOOLCHAIN_TYPE",
 )
 load(
+    "//kotlin/internal:opts.bzl",
+    _KotlincOptions = "KotlincOptions",
+)
+load(
     "//kotlin/internal/js:impl.bzl",
     _kt_js_import_impl = "kt_js_import_impl",
     _kt_js_library_impl = "kt_js_library_impl",
@@ -85,6 +89,13 @@ kt_js_library = rule(
         ),
         "module_name": attr.string(
             doc = "internal attribute",
+            mandatory = False,
+        ),
+        "kotlinc_opts": attr.label(
+            doc = """Kotlinc options to be used when compiling this target. These opts if provided
+                    will be used instead of the ones provided to the toolchain.""",
+            default = None,
+            providers = [_KotlincOptions],
             mandatory = False,
         ),
         "_toolchain": attr.label(


### PR DESCRIPTION
Fixes #1016

I haven't yet considered what options may need to be e.g. stripped out before sending along. But if there are other glaring holes in this, or reasons to avoid this kind of approach altogether, LMK.