### PR TITLE
Update name of experimental_prune_transitive_deps flag.

### DIFF
--- a/kotlin/settings/BUILD.bazel
+++ b/kotlin/settings/BUILD.bazel
@@ -30,7 +30,7 @@ bool_flag(
 )
 
 # Kotlin strict deps can be enabled by setting the following value on the command line
-# --@io_bazel_rules_kotlin//kotlin/settings:experimental_prune_transitive_deps=True
+# --@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps=True
 bool_flag(
     name = "experimental_prune_transitive_deps",
     build_setting_default = False,

--- a/kotlin/settings/BUILD.release.bazel
+++ b/kotlin/settings/BUILD.release.bazel
@@ -21,7 +21,7 @@ bool_flag(
 )
 
 # Kotlin strict deps can be enabled by setting the following value on the command line
-# --@io_bazel_rules_kotlin//kotlin/settings:experimental_prune_transitive_deps=True
+# --@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps=True
 bool_flag(
     name = "experimental_prune_transitive_deps",
     build_setting_default = False,


### PR DESCRIPTION
After the rename to `rules_kotlin`, the flag
`--@io_bazel_rules_kotlin//kotlin/settings:experimental_prune_transitive_deps=True` no longer exists.