### PR TITLE
Rename build_bazel_rules_android to rules_android

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,7 +14,7 @@ bazel_dep(name = "rules_cc", version = "0.0.8")
 rules_kotlin_extensions = use_extension("//src/main/starlark/core/repositories:bzlmod_setup.bzl", "rules_kotlin_extensions")
 use_repo(
     rules_kotlin_extensions,
-    "build_bazel_rules_android",
+    "rules_android",
     "buildkite_config",
     "com_github_google_ksp",
     "com_github_jetbrains_kotlin",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -14,12 +14,12 @@ bazel_dep(name = "rules_cc", version = "0.0.8")
 rules_kotlin_extensions = use_extension("//src/main/starlark/core/repositories:bzlmod_setup.bzl", "rules_kotlin_extensions")
 use_repo(
     rules_kotlin_extensions,
-    "rules_android",
     "buildkite_config",
     "com_github_google_ksp",
     "com_github_jetbrains_kotlin",
     "com_github_pinterest_ktlint",
     "kt_java_stub_template",
+    "rules_android",
 )
 
 register_toolchains("//kotlin/internal:default_toolchain")

--- a/examples/android/MODULE.bazel
+++ b/examples/android/MODULE.bazel
@@ -3,7 +3,7 @@ module(name = "android-example")
 remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
 use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
 
-bazel_dep(name = "rules_android", version = "0.1.1", repo_name = "rules_android")
+bazel_dep(name = "rules_android", version = "0.1.1")
 bazel_dep(name = "bazel_skylib", version = "1.2.1")
 bazel_dep(name = "rules_robolectric", version = "4.10.3", repo_name = "robolectric")
 bazel_dep(name = "rules_java", version = "6.4.0")

--- a/examples/android/MODULE.bazel
+++ b/examples/android/MODULE.bazel
@@ -3,7 +3,7 @@ module(name = "android-example")
 remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
 use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
 
-bazel_dep(name = "rules_android", version = "0.1.1", repo_name = "build_bazel_rules_android")
+bazel_dep(name = "rules_android", version = "0.1.1", repo_name = "rules_android")
 bazel_dep(name = "bazel_skylib", version = "1.2.1")
 bazel_dep(name = "rules_robolectric", version = "4.10.3", repo_name = "robolectric")
 bazel_dep(name = "rules_java", version = "6.4.0")

--- a/examples/android/WORKSPACE
+++ b/examples/android/WORKSPACE
@@ -65,14 +65,14 @@ maven_install(
 )
 
 http_archive(
-    name = "build_bazel_rules_android",
+    name = "rules_android",
     sha256 = versions.ANDROID.SHA,
     strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
     urls = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % versions.ANDROID.VERSION],
 )
 
 load(
-    "@build_bazel_rules_android//android:rules.bzl",
+    "@rules_android//android:rules.bzl",
     "android_sdk_repository",
 )
 

--- a/examples/android/app/BUILD.bazel
+++ b/examples/android/app/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@rules_android//android:rules.bzl", "android_binary")
 
 # An app that consumes android-kt deps
 android_binary(

--- a/examples/android/libAndroid/BUILD.bazel
+++ b/examples/android/libAndroid/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_android//android:rules.bzl", "android_library")
+load("@rules_android//android:rules.bzl", "android_library")
 load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_library")
 
 android_library(

--- a/examples/anvil/WORKSPACE
+++ b/examples/anvil/WORKSPACE
@@ -18,13 +18,13 @@ register_toolchains("//:kotlin_toolchain")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "build_bazel_rules_android",
+    name = "rules_android",
     sha256 = versions.ANDROID.SHA,
     strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
     urls = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % versions.ANDROID.VERSION],
 )
 
-load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
+load("@rules_android//android:rules.bzl", "android_sdk_repository")
 
 android_sdk_repository(name = "androidsdk")
 

