### PR TITLE
fix(jvm): explicitly merge runfiles

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -50,10 +50,10 @@ def _make_providers(ctx, providers, transitive_files = depset(order = "default")
                     # explicitly include data files, otherwise they appear to be missing
                     files = ctx.files.data,
                     transitive_files = transitive_files,
-                    # continue to use collect_default until proper transitive data collecting is
-                    # implmented.
-                    collect_default = True,
-                ),
+                ).merge_all([
+                    target[DefaultInfo].default_runfiles
+                    for target in ctx.attr.runtime_deps
+                ]),
             ),
         ] + list(additional_providers),
     )


### PR DESCRIPTION
Fixes a TODO about collecting proper transitive data. Note: I don't know where a test for this belongs, nor whether there are other providers which should be scanned for data originating from srcs/deps

Fixes #1033