### PR TITLE
[bazel-bsp-aspect] extract more generated jars

### DIFF
--- a/kotlin/internal/defs.bzl
+++ b/kotlin/internal/defs.bzl
@@ -36,6 +36,8 @@ KtJvmInfo = provider(
         "transitive_compile_time_jars": "Returns the transitive set of Jars required to build the target. [intellij-aspect]",
         "transitive_source_jars": "Returns the Jars containing source files of the current target and all of its transitive dependencies. [intellij-aspect]",
         "annotation_processing": "Generated annotation processing jars. [intellij-aspect]",
+        "additional_generated_source_jars": "Returns additional Jars containing generated source files from kapt, ksp, etc. [bazel-bsp-aspect]",
+        "all_output_jars": "Returns all the output Jars produced by this rule. [bazel-bsp-aspect]",
     },
 )
 

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -633,6 +633,8 @@ def kt_jvm_produce_jar_actions(ctx, rule_kind):
             transitive_compile_time_jars = java_info.transitive_compile_time_jars,
             transitive_source_jars = java_info.transitive_source_jars,
             annotation_processing = annotation_processing,
+            additional_generated_source_jars = generated_src_jars,
+            all_output_jars = output_jars,
         ),
     )
 


### PR DESCRIPTION
This is a proposal to fix [this issue](https://github.com/bazelbuild/rules_kotlin/issues/1032).