### PR TITLE
Update bazel_skylib 1.3.0 -> 1.4.1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.6")
-bazel_dep(name = "bazel_skylib", version = "1.3.0")
+bazel_dep(name = "bazel_skylib", version = "1.4.2")
 bazel_dep(name = "rules_java", version = "6.4.0")
 bazel_dep(name = "rules_python", version = "0.23.1")
 bazel_dep(name = "rules_cc", version = "0.0.8")

--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -31,8 +31,8 @@ versions = struct(
     # 1. Download archive
     # 2. Download dependencies and Configure rules
     # --> 3. Configure dependencies <--
-    SKYLIB_VERSION = "1.2.1",
-    SKYLIB_SHA = "f7be3474d42aae265405a592bb7da8e171919d74c16f082a5457840f06054728",
+    SKYLIB_VERSION = "1.4.2",
+    SKYLIB_SHA = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
     PROTOBUF_VERSION = "3.11.3",
     PROTOBUF_SHA = "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
     RULES_JVM_EXTERNAL_TAG = "5.3",


### PR DESCRIPTION
Seeing warnings when building this repo with Bzlmod about version mismatches.

```
WARNING: For repository 'bazel_skylib', the root module requires module version bazel_skylib@1.3.0, but got bazel_skylib@1.4.1 in the resolved dependency graph.
```