### PR TITLE
fix running kotlin targets (at least under bzlmod?)

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -71,7 +71,7 @@ def _write_launcher_action(ctx, rjars, main_class, jvm_flags):
     """
     jvm_flags = " ".join([ctx.expand_location(f, ctx.attr.data) for f in jvm_flags])
     template = ctx.attr._java_stub_template.files.to_list()[0]
-    java_bin_path = ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_exec_path
+    java_bin_path = ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_runfiles_path
 
     if ctx.configuration.coverage_enabled:
         jacocorunner = ctx.toolchains[_TOOLCHAIN_TYPE].jacocorunner


### PR DESCRIPTION
I was just integrating rules_kotlin into an existing bazel project and run into some issues getting a simple kotlin app up and running. I was seeing the error 

```
...<app>.runfiles/_main/external/rules_java~~toolchains~remotejdk21_macos_aarch64/bin/java: No such file or directory
```

I explored a little and saw that these two fields in the java toolchain differed and explained the problem (since _exec_ is what's being used, but _runfiles_ is what points to the actual file.)

```
java_executable_exec_path = external/rules_java~~toolchains~remotejdk21_macos_aarch64/bin/java
java_executable_runfiles_path = ../rules_java~~toolchains~remotejdk21_macos_aarch64/bin/java
```

Looking at the docs for these two fields (https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/starlarkbuildapi/java/JavaRuntimeInfoApi.java#L60 ) it looks to me like exec is for use while running java as _part_ of the action, whereas runfiles is for use when using `bazel run` (but this is all a bit new to me so I might be wrong / perhaps there's some nuance -- e.g. I can see in (what looks to me like) the core java stuff, there's all sorts of complex stuff going on when they set javabin . . . -- https://github.com/bazelbuild/bazel/blob/master/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary.bzl#L203 )

env details
- macos
- bazel version: 7.1.0
- rules_kotlin version: 1.9.1

[edit] forgot to mention, that I'm using this as a patch and `bazel run <kotlin app target>` is working fine now