### PR TITLE
Update and align rules_python versions on 0.23.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -8,7 +8,7 @@ module(
 bazel_dep(name = "platforms", version = "0.0.6")
 bazel_dep(name = "bazel_skylib", version = "1.3.0")
 bazel_dep(name = "rules_java", version = "6.4.0")
-bazel_dep(name = "rules_python", version = "0.24.0")
+bazel_dep(name = "rules_python", version = "0.23.1")
 bazel_dep(name = "rules_cc", version = "0.0.8")
 
 rules_kotlin_extensions = use_extension("//src/main/starlark/core/repositories:bzlmod_setup.bzl", "rules_kotlin_extensions")

--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -96,12 +96,12 @@ versions = struct(
     ),
     # needed for rules_pkg and java
     RULES_PYTHON = version(
-        version = "0.20.0",
+        version = "0.23.1",
         strip_prefix_template = "rules_python-{version}",
         url_templates = [
             "https://github.com/bazelbuild/rules_python/archive/refs/tags/{version}.tar.gz",
         ],
-        sha256 = "a644da969b6824cc87f8fe7b18101a8a6c57da5db39caa6566ec6109f37d2141",
+        sha256 = "84aec9e21cc56fbc7f1335035a71c850d1b9b5cc6ff497306f84cced9a769841",
     ),
     # needed for rules_pkg and java
     RULES_JAVA = version(


### PR DESCRIPTION
Upgrades and aligns the WORKSPACE and Bzlmod versions on version 0.23.1. I tried downgrading Bzlmod to 0.20.0 but ran into issues with some internal Bazel tools no longer being compatible with older versions. 0.23.x is the first release of rules_python that starts working again with Bazel tools.