### PR TITLE
[bzlmod] Move providers to live in the kotlinc repo

### DIFF
--- a/kotlin/internal/defs.bzl
+++ b/kotlin/internal/defs.bzl
@@ -11,58 +11,33 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.#
+load(
+    "//src/main/starlark/core:providers.bzl",
+    _KspPluginInfo = "KspPluginInfo",
+    _KtCompilerPluginInfo = "KtCompilerPluginInfo",
+    _KtJsInfo = "KtJsInfo",
+    _KtJvmInfo = "KtJvmInfo",
+)
+load("//src/main/starlark/core/repositories:versions.bzl", "constants")
 
 # The Kotlin Toolchain type.
 TOOLCHAIN_TYPE = "%s" % Label("//kotlin/internal:kt_toolchain_type")
 
 # Java toolchains
-JAVA_TOOLCHAIN_TYPE = "@bazel_tools//tools/jdk:toolchain_type"
-JAVA_RUNTIME_TOOLCHAIN_TYPE = "@bazel_tools//tools/jdk:runtime_toolchain_type"
+JAVA_TOOLCHAIN_TYPE = constants.JAVA_TOOLCHAIN_TYPE
+JAVA_RUNTIME_TOOLCHAIN_TYPE = constants.JAVA_RUNTIME_TOOLCHAIN_TYPE
 
 # Upstream provider for Java plugins
 JavaPluginInfo = getattr(java_common, "JavaPluginInfo")
 
 # The name of the Kotlin compiler workspace.
-KT_COMPILER_REPO = "com_github_jetbrains_kotlin"
+KT_COMPILER_REPO = constants.KT_COMPILER_REPO
 
 # The name of the KSP compiler plugin workspace
-KSP_COMPILER_PLUGIN_REPO = "com_github_google_ksp"
+KSP_COMPILER_PLUGIN_REPO = constants.KSP_COMPILER_PLUGIN_REPO
 
-KtJvmInfo = provider(
-    fields = {
-        "module_name": "the module name",
-        "module_jars": "Jars comprising the module (logical compilation unit), a.k.a. associates",
-        "exported_compiler_plugins": "compiler plugins to be invoked by targets depending on this.",
-        "srcs": "the source files. [intelij-aspect]",
-        "outputs": "output jars produced by this rule. [intelij-aspect]",
-        "language_version": "version of kotlin used. [intellij-aspect]",
-        "transitive_compile_time_jars": "Returns the transitive set of Jars required to build the target. [intellij-aspect]",
-        "transitive_source_jars": "Returns the Jars containing source files of the current target and all of its transitive dependencies. [intellij-aspect]",
-        "annotation_processing": "Generated annotation processing jars. [intellij-aspect]",
-    },
-)
-
-KtJsInfo = provider(
-    fields = {
-        "js": "The primary output of the library",
-        "js_map": "The map file for the library",
-        "jar": "A jar of the library.",
-        "srcjar": "The jar containing the sources of the library",
-    },
-)
-
-KtCompilerPluginInfo = provider(
-    fields = {
-        "plugin_jars": "List of plugin jars.",
-        "classpath": "The kotlin compiler plugin classpath.",
-        "stubs": "Run this plugin during kapt stub generation.",
-        "compile": "Run this plugin during koltinc compilation.",
-        "options": "List of plugin options, represented as structs with an id and a value field, to be passed to the compiler",
-    },
-)
-
-KspPluginInfo = provider(
-    fields = {
-        "plugins": "List of JavaPLuginInfo providers for the plugins to run with KSP",
-    },
-)
+# Providers from the current kotlin repository.
+KtJvmInfo = _KtJvmInfo
+KtJsInfo = _KtJsInfo
+KtCompilerPluginInfo = _KtCompilerPluginInfo
+KspPluginInfo = _KspPluginInfo

--- a/src/main/starlark/core/options/BUILD.bazel
+++ b/src/main/starlark/core/options/BUILD.bazel
@@ -16,6 +16,6 @@ bzl_library(
     srcs = glob(["*.bzl"]),
     visibility = ["//:__subpackages__"],
     deps = [
-        "@com_github_jetbrains_kotlin//:capabilities",
+        "@com_github_jetbrains_kotlin//:bzl",
     ],
 )

