### PR TITLE
Include Bzlmod files into release binary

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -54,6 +54,10 @@ test_suite(
 # Release target.
 release_archive(
     name = "rules_kotlin_release",
+    srcs = [
+        "MODULE.bazel",
+        "WORKSPACE.bzlmod",
+    ],
     src_map = {
         "BUILD.release.bazel": "BUILD.bazel",
         "WORKSPACE.release.bazel": "WORKSPACE",

--- a/src/main/starlark/core/repositories/BUILD
+++ b/src/main/starlark/core/repositories/BUILD
@@ -19,6 +19,7 @@ release_archive(
     srcs = [
         "BUILD.com_github_google_ksp.bazel",
         "BUILD.com_github_jetbrains_kotlin.bazel",
+        "bzlmod_setup.bzl",
         "compiler.bzl",
         "ksp.bzl",
         "versions.bzl",


### PR DESCRIPTION
Including the Bzlmod files into the distributed release binary.