### PR TITLE
Add BUILD.release.bazel file for src/main/starlark/core/repositories/kotlin/

### DIFF
--- a/src/main/starlark/core/repositories/kotlin/BUILD
+++ b/src/main/starlark/core/repositories/kotlin/BUILD
@@ -2,7 +2,8 @@ load("//src/main/starlark/release:packager.bzl", "release_archive")
 
 release_archive(
     name = "pkg",
-    srcs = [
-        "BUILD",
-    ] + glob(["capabilities_*.bazel"]),
+    srcs = glob(["capabilities_*.bazel"]),
+    src_map = {
+        "BUILD.release.bazel": "BUILD",
+    },
 )


### PR DESCRIPTION
We don't include `packager.bzl` into the release package. Adding a release `BUILD` file for `src/main/starlark/core/repositories/kotlin/` to make sure that we aren't packaging of build files that references bzl files that don't exist.