### PR TITLE
Add user.bazelrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 trace.profile.gz
 .idea
 MODULE.bazel.lock
+user.bazelrc


### PR DESCRIPTION
Follow up to https://github.com/bazelbuild/rules_kotlin/commit/1fea7ced59ab2813030711c6370774c2e809b602 to make sure that nobody actually checks in their personal user.bazelrc file.