--- a/examples/anvil/app/BUILD.bazel
+++ b/examples/anvil/app/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@rules_android//android:rules.bzl", "android_binary")
 
 android_binary(
     name = "app",

--- a/examples/associates/WORKSPACE
+++ b/examples/associates/WORKSPACE
@@ -20,7 +20,7 @@ kt_register_toolchains()
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
-    name = "build_bazel_rules_android",
+    name = "rules_android",
     sha256 = "cd06d15dd8bb59926e4d65f9003bfc20f9da4b2519985c27e190cddc8b7a7806",
     strip_prefix = "rules_android-0.1.1",
     urls = ["https://github.com/bazelbuild/rules_android/archive/v0.1.1.zip"],

--- a/examples/deps/WORKSPACE
+++ b/examples/deps/WORKSPACE
@@ -60,14 +60,14 @@ maven_install(
 )
 
 http_archive(
-    name = "build_bazel_rules_android",
+    name = "rules_android",
     sha256 = versions.ANDROID.SHA,
     strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
     urls = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % versions.ANDROID.VERSION],
 )
 
 load(
-    "@build_bazel_rules_android//android:rules.bzl",
+    "@rules_android//android:rules.bzl",
     "android_sdk_repository",
 )
 

--- a/examples/jetpack_compose/WORKSPACE
+++ b/examples/jetpack_compose/WORKSPACE
@@ -76,12 +76,12 @@ http_archive(
 ## Android
 
 http_archive(
-    name = "build_bazel_rules_android",
+    name = "rules_android",
     sha256 = versions.ANDROID.SHA,
     strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
     urls = ["https://github.com/bazelbuild/rules_android/archive/v%s.zip" % versions.ANDROID.VERSION],
 )
 
-load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
+load("@rules_android//android:rules.bzl", "android_sdk_repository")
 
 android_sdk_repository(name = "androidsdk")

--- a/examples/jetpack_compose/app/BUILD
+++ b/examples/jetpack_compose/app/BUILD
@@ -1,5 +1,5 @@
 load("@bazel_skylib//rules:build_test.bzl", "build_test")
-load("@build_bazel_rules_android//android:rules.bzl", "android_binary")
+load("@rules_android//android:rules.bzl", "android_binary")
 
 # An app that consumes android-kt deps
 android_binary(

--- a/examples/plugin/WORKSPACE
+++ b/examples/plugin/WORKSPACE
@@ -41,6 +41,6 @@ maven_install(
     ],
 )
 
-load("@build_bazel_rules_android//android:rules.bzl", "android_sdk_repository")
+load("@rules_android//android:rules.bzl", "android_sdk_repository")
 
 android_sdk_repository(name = "androidsdk")

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -1,5 +1,5 @@
 load(
-    "@build_bazel_rules_android//android:rules.bzl",
+    "@rules_android//android:rules.bzl",
     _android_library = "android_library",
     _android_local_test = "android_local_test",
 )

--- a/src/main/starlark/core/repositories/download.bzl
+++ b/src/main/starlark/core/repositories/download.bzl
@@ -85,7 +85,7 @@ def kt_download_local_dev_dependencies():
     )
 
     rules_stardoc_repository(
-        name = "build_bazel_rules_android",
+        name = "rules_android",
         sha256 = versions.ANDROID.SHA,
         strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
         urls = versions.ANDROID.URLS,

--- a/src/main/starlark/core/repositories/initialize.release.bzl
+++ b/src/main/starlark/core/repositories/initialize.release.bzl
@@ -82,7 +82,7 @@ def kotlin_repositories(
 
     maybe(
         http_archive,
-        name = "build_bazel_rules_android",
+        name = "rules_android",
         sha256 = versions.ANDROID.SHA,
         strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
         urls = versions.ANDROID.URLS,


### PR DESCRIPTION
[rules_android](https://github.com/bazelbuild/rules_android) has aligned it's rule set name on `rules_android`. Going to rename all of the rules_kotlin references so that we are aligned.

If you are importing this Android rules in your `WORKSPACE` file using `name = "build_bazel_rules_android"` you will need to rename it to `name = "rules_android"` otherwise you may be downloading the rules multiple times under different namespaces.