### PR TITLE
Fix README installation's string formatting code

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ rules_kotlin_version = "1.9.0"
 rules_kotlin_sha = "5766f1e599acf551aa56f49dab9ab9108269b03c557496c54acaf41f98e2b8d6"
 http_archive(
     name = "rules_kotlin",
-    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v%s/rules_kotlin-v%s.tar.gz" % rules_kotlin_version],
+    urls = ["https://github.com/bazelbuild/rules_kotlin/releases/download/v%s/rules_kotlin-v%s.tar.gz" % (rules_kotlin_version, rules_kotlin_version)],
     sha256 = rules_kotlin_sha,
 )
 


### PR DESCRIPTION
Fixes a string formatting bug I'm seeing on my version of Bazel (v7.0)