### PR TITLE
Support user.bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -4,3 +4,5 @@ build --strategy=KotlinCompile=worker
 build --test_output=all
 build --verbose_failures
 
+# User-specific .bazelrc
+try-import %workspace%/user.bazelrc


### PR DESCRIPTION
Supporting the optional user.bazelrc file for machine specific options that we don't want checked into the rules.