### PR TITLE
Update MODULE.bazel rules_jvm_external to 5.3

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -27,6 +27,7 @@ register_toolchains("//kotlin/internal:default_toolchain")
 # Development dependencies
 
 bazel_dep(name = "rules_jvm_external", version = "5.3")
+
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     name = "kotlin_rules_maven",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -26,8 +26,7 @@ register_toolchains("//kotlin/internal:default_toolchain")
 
 # Development dependencies
 
-bazel_dep(name = "rules_jvm_external", version = "4.4.2")
-
+bazel_dep(name = "rules_jvm_external", version = "5.3")
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     name = "kotlin_rules_maven",

--- a/examples/trivial/MODULE.bazel
+++ b/examples/trivial/MODULE.bazel
@@ -7,8 +7,7 @@ local_path_override(
     path = "../..",
 )
 
-bazel_dep(name = "rules_jvm_external", version = "4.4.2")
-
+bazel_dep(name = "rules_jvm_external", version = "5.3")
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [

--- a/examples/trivial/MODULE.bazel
+++ b/examples/trivial/MODULE.bazel
@@ -8,6 +8,7 @@ local_path_override(
 )
 
 bazel_dep(name = "rules_jvm_external", version = "5.3")
+
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")
 maven.install(
     artifacts = [


### PR DESCRIPTION
The WORKSPACE version is already using 5.3. This just aligns the Bzlmod path with what's already being used for the WORKSPACE path.