### PR TITLE
Add bzl_library targets to released artifacts

### DIFF
--- a/kotlin/BUILD.release.bazel
+++ b/kotlin/BUILD.release.bazel
@@ -11,3 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "kotlin",
+    srcs = glob(
+        ["*.bzl"],
+        exclude = [
+            "android.bzl",
+            "kotlin.bzl",
+        ],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//kotlin/internal",
+    ],
+)

--- a/kotlin/compiler/BUILD.release.bazel
+++ b/kotlin/compiler/BUILD.release.bazel
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":compiler.bzl", "kt_configure_compiler")
 load(":ksp.bzl", "kt_configure_ksp")
 
@@ -21,3 +23,11 @@ kt_configure_compiler()
 
 # Configures the KSP plugins
 kt_configure_ksp()
+
+bzl_library(
+    name = "compiler",
+    srcs = glob(["*.bzl"]),
+    deps = [
+        "@rules_proto//proto:repositories",
+    ],
+)

--- a/kotlin/internal/BUILD.release.bazel
+++ b/kotlin/internal/BUILD.release.bazel
@@ -12,6 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("//kotlin/internal:toolchains.bzl", "kt_configure_toolchains")
 
 kt_configure_toolchains()
+
+bzl_library(
+    name = "internal",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//kotlin/internal/js",
+        "//kotlin/internal/jvm",
+        "//kotlin/internal/lint",
+        "//kotlin/internal/utils",
+        "//src/main/starlark",
+    ],
+)

--- a/kotlin/internal/js/BUILD.release.bazel
+++ b/kotlin/internal/js/BUILD.release.bazel
@@ -12,10 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_python//python:defs.bzl", "py_binary")
 
 py_binary(
     name = "importer",
     srcs = ["importer.py"],
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "js",
+    srcs = glob(["*.bzl"]),
     visibility = ["//visibility:public"],
 )

--- a/kotlin/internal/jvm/BUILD.release.bazel
+++ b/kotlin/internal/jvm/BUILD.release.bazel
@@ -12,4 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
 exports_files(["jetbrains-deshade.jarjar"])
+
+bzl_library(
+    name = "jvm",
+    srcs = glob(
+        ["*.bzl"],
+        exclude = ["android.bzl"],
+    ),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//third_party:bzl",
+        "@bazel_skylib//rules:common_settings",
+    ],
+)

--- a/kotlin/internal/lint/BUILD.release.bazel
+++ b/kotlin/internal/lint/BUILD.release.bazel
@@ -11,3 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "lint",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+)

--- a/kotlin/internal/utils/BUILD.release.bazel
+++ b/kotlin/internal/utils/BUILD.release.bazel
@@ -11,3 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "utils",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+)

--- a/src/main/starlark/BUILD.release.bazel
+++ b/src/main/starlark/BUILD.release.bazel
@@ -1,0 +1,24 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "starlark",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/main/starlark/core",
+    ],
+)

--- a/src/main/starlark/core/BUILD.release.bazel
+++ b/src/main/starlark/core/BUILD.release.bazel
@@ -1,0 +1,25 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "core",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/main/starlark/core/options",
+        "//src/main/starlark/core/repositories",
+    ],
+)

--- a/src/main/starlark/core/options/BUILD.release.bazel
+++ b/src/main/starlark/core/options/BUILD.release.bazel
@@ -1,0 +1,24 @@
+# Copyright 2020 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "options",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_jetbrains_kotlin//:capabilities.bzl",
+    ],
+)

--- a/src/main/starlark/core/repositories/BUILD.release.bazel
+++ b/src/main/starlark/core/repositories/BUILD.release.bazel
@@ -11,3 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "repositories",
+    srcs = glob(["*.bzl"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "@rules_proto//proto:repositories",
+    ],
+)

--- a/third_party/BUILD.release.bazel
+++ b/third_party/BUILD.release.bazel
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_import")
 
 exports_files([
@@ -30,5 +31,14 @@ java_import(
     name = "android_sdk",
     jars = ["@bazel_tools//tools/android:android_jar"],
     neverlink = True,
+    visibility = ["//visibility:public"],
+)
+
+bzl_library(
+    name = "bzl",
+    srcs = [
+        "jarjar.bzl",
+        "@bazel_tools//tools:bzl_srcs",
+    ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This doesn't include android related .bzl files because rules_android doesn't provide bzl_library targets.

Closes https://github.com/bazelbuild/rules_kotlin/issues/572