### PR TITLE
Relativize jar paths in jdeps and rework `BazelRunFiles` to return relative paths

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/BazelRunFiles.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/BazelRunFiles.kt
@@ -32,7 +32,7 @@ object BazelRunFiles {
   @JvmStatic
   fun resolveVerifiedFromProperty(key: String) =
     System.getProperty(key)
-      ?.let { path -> runfiles.rlocation(path) }
+      ?.let { path -> runfiles.rlocation(path).relativizeToPwd() }
       ?.let { File(it) }
       ?.also {
         if (!it.exists()) {

--- a/src/main/kotlin/io/bazel/kotlin/builder/utils/PathUtils.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/utils/PathUtils.kt
@@ -1,0 +1,28 @@
+package io.bazel.kotlin.builder.utils
+
+import java.io.File
+import java.nio.file.Paths
+import kotlin.io.path.absolute
+import kotlin.io.path.exists
+
+/**
+ * Try to relativize this path to be relative to current working directory. Original path is
+ * returned as-is if relativization can't be done.
+ * Ensures returned path exists on the file system
+ */
+fun String.relativizeToPwd(): String {
+  val pwd = System.getenv("PWD") ?: ""
+  if (startsWith(pwd)) {
+    val rpath = replace(pwd, "")
+    if (File(rpath).exists()) {
+      return rpath
+    }
+  }
+  // Handle cases where path is in runfiles.
+  // In this case relativize from current directory to runfiles dir
+  val runfilesRPath = Paths.get(".").absolute().relativize(Paths.get(this).absolute())
+  if (runfilesRPath.exists()) {
+    return runfilesRPath.toString()
+  }
+  return this
+}

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/BUILD.bazel
@@ -23,6 +23,7 @@ kt_bootstrap_library(
     visibility = ["//src:__subpackages__"],
     deps = [
         "//kotlin/compiler:kotlin-compiler",
+        "//src/main/kotlin/io/bazel/kotlin/builder/utils",
         "//src/main/kotlin/io/bazel/kotlin/builder/utils/jars",
         "//src/main/protobuf:deps_java_proto",
         "@kotlin_rules_maven//:com_google_protobuf_protobuf_java",


### PR DESCRIPTION
Fixes #941 

We found that certain Kotlin versions, 1.8.10 for example can produce absolute paths in jdeps output. Although this is fixed in 1.8.20 (not sure which commit caused this on Kotlin side), this PR ensures jdeps jars always use relative path.

* Added test to assert all jar paths in jdeps are relative
* Updated test builder to use relative paths for assertions