--- a/src/main/starlark/core/providers.bzl
+++ b/src/main/starlark/core/providers.bzl
@@ -1,0 +1,12 @@
+load(
+    "@com_github_jetbrains_kotlin//:providers.bzl",
+    _KspPluginInfo = "KspPluginInfo",
+    _KtCompilerPluginInfo = "KtCompilerPluginInfo",
+    _KtJsInfo = "KtJsInfo",
+    _KtJvmInfo = "KtJvmInfo",
+)
+
+KtJvmInfo = _KtJvmInfo
+KtJsInfo = _KtJsInfo
+KtCompilerPluginInfo = _KtCompilerPluginInfo
+KspPluginInfo = _KspPluginInfo

--- a/src/main/starlark/core/repositories/initialize.release.bzl
+++ b/src/main/starlark/core/repositories/initialize.release.bzl
@@ -15,11 +15,6 @@
 """
 
 load(
-    "//kotlin/internal:defs.bzl",
-    _KSP_COMPILER_PLUGIN_REPO = "KSP_COMPILER_PLUGIN_REPO",
-    _KT_COMPILER_REPO = "KT_COMPILER_REPO",
-)
-load(
     "@bazel_tools//tools/build_defs/repo:http.bzl",
     "http_archive",
     "http_file",
@@ -27,15 +22,15 @@ load(
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("//src/main/starlark/core/repositories/kotlin:compiler.bzl", "kotlin_compiler_repository")
 load(":ksp.bzl", "ksp_compiler_plugin_repository")
-load(":versions.bzl", "version", _versions = "versions")
+load(":versions.bzl", "constants", "version", _versions = "versions")
 
 versions = _versions
 
 RULES_KOTLIN = Label("//:all")
 
 def kotlin_repositories(
-        compiler_repository_name = _KT_COMPILER_REPO,
-        ksp_repository_name = _KSP_COMPILER_PLUGIN_REPO,
+        compiler_repository_name = constants.KT_COMPILER_REPO,
+        ksp_repository_name = constants.KSP_COMPILER_PLUGIN_REPO,
         compiler_release = versions.KOTLIN_CURRENT_COMPILER_RELEASE,
         ksp_compiler_release = versions.KSP_CURRENT_COMPILER_PLUGIN_RELEASE):
     """Call this in the WORKSPACE file to setup the Kotlin rules.

