### PR TITLE
Add transitive_runtime_jars to KtKvmInfo

### DIFF
--- a/kotlin/internal/defs.bzl
+++ b/kotlin/internal/defs.bzl
@@ -37,6 +37,7 @@ KtJvmInfo = provider(
         "outputs": "output jars produced by this rule. [intelij-aspect]",
         "language_version": "version of kotlin used. [intellij-aspect]",
         "transitive_compile_time_jars": "Returns the transitive set of Jars required to build the target. [intellij-aspect]",
+        "transitive_runtime_jars": "Returns the transitive set of Jars required to run the target. [intellij-aspect]",
         "transitive_source_jars": "Returns the Jars containing source files of the current target and all of its transitive dependencies. [intellij-aspect]",
         "annotation_processing": "Generated annotation processing jars. [intellij-aspect]",
     },

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -617,6 +617,7 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
                 )],
             ),
             transitive_compile_time_jars = java_info.transitive_compile_time_jars,
+            transitive_runtime_jars = java_info.transitive_runtime_jars,
             transitive_source_jars = java_info.transitive_source_jars,
             annotation_processing = annotation_processing,
         ),


### PR DESCRIPTION
Add transitive_runtime_jars to KtKvmInfo so we can store the java_info.transitive_runtime_jars for access in the IntelliJ Bazel Plugin's aspect