### PR TITLE
Allow setting jvm_target up to Java 21

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 define_kt_toolchain(
     name = "kotlin_toolchain",
     api_version = KOTLIN_LANGUAGE_LEVEL,  # "1.1", "1.2", "1.3", "1.4", "1.5" "1.6", "1.7", "1.8", or "1.9"
-    jvm_target = JAVA_LANGUAGE_LEVEL, # "1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", or "17"
+    jvm_target = JAVA_LANGUAGE_LEVEL, # "1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", "17", "18", "19", "20" or "21"
     language_version = KOTLIN_LANGUAGE_LEVEL,  # "1.1", "1.2", "1.3", "1.4", "1.5" "1.6", "1.7", "1.8", or "1.9"
 )
 ```

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -196,6 +196,10 @@ _kt_toolchain = rule(
                 "15",
                 "16",
                 "17",
+                "18",
+                "19",
+                "20",
+                "21",
             ],
         ),
         "js_target": attr.string(


### PR DESCRIPTION
Adds recent Java releases to allowed values for `jvm_target`.