### PR TITLE
Fix the nouse_workers_with_dexbuilder error

### DIFF
--- a/examples/jetpack_compose/.bazelrc
+++ b/examples/jetpack_compose/.bazelrc
@@ -4,4 +4,3 @@ build --define=android_dexmerger_tool=d8_dexmerger
 # Flags for the D8 dexer
 build --define=android_incremental_dexing_tool=d8_dexbuilder
 build --define=android_standalone_dexing_tool=d8_compat_dx
-build --nouse_workers_with_dexbuilder


### PR DESCRIPTION
With the recent changes of a flag, which was removed in this commit in Bazel bazelbuild/bazel@f2c11f7.

This fixes the #1039

CC Greenteam @salmasamy