--- a/src/main/starlark/core/repositories/kotlin/BUILD
+++ b/src/main/starlark/core/repositories/kotlin/BUILD
@@ -12,6 +12,6 @@ release_archive(
 
 bzl_library(
     name = "kotlin",
-    srcs = glob(["*.bzl"]),
+    srcs = ["compiler.bzl"],
     visibility = ["//:__subpackages__"],
 )

--- a/src/main/starlark/core/repositories/kotlin/BUILD.com_github_jetbrains_kotlin.bazel
+++ b/src/main/starlark/core/repositories/kotlin/BUILD.com_github_jetbrains_kotlin.bazel
@@ -12,15 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # io_bazel_rules_kotlin
-load("@{{.KotlinRulesRepository}}//kotlin:jvm.bzl", "kt_jvm_import")
-load("@{{.KotlinRulesRepository}}//kotlin:js.bzl", "kt_js_import")
-load("@rules_java//java:defs.bzl", "java_import")
+load(":kt_repo_import.bzl", "kt_repo_import")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
 package(default_visibility = ["//visibility:public"])
 
 exports_files(
-    ["capabilities.bzl"],
+    [
+        "capabilities.bzl",
+        "providers.bzl",
+    ],
 )
 
 # Kotlin home filegroup containing everything that is needed.
@@ -29,22 +30,22 @@ filegroup(
     srcs = glob(["**"]),
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "annotations",
     jar = "lib/annotations-13.0.jar",
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "trove4j",
     jar = "lib/trove4j.jar",
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "jvm-abi-gen",
     jar = "lib/jvm-abi-gen.jar",
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "kotlin-compiler",
     jar = "lib/kotlin-compiler.jar",
     neverlink = 1,
@@ -57,51 +58,51 @@ kt_jvm_import(
     ],
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "kotlin-annotation-processing-runtime",
     jar = "lib/kotlin-annotation-processing-runtime.jar",
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "kotlin-annotation-processing",
     jar = "lib/kotlin-annotation-processing.jar",
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "kotlinx-serialization-compiler-plugin",
     jar = "lib/kotlinx-serialization-compiler-plugin.jar",
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "allopen-compiler-plugin",
     jar = "lib/allopen-compiler-plugin.jar",
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "noarg-compiler-plugin",
     jar = "lib/noarg-compiler-plugin.jar",
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "sam-with-receiver-compiler-plugin",
     jar = "lib/sam-with-receiver-compiler-plugin.jar",
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "parcelize-compiler-plugin",
     jar = "lib/parcelize-compiler.jar",
 )
 
-kt_jvm_import(
+kt_repo_import(
     name = "parcelize-runtime",
     jar = "lib/parcelize-runtime.jar",
 )
 
 # Kotlin dependencies that are internal to this repo and may be linked.
 [
-    java_import(
+    kt_repo_import(
         name = "kotlin-%s" % art,
-        jars = ["lib/kotlin-%s.jar" % art],
+        jar = "lib/kotlin-%s.jar" % art,
     )
     for art in [
         "preloader",
@@ -110,7 +111,7 @@ kt_jvm_import(
 
 #  The Kotlin standard libraries. These should be setup in a Toolchain.
 [
-    kt_jvm_import(
+    kt_repo_import(
         name = "kotlin-%s" % art,
         jar = "lib/kotlin-%s.jar" % art,
         srcjar = "lib/kotlin-%s-sources.jar" % art,
@@ -128,19 +129,22 @@ kt_jvm_import(
 
 #  The Kotlin JS standard libraries. These should be setup in a Toolchain.
 [
-    kt_js_import(
-        name = "kotlin-%s" % art,
-        jars = ["lib/kotlin-%s.jar" % art],
-        srcjar = "lib/kotlin-%s-sources.jar" % art,
+    kt_repo_import(
+        name = name,
+        jar = "lib/%s.jar" % name,
+        # symlinked by the kotlin_compiler_repository rule.
+        js = "js/%s.js" % name,
+        js_map = "js/%s.js.map" % name,
+        srcjar = "lib/%s.srcjar" % name,
         visibility = ["//visibility:public"],
     )
-    for art in [
-        "test-js",
-        "stdlib-js",
+    for name in [
+        "kotlin-test-js",
+        "kotlin-stdlib-js",
     ]
 ]
 
 bzl_library(
-    name = "capabilities",
-    srcs = ["capabilities.bzl"],
+    name = "bzl",
+    srcs = glob(["*.bzl"]),
 )

--- a/src/main/starlark/core/repositories/kotlin/kt_repo_import.com_github_jetbrains_kotlin.bzl
+++ b/src/main/starlark/core/repositories/kotlin/kt_repo_import.com_github_jetbrains_kotlin.bzl
@@ -1,0 +1,82 @@
+load("//:providers.bzl", "KtJsInfo", "KtJvmInfo")
+
+def _kt_repo_import_impl(ctx):
+    artifact = struct(
+        class_jar = ctx.file.jar,
+        ijar = None,
+        source_jars = [ctx.file.srcjar] if ctx.file.srcjar else [],
+    )
+    label = ctx.label
+    module_name = label.package.lstrip("/").replace("/", "_") + "-" + label.name.replace("/", "_")
+    kt_jvm_info = KtJvmInfo(
+        module_name = module_name,
+        module_jars = [
+            artifact.class_jar,
+        ],
+        srcs = artifact.source_jars,
+        exported_compiler_plugins = depset(),
+        outputs = struct(jars = [artifact]),
+    )
+    kt_providers = [kt_jvm_info]
+    if ctx.files.js:
+        kt_providers.append(
+            KtJsInfo(
+                js = ctx.file.js,
+                js_map = ctx.file.js_map,
+                jar = artifact.class_jar,
+                srcjar = ctx.file.srcjar if ctx.file.srcjar else None,
+            ),
+        )
+
+    return struct(
+        kt = kt_jvm_info,  # needed for ijwb
+        providers = [
+            DefaultInfo(
+                files = depset(direct = [artifact.class_jar]),
+                runfiles = ctx.runfiles(
+                    files = [artifact.class_jar] + artifact.source_jars,
+                ).merge_all([d[DefaultInfo].default_runfiles for d in ctx.attr.deps]),
+            ),
+            JavaInfo(
+                output_jar = artifact.class_jar,
+                compile_jar = artifact.class_jar,
+                source_jar = ctx.file.srcjar if ctx.file.srcjar else None,
+                runtime_deps = [],
+                deps = [dep[JavaInfo] for dep in ctx.attr.deps if JavaInfo in dep],
+                exports = [],
+                neverlink = ctx.attr.neverlink,
+            ),
+        ] + kt_providers,
+    )
+
+kt_repo_import = rule(
+    implementation = _kt_repo_import_impl,
+    attrs = {
+        "jar": attr.label(
+            doc = """The jar listed here is equivalent to an export attribute.""",
+            allow_single_file = True,
+            cfg = "target",
+            mandatory = True,
+        ),
+        "srcjar": attr.label(
+            doc = """The sources for the class jar.""",
+            allow_single_file = True,
+            cfg = "target",
+        ),
+        "neverlink": attr.bool(
+            default = False,
+        ),
+        "js": attr.label(
+            allow_single_file = [".js"],
+        ),
+        "js_map": attr.label(
+            allow_single_file = [".js.map"],
+        ),
+        "deps": attr.label_list(
+            doc = """Compile and runtime dependencies""",
+            default = [],
+            providers = [JavaInfo],
+        ),
+    },
+    provides = [JavaInfo, KtJvmInfo],
+)

--- a/src/main/starlark/core/repositories/kotlin/providers.com_github_jetbrains_kotlin.bzl
+++ b/src/main/starlark/core/repositories/kotlin/providers.com_github_jetbrains_kotlin.bzl
@@ -1,0 +1,40 @@
+# The core kotlin providers are returned from the kotlinc repository in use.
+# DO NOT IMPORT on this file.
+KtJvmInfo = provider(
+    fields = {
+        "module_name": "the module name",
+        "module_jars": "Jars comprising the module (logical compilation unit), a.k.a. associates",
+        "exported_compiler_plugins": "compiler plugins to be invoked by targets depending on this.",
+        "srcs": "the source files. [intelij-aspect]",
+        "outputs": "output jars produced by this rule. [intelij-aspect]",
+        "language_version": "version of kotlin used. [intellij-aspect]",
+        "transitive_compile_time_jars": "Returns the transitive set of Jars required to build the target. [intellij-aspect]",
+        "transitive_source_jars": "Returns the Jars containing source files of the current target and all of its transitive dependencies. [intellij-aspect]",
+        "annotation_processing": "Generated annotation processing jars. [intellij-aspect]",
+    },
+)
+
+KtJsInfo = provider(
+    fields = {
+        "js": "The primary output of the library",
+        "js_map": "The map file for the library",
+        "jar": "A jar of the library.",
+        "srcjar": "The jar containing the sources of the library",
+    },
+)
+
+KtCompilerPluginInfo = provider(
+    fields = {
+        "plugin_jars": "List of plugin jars.",
+        "classpath": "The kotlin compiler plugin classpath.",
+        "stubs": "Run this plugin during kapt stub generation.",
+        "compile": "Run this plugin during koltinc compilation.",
+        "options": "List of plugin options, represented as structs with an id and a value field, to be passed to the compiler",
+    },
+)
+
+KspPluginInfo = provider(
+    fields = {
+        "plugins": "List of JavaPLuginInfo providers for the plugins to run with KSP",
+    },
+)

--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -120,3 +120,13 @@ versions = struct(
     ),
     use_repository = _use_repository,
 )
+
+constants = struct(
+    # Java constants. Not expecitn them to change...
+    JAVA_TOOLCHAIN_TYPE = "@bazel_tools//tools/jdk:toolchain_type",
+    JAVA_RUNTIME_TOOLCHAIN_TYPE = "@bazel_tools//tools/jdk:runtime_toolchain_type",
+    # The name of the Kotlin compiler workspace.
+    KT_COMPILER_REPO = "com_github_jetbrains_kotlin",
+    # The name of the KSP compiler plugin workspace
+    KSP_COMPILER_PLUGIN_REPO = "com_github_google_ksp",
+)


### PR DESCRIPTION
* Introduce kt_repo_import, a specialized internal rule to import kotlinc binaries and source
* Reading the providers from the kotlinc repo ensures that the provider is pinned to a kotlin version. 

Notes:
* This doesn't replace the kt_jvm_import which does more and interesting things.
* It does expand the js from the jar, which turned out to be the hardest part.
