### PR TITLE
Update release_prep.sh to have correct WORKSPACE download URL

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -34,6 +34,6 @@ http_archive(
     name = "rules_kotlin",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/buildfoundation/rules_kotlin/releases/download/${TAG}/${ARCHIVE}",
+    url = "https://github.com/bazelbuild/rules_kotlin/releases/download/${TAG}/${ARCHIVE}",
 )
 EOF


### PR DESCRIPTION
https://github.com/bazelbuild/rules_kotlin/issues/1065