### PR TITLE
Add javac_option to pass release flag to javac

### DIFF
--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -48,7 +48,7 @@ kt_js_library(<a href="#kt_js_library-name">name</a>, <a href="#kt_js_library-kw
 
 ## kt_javac_options
 
-kt_javac_options(<a href="#kt_javac_options-name">name</a>, <a href="#kt_javac_options-warn">warn</a>, <a href="#kt_javac_options-x_ep_disable_all_checks">x_ep_disable_all_checks</a>, <a href="#kt_javac_options-x_explicit_api_mode">x_explicit_api_mode</a>, <a href="#kt_javac_options-x_lint">x_lint</a>,
+kt_javac_options(<a href="#kt_javac_options-name">name</a>, <a href="#kt_javac_options-release">release</a>, <a href="#kt_javac_options-warn">warn</a>, <a href="#kt_javac_options-x_ep_disable_all_checks">x_ep_disable_all_checks</a>, <a href="#kt_javac_options-x_explicit_api_mode">x_explicit_api_mode</a>, <a href="#kt_javac_options-x_lint">x_lint</a>,
                  <a href="#kt_javac_options-xd_suppress_notes">xd_suppress_notes</a>)
 
                                                                                                 
@@ -61,6 +61,7 @@ kt_javac_options(<a href="#kt_javac_options-name">name</a>, <a href="#kt_javac_o
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 |<a id="kt_javac_options-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+|<a id="kt_javac_options-release"></a>release |  Compile for the specified Java SE release   | String | optional | "default" |
 |<a id="kt_javac_options-warn"></a>warn |  Control warning behaviour.   | String | optional | "report" |
 |<a id="kt_javac_options-x_ep_disable_all_checks"></a>x_ep_disable_all_checks |  See javac -XepDisableAllChecks documentation   | Boolean | optional | False |
 |<a id="kt_javac_options-x_explicit_api_mode"></a>x_explicit_api_mode |  Enable explicit API mode for Kotlin libraries.   | String | optional | "off" |
@@ -368,7 +369,7 @@ kt_compiler_plugin(<a href="#kt_compiler_plugin-name">name</a>, <a href="#kt_com
 
 ## kt_javac_options
 
-kt_javac_options(<a href="#kt_javac_options-name">name</a>, <a href="#kt_javac_options-warn">warn</a>, <a href="#kt_javac_options-x_ep_disable_all_checks">x_ep_disable_all_checks</a>, <a href="#kt_javac_options-x_explicit_api_mode">x_explicit_api_mode</a>, <a href="#kt_javac_options-x_lint">x_lint</a>,
+kt_javac_options(<a href="#kt_javac_options-name">name</a>, <a href="#kt_javac_options-release">release</a>, <a href="#kt_javac_options-warn">warn</a>, <a href="#kt_javac_options-x_ep_disable_all_checks">x_ep_disable_all_checks</a>, <a href="#kt_javac_options-x_explicit_api_mode">x_explicit_api_mode</a>, <a href="#kt_javac_options-x_lint">x_lint</a>,
                  <a href="#kt_javac_options-xd_suppress_notes">xd_suppress_notes</a>)
 
                                                                                                 
@@ -381,6 +382,7 @@ kt_javac_options(<a href="#kt_javac_options-name">name</a>, <a href="#kt_javac_o
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 |<a id="kt_javac_options-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+|<a id="kt_javac_options-release"></a>release |  Compile for the specified Java SE release   | String | optional | "default" |
 |<a id="kt_javac_options-warn"></a>warn |  Control warning behaviour.   | String | optional | "report" |
 |<a id="kt_javac_options-x_ep_disable_all_checks"></a>x_ep_disable_all_checks |  See javac -XepDisableAllChecks documentation   | Boolean | optional | False |
 |<a id="kt_javac_options-x_explicit_api_mode"></a>x_explicit_api_mode |  Enable explicit API mode for Kotlin libraries.   | String | optional | "off" |

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -763,7 +763,7 @@ def _run_kt_java_builder_actions(
     # If there is Java source or KAPT generated Java source compile that Java and fold it into
     # the final ABI jar. Otherwise just use the KT ABI jar as final ABI jar.
     if srcs.java or generated_kapt_src_jars or srcs.src_jars:
-        javac_opts = javac_options_to_flags(toolchains.kt.javac_options)
+        javac_opts = javac_options_to_flags(ctx.attr.javac_opts[JavacOptions] if ctx.attr.javac_opts else toolchains.kt.javac_options)
 
         # Kotlin takes care of annotation processing. Note that JavaBuilder "discovers"
         # annotation processors in `deps` also.

--- a/src/main/starlark/core/options/opts.javac.bzl
+++ b/src/main/starlark/core/options/opts.javac.bzl
@@ -29,6 +29,21 @@ _JOPTS = {
             "report": None,
         },
     ),
+    "release": struct(
+        args = dict(
+            default = "default",
+            doc = "Compile for the specified Java SE release",
+            values = ["default", "8", "11", "17", "21"],
+        ),
+        type = attr.string,
+        value_to_flag = {
+            "8": ["--release 8"],
+            "11": ["--release 11"],
+            "17": ["--release 17"],
+            "21": ["--release 21"],
+            "default": None,
+        },
+    ),
     "x_ep_disable_all_checks": struct(
         args = dict(
             default = False,


### PR DESCRIPTION
I need the option to change the `-release` flag passed to javac.

I only added the LTS java versions as options but this could easily be changed to include every java version.