### PR TITLE
Remove legacy struct providers

### DIFF
--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -140,9 +140,9 @@ _implicit_deps = {
         allow_single_file = True,
     ),
     "_toolchain": attr.label(
-        doc = """The Kotlin JVM Runtime. it's only purpose is to enable the Android native rules to discover the Kotlin
-        runtime for dexing""",
-        default = Label("//kotlin/compiler:kotlin-stdlib"),
+        doc = """The Kotlin toolchain. it's only purpose is to enable the Intellij
+        to discover Kotlin language version""",
+        default = Label("//kotlin/internal:default_toolchain_impl"),
         cfg = "target",
     ),
     "_java_toolchain": attr.label(

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -140,6 +140,12 @@ _implicit_deps = {
         allow_single_file = True,
     ),
     "_toolchain": attr.label(
+        doc = """The Kotlin JVM Runtime. it's only purpose is to enable the Android native rules to discover the Kotlin
+        runtime for dexing""",
+        default = Label("//kotlin/compiler:kotlin-stdlib"),
+        cfg = "target",
+    ),
+    "_kt_toolchain": attr.label(
         doc = """The Kotlin toolchain. it's only purpose is to enable the Intellij
         to discover Kotlin language version""",
         default = Label("//kotlin/internal:default_toolchain_impl"),

--- a/kotlin/internal/utils/generate_jvm_service.bzl
+++ b/kotlin/internal/utils/generate_jvm_service.bzl
@@ -46,22 +46,20 @@ def _generate_jvm_service_impl(ctx):
         arguments = [zipper_args],
         progress_message = "JVM service info jar for %%{label}",
     )
-    return struct(
-        providers = [
-            JavaInfo(
-                output_jar = jar,
-                compile_jar = jar,
-                source_jar = jar,
-                runtime_deps = [],
-                exports = [],
-                neverlink = False,
-            ),
-            DefaultInfo(
-                files = depset([jar]),
-                runfiles = ctx.runfiles(files = [jar]),
-            ),
-        ],
-    )
+    return [
+        JavaInfo(
+            output_jar = jar,
+            compile_jar = jar,
+            source_jar = jar,
+            runtime_deps = [],
+            exports = [],
+            neverlink = False,
+        ),
+        DefaultInfo(
+            files = depset([jar]),
+            runfiles = ctx.runfiles(files = [jar]),
+        ),
+    ]
 
 def _write_service_file(ctx, srv, impls):
     f = ctx.actions.declare_file(ctx.label.name + "/" + srv)

--- a/src/main/starlark/core/options/opts.javac.bzl
+++ b/src/main/starlark/core/options/opts.javac.bzl
@@ -100,11 +100,7 @@ _JOPTS = {
 }
 
 def _javac_options_impl(ctx):
-    return struct(
-        providers = [
-            JavacOptions(**{n: getattr(ctx.attr, n, None) for n in _JOPTS}),
-        ],
-    )
+    return [JavacOptions(**{n: getattr(ctx.attr, n, None) for n in _JOPTS})]
 
 JavacOptions = provider(
     fields = {

--- a/src/main/starlark/core/options/opts.kotlinc.bzl
+++ b/src/main/starlark/core/options/opts.kotlinc.bzl
@@ -362,11 +362,7 @@ KotlincOptions = provider(
 )
 
 def _kotlinc_options_impl(ctx):
-    return struct(
-        providers = [
-            KotlincOptions(**{n: getattr(ctx.attr, n, None) for n in _KOPTS}),
-        ],
-    )
+    return [KotlincOptions(**{n: getattr(ctx.attr, n, None) for n in _KOPTS})]
 
 kt_kotlinc_options = rule(
     implementation = _kotlinc_options_impl,


### PR DESCRIPTION
Legacy struct providers have been deprecated by Bazel. Replacing them with modern providers, will make it possible to simplify and remove legacy handling from Bazel.

More info on: https://bazel.build/extending/rules#migrating_from_legacy_providers
Issue: https://github.com/bazelbuild/bazel/issues/19467
