### PR TITLE
Pass javac options to Kapt javacArguments so the javac_options warn='off' option works for annotation processors that print warnings

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -53,6 +53,7 @@ class KotlinBuilder
       ) : Flag {
         TARGET_LABEL("--target_label"),
         CLASSPATH("--classpath"),
+        JAVAC_OPTS("--javacopts"),
         DIRECT_DEPENDENCIES("--direct_dependencies"),
         DEPS_ARTIFACTS("--deps_artifacts"),
         SOURCES("--sources"),
@@ -288,6 +289,8 @@ class KotlinBuilder
             ?.also {
               addAllSourceJars(it)
             }
+
+          addAllJavacFlags(argMap.optional(KotlinBuilderFlags.JAVAC_OPTS) ?: emptyList())
         }
 
         with(root.infoBuilder) {

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
@@ -119,6 +119,35 @@ internal fun JvmCompilationTask.preProcessingSteps(
   context: CompilationTaskContext,
 ): JvmCompilationTask = context.execute("expand sources") { expandWithSourceJarSources() }
 
+internal fun parseJavacArgsToMap(args: List<String>): Map<String, String> {
+  val optionsMap = mutableMapOf<String, String>()
+  var i = 0
+
+  while (i < args.size) {
+    val arg = args[i]
+
+    // map option arguments as key value pairs e.g. --source 8 => ("--source", "8")
+    // map flag arguments as key with value = "true" e.g. map -nowarn => ("-nowarn", "true")
+    if (arg.startsWith("-")) {
+      val hasNext = i + 1 < args.size
+      val nextArg = if (hasNext) args[i + 1] else null
+
+      if (hasNext && !nextArg!!.startsWith("-")) {
+        optionsMap[arg] = nextArg
+        i += 2
+      } else {
+        optionsMap[arg] = "true"
+        i++
+      }
+    } else {
+      // Ignore non-option arguments
+      i++
+    }
+  }
+
+  return optionsMap
+}
+
 internal fun encodeMap(options: Map<String, String>): String {
   val os = ByteArrayOutputStream()
   val oos = ObjectOutputStream(os)
@@ -141,10 +170,15 @@ internal fun JvmCompilationTask.kaptArgs(
   aptMode: String,
 ): CompilationArgs {
   val javacArgs =
-    mapOf<String, String>(
-      "-target" to info.toolchainInfo.jvm.jvmTarget,
-      "-source" to info.toolchainInfo.jvm.jvmTarget,
+    parseJavacArgsToMap(
+      listOf(
+        "-target",
+        info.toolchainInfo.jvm.jvmTarget,
+        "-source",
+        info.toolchainInfo.jvm.jvmTarget,
+      ).plus(inputs.javacFlagsList),
     )
+
   return CompilationArgs().apply {
     xFlag("plugin", plugins.kapt.jarPath)
 

--- a/src/main/starlark/core/options/opts.javac.bzl
+++ b/src/main/starlark/core/options/opts.javac.bzl
@@ -24,7 +24,7 @@ _JOPTS = {
         ),
         type = attr.string,
         value_to_flag = {
-            "off": ["-nowarn"],
+            "off": ["-nowarn", "-Xlint:none"],
             "error": ["-Werror"],
             "report": None,
         },


### PR DESCRIPTION
In our codebase we're using the [MapStruct annotation processor](https://github.com/mapstruct/mapstruct/tree/main) which can print out a lot of warnings for unmapped target properties when the annotation processors are run.

Using javac_options with `warn = "off"`
```
kt_javac_options(
    name = "javac_options",
    warn = "off"
)
```
does not silience these warnings and using javac_options with `warn = "error"` does not cause errors for these warnings.  

The reason is because the javac options were not passed to the Kapt processor invocation. This PR passes the javac_options to the Kapt processor and adds the parameter "-Xlint:none" so the annotation processor warnings are silenced when using `warn = "off"`
