### PR TITLE
Remove leading . from package inference

### DIFF
--- a/src/test/kotlin/io/bazel/kotlin/KotlinJvmKspAssertionTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/KotlinJvmKspAssertionTest.kt
@@ -1,10 +1,7 @@
 package io.bazel.kotlin
 
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith
-import org.junit.runners.JUnit4
 
-@RunWith(JUnit4::class)
 class KotlinJvmKspAssertionTest: KotlinAssertionTestCase("src/test/data/jvm/ksp") {
 
     @Test

--- a/src/test/kotlin/kt_junit5_test.bzl
+++ b/src/test/kotlin/kt_junit5_test.bzl
@@ -1,7 +1,7 @@
 load("//kotlin:jvm.bzl", _kt_jvm_test = "kt_jvm_test")
 
 def kt_jvm_test(name, args = [], deps = [], runtime_deps = [], **kwargs):
-    test_package = native.package_name().replace("src/test/kotlin", "").replace("/", ".")
+    test_package = native.package_name().replace("src/test/kotlin/", "").replace("/", ".")
 
     _kt_jvm_test(
         name = name,


### PR DESCRIPTION
Fixes tests erronously not failing on junit5.

fixes https://github.com/bazelbuild/rules_kotlin/issues/1141