### PR TITLE
WIP: Fix missing jdeps by consistently using `collectTypeReferences`

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -145,7 +145,7 @@ class JdepsGenExtension(
           )?.let { explicitClassesCanonicalPaths.add(it) }
         }
         is FunctionDescriptor -> {
-          resultingDescriptor.returnType?.let { collectTypeReferences(it, isExplicit = false) }
+          resultingDescriptor.returnType?.let { collectTypeReferences(it, isExplicit = false, collectTypeArguments = false) }
           resultingDescriptor.valueParameters.forEach { valueParameter ->
             collectTypeReferences(valueParameter.type, isExplicit = false)
           }
@@ -236,6 +236,7 @@ class JdepsGenExtension(
     private fun collectTypeReferences(
       kotlinType: KotlinType,
       isExplicit: Boolean = true,
+      collectTypeArguments: Boolean = true
     ) {
       if (isExplicit) {
         addExplicitDep(kotlinType)
@@ -247,7 +248,9 @@ class JdepsGenExtension(
         addImplicitDep(it)
       }
 
-      collectTypeArguments(kotlinType, isExplicit)
+      if (collectTypeArguments) {
+        collectTypeArguments(kotlinType, isExplicit)
+      }
     }
 
     private fun collectTypeArguments(

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -175,7 +175,7 @@ class JdepsGenExtension(
               explicitClassesCanonicalPaths.add(virtualFileClass.file.path)
             }
           }
-          addImplicitDep(resultingDescriptor.type)
+          collectTypeReferences(resultingDescriptor.type, isExplicit = false)
         }
         else -> return
       }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -40,6 +40,7 @@ import org.jetbrains.kotlin.resolve.calls.util.FakeCallableDescriptorForObject
 import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
 import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
+import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedClassConstructorDescriptor
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeConstructor
 import org.jetbrains.kotlin.types.typeUtil.supertypes
@@ -145,7 +146,7 @@ class JdepsGenExtension(
           )?.let { explicitClassesCanonicalPaths.add(it) }
         }
         is FunctionDescriptor -> {
-          resultingDescriptor.returnType?.let { addImplicitDep(it) }
+          resultingDescriptor.returnType?.let { collectTypeReferences(it, isExplicit = false) }
           resultingDescriptor.valueParameters.forEach { valueParameter ->
             collectTypeReferences(valueParameter.type, isExplicit = false)
           }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -40,7 +40,6 @@ import org.jetbrains.kotlin.resolve.calls.util.FakeCallableDescriptorForObject
 import org.jetbrains.kotlin.resolve.checkers.DeclarationChecker
 import org.jetbrains.kotlin.resolve.checkers.DeclarationCheckerContext
 import org.jetbrains.kotlin.resolve.jvm.extensions.AnalysisHandlerExtension
-import org.jetbrains.kotlin.serialization.deserialization.descriptors.DeserializedClassConstructorDescriptor
 import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeConstructor
 import org.jetbrains.kotlin.types.typeUtil.supertypes

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -1262,10 +1262,6 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       )
       c.addDirectDependencies(depWithFunction)
       c.addTransitiveDependencies(depWithReturnType)
-      //TODO: Adding a dep on depWithReturnTypesSuperType "fixes" this test which started failing after this jdeps bugfix
-      //      Instead, should our jdeps bug fix only be enabled when "-Xextended-compiler-checks" is set, such that this test would continue passing
-      //      And then we'd add another test which sets "-Xextended-compiler-checks" and has the proper transitive dependency on "depWithReturnTypesSuperType"?
-      //      For more info on "-Xextended-compiler-checks" see: https://youtrack.jetbrains.com/issue/KT-44583
       c.addTransitiveDependencies(depWithReturnTypesSuperType)
       c.setLabel("dependingTarget")
     }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -988,7 +988,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
   }
 
   @Test
-  fun `function call on a 'LazyClassDescriptor' class should collect indirect super class of that class as an implicit dependency`() {
+  fun `function call on a class should collect indirect super class of that class as an implicit dependency`() {
     val implicitSuperClassDep = runCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
       c.addSource(
         "Base.kt",

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -1262,6 +1262,11 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       )
       c.addDirectDependencies(depWithFunction)
       c.addTransitiveDependencies(depWithReturnType)
+      //TODO: Adding a dep on depWithReturnTypesSuperType "fixes" this test which started failing after this jdeps bugfix
+      //      Instead, should our jdeps bug fix only be enabled when "-Xextended-compiler-checks" is set, such that this test would continue passing
+      //      And then we'd add another test which sets "-Xextended-compiler-checks" and has the proper transitive dependency on "depWithReturnTypesSuperType"?
+      //      For more info on "-Xextended-compiler-checks" see: https://youtrack.jetbrains.com/issue/KT-44583
+      c.addTransitiveDependencies(depWithReturnTypesSuperType)
       c.setLabel("dependingTarget")
     }
     val jdeps = depsProto(dependingTarget)


### PR DESCRIPTION
# Problem
Kotlin jdeps are missing in some cases which is preventing Airbnb from enabling certain compile-time pruning optimizations in our fork of the IntelliJ Bazel Plugin. For example, in the below repro case, Airbnb's IntelliJ Bazel Plugin compile time pruning drops the jar containing `Base` which results in the following compilation error:
```
 Kotlin: Supertypes of the following classes cannot be resolved. Please make sure you have the required dependencies in the classpath:
        class something.ReferencesClassWithSuperClass, unresolved supertypes: something.Base
```

Without the change in this PR, `ReferencesClassWithSuperClass` has a missing jdep on superclass `Base`:
```kotlin
open class Base

class Derived : Base() {
  fun hi(): String {
    return "Hello"
  }
}

class ReferencesClassWithSuperClass {
    fun stuff(): String {
        return Derived().hi()
    }
}
```

# Solution
Use `collectTypeReferences` instead of directly calling `addImplicitDep` or `addExplicitDep` as `collectTypeReferences` additionally always adds superclasses as implicit deps.

Note that the initial fix originally caused two existing test cases to fail:
```
1) function call return type[enableK2Compiler=false](io.bazel.kotlin.builder.tasks.jvm.KotlinBuilderJvmJdepsTest)
io.bazel.kotlin.builder.toolchain.CompilationStatusException: compile phase failed:
error: supertypes of the following classes cannot be resolved. Please make sure you have the required dependencies in the classpath:
    class something.SomeType, unresolved supertypes: something.SomeSuperType
Adding -Xextended-compiler-checks argument might provide additional information.

        at io.bazel.kotlin.builder.toolchain.CompilationTaskContext.executeCompilerTask(CompilationTaskContext.kt:135)
```
This existing test failure seems related to both:
- #855
- https://youtrack.jetbrains.com/issue/KT-44583

To fix this test, I added `c.addTransitiveDependencies(depWithReturnTypesSuperType)` as `SomeSuperType` is required to compile `ReferencesClassWithSuperClass`.
