### PR TITLE
Send `**kwargs` to base `_android_library`

### DIFF
--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -67,6 +67,7 @@ def _kt_android_artifact(
         # TODO(https://github.com/bazelbuild/rules_kotlin/issues/556): replace with starlark
         # buildifier: disable=native-android
         # Do not export deps to avoid all upstream targets to be invalidated when ABI changes.
+        kwargs.pop("exports", None)
         _android_library(
             name = base_name,
             resource_files = resource_files,

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -63,7 +63,7 @@ def _kt_android_artifact(
             **kwargs
         )
         exported_target_labels.append(base_name)
-    elif resource_files or manifest:
+    elif resource_files or manifest or assets:
         # TODO(https://github.com/bazelbuild/rules_kotlin/issues/556): replace with starlark
         # buildifier: disable=native-android
         # Do not export deps to avoid all upstream targets to be invalidated when ABI changes.

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -49,6 +49,7 @@ def _kt_android_artifact(
 
     exported_target_labels = [kt_name]
     manifest = kwargs.get("manifest", default = None)
+    assets = kwargs.get("assets", default = [])
     if "kt_prune_transitive_deps_incompatible" in tags:
         # TODO(https://github.com/bazelbuild/rules_kotlin/issues/556): replace with starlark
         # buildifier: disable=native-android
@@ -67,13 +68,12 @@ def _kt_android_artifact(
         # TODO(https://github.com/bazelbuild/rules_kotlin/issues/556): replace with starlark
         # buildifier: disable=native-android
         # Do not export deps to avoid all upstream targets to be invalidated when ABI changes.
-        kwargs.pop("exports", None)
+        kwargs.pop("exports", default = None)
         _android_library(
             name = base_name,
             resource_files = resource_files,
             deps = deps,
             custom_package = kwargs.get("custom_package", default = None),
-            manifest = manifest,
             enable_data_binding = enable_data_binding,
             tags = tags,
             visibility = ["//visibility:private"],

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -76,6 +76,7 @@ def _kt_android_artifact(
             enable_data_binding = enable_data_binding,
             tags = tags,
             visibility = ["//visibility:private"],
+            **kwargs
         )
         exported_target_labels.append(base_name)
     else:

--- a/kotlin/internal/jvm/android.bzl
+++ b/kotlin/internal/jvm/android.bzl
@@ -73,7 +73,6 @@ def _kt_android_artifact(
             name = base_name,
             resource_files = resource_files,
             deps = deps,
-            custom_package = kwargs.get("custom_package", default = None),
             enable_data_binding = enable_data_binding,
             tags = tags,
             visibility = ["//visibility:private"],


### PR DESCRIPTION
Prior to #842, kwargs were sent to the base android library rule. In that PR, one of the branches no longer contained it. This causes any target with resources/manifest not to send kwargs, which means that e.g. `assets` don't get passed down.