### PR TITLE
Fix release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         env:
           # Bazelisk will download bazel to here.
           XDG_CACHE_HOME: ~/.cache/bazel-repo
-        run: .github/workflows/release_prep.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
+        run: .github/workflows/release_prep.sh ${{ env.GITHUB_REF_NAME }}
       - name: Release
         uses: softprops/action-gh-release@v1
         with:

--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -12,7 +12,9 @@ bazel --bazelrc=.github/workflows/ci.bazelrc --bazelrc=.bazelrc build //:rules_k
 cp bazel-bin/rules_kotlin_release.tgz $ARCHIVE
 SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
-cat << EOF
+# Write the release notes to release_notes.txt
+cat > release_notes.txt << EOF
+# Release notes for $TAG
 ## Using Bzlmod with Bazel 6
 
 1. Enable with \`common --enable_bzlmod\` in \`.bazelrc\`.
@@ -24,7 +26,7 @@ bazel_dep(name = "rules_kotlin", version = "${TAG:1}")
 
 ## Using WORKSPACE
 
-Paste this snippet into your `WORKSPACE.bazel` file:
+Paste this snippet into your \`WORKSPACE.bazel\` file:
 
 \`\`\`starlark
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
@@ -35,5 +37,3 @@ http_archive(
     url = "https://github.com/buildfoundation/rules_kotlin/releases/download/${TAG}/${ARCHIVE}",
 )
 EOF
-
-echo "\`\`\`"


### PR DESCRIPTION
Some build warnings are ending up in the release notes as a result of the entire `prep_release.sh` out being written to the release notes file.

This moves the release notes generation into `prep_release.sh` where we can write just what needs to be in that file.