### PR TITLE
Prepare Jdeps extension for K2 implementation

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/BaseJdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/BaseJdepsGenExtension.kt
@@ -1,0 +1,149 @@
+package io.bazel.kotlin.plugin.jdeps
+
+import com.google.devtools.build.lib.view.proto.Deps
+import io.bazel.kotlin.builder.utils.jars.JarOwner
+import org.jetbrains.kotlin.config.CompilerConfiguration
+import java.io.BufferedOutputStream
+import java.io.File
+import java.nio.file.Paths
+
+abstract class BaseJdepsGenExtension(
+  protected val configuration: CompilerConfiguration,
+) {
+
+  protected fun onAnalysisCompleted(
+    explicitClassesCanonicalPaths: Set<String>,
+    implicitClassesCanonicalPaths: Set<String>,
+  ) {
+    val directDeps = configuration.getList(JdepsGenConfigurationKeys.DIRECT_DEPENDENCIES)
+    val targetLabel = configuration.getNotNull(JdepsGenConfigurationKeys.TARGET_LABEL)
+    val explicitDeps = createDepsMap(explicitClassesCanonicalPaths)
+
+    doWriteJdeps(directDeps, targetLabel, explicitDeps, implicitClassesCanonicalPaths)
+
+    doStrictDeps(configuration, targetLabel, directDeps, explicitDeps)
+  }
+
+  /**
+   * Returns a map of jars to classes loaded from those jars.
+   */
+  private fun createDepsMap(classes: Set<String>): Map<String, List<String>> {
+    val jarsToClasses = mutableMapOf<String, MutableList<String>>()
+    classes.forEach {
+      val parts = it.split("!/")
+      val jarPath = parts[0]
+      if (jarPath.endsWith(".jar")) {
+        jarsToClasses.computeIfAbsent(jarPath) { ArrayList() }.add(parts[1])
+      }
+    }
+    return jarsToClasses
+  }
+
+  private fun doWriteJdeps(
+    directDeps: MutableList<String>,
+    targetLabel: String,
+    explicitDeps: Map<String, List<String>>,
+    implicitClassesCanonicalPaths: Set<String>,
+  ) {
+    val implicitDeps = createDepsMap(implicitClassesCanonicalPaths)
+
+    // Build and write out deps.proto
+    val jdepsOutput = configuration.getNotNull(JdepsGenConfigurationKeys.OUTPUT_JDEPS)
+
+    val rootBuilder = Deps.Dependencies.newBuilder()
+    rootBuilder.success = true
+    rootBuilder.ruleLabel = targetLabel
+
+    val unusedDeps = directDeps.subtract(explicitDeps.keys)
+    unusedDeps.forEach { jarPath ->
+      val dependency = Deps.Dependency.newBuilder()
+      dependency.kind = Deps.Dependency.Kind.UNUSED
+      dependency.path = jarPath
+      rootBuilder.addDependency(dependency)
+    }
+
+    explicitDeps.forEach { (jarPath, _) ->
+      val dependency = Deps.Dependency.newBuilder()
+      dependency.kind = Deps.Dependency.Kind.EXPLICIT
+      dependency.path = jarPath
+      rootBuilder.addDependency(dependency)
+    }
+
+    implicitDeps.keys.subtract(explicitDeps.keys).forEach {
+      val dependency = Deps.Dependency.newBuilder()
+      dependency.kind = Deps.Dependency.Kind.IMPLICIT
+      dependency.path = it
+      rootBuilder.addDependency(dependency)
+    }
+
+    BufferedOutputStream(File(jdepsOutput).outputStream()).use {
+      it.write(rootBuilder.buildSorted().toByteArray())
+    }
+  }
+
+  private fun doStrictDeps(
+    compilerConfiguration: CompilerConfiguration,
+    targetLabel: String,
+    directDeps: MutableList<String>,
+    explicitDeps: Map<String, List<String>>,
+  ) {
+    when (compilerConfiguration.getNotNull(JdepsGenConfigurationKeys.STRICT_KOTLIN_DEPS)) {
+      "warn" -> checkStrictDeps(explicitDeps, directDeps, targetLabel)
+      "error" -> {
+        if (checkStrictDeps(explicitDeps, directDeps, targetLabel)) {
+          error(
+            "Strict Deps Violations - please fix",
+          )
+        }
+      }
+    }
+  }
+
+  /**
+   * Prints strict deps warnings and returns true if violations were found.
+   */
+  private fun checkStrictDeps(
+    result: Map<String, List<String>>,
+    directDeps: List<String>,
+    targetLabel: String,
+  ): Boolean {
+    val missingStrictDeps = result.keys
+      .filter { !directDeps.contains(it) }
+      .map { JarOwner.readJarOwnerFromManifest(Paths.get(it)) }
+
+    if (missingStrictDeps.isNotEmpty()) {
+      val missingStrictLabels = missingStrictDeps.mapNotNull { it.label }
+
+      val open = "\u001b[35m\u001b[1m"
+      val close = "\u001b[0m"
+
+      var command =
+        """
+        $open ** Please add the following dependencies:$close
+        ${
+          missingStrictDeps.map { it.label ?: it.jar }.joinToString(" ")
+        } to $targetLabel
+        """
+
+      if (missingStrictLabels.isNotEmpty()) {
+        command += """$open ** You can use the following buildozer command:$close
+        buildozer 'add deps ${
+          missingStrictLabels.joinToString(" ")
+        }' $targetLabel
+        """
+      }
+
+      println(command.trimIndent())
+      return true
+    }
+    return false
+  }
+}
+
+private fun Deps.Dependencies.Builder.buildSorted(): Deps.Dependencies {
+  val sortedDeps = dependencyList.sortedBy { it.path }
+  sortedDeps.forEachIndexed { index, dep ->
+    setDependency(index, dep)
+  }
+  return build()
+}

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -1,9 +1,7 @@
 package io.bazel.kotlin.plugin.jdeps
 
-import com.google.devtools.build.lib.view.proto.Deps
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiElement
-import io.bazel.kotlin.builder.utils.jars.JarOwner
 import org.jetbrains.kotlin.analyzer.AnalysisResult
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import org.jetbrains.kotlin.container.StorageComponentContainer
@@ -48,9 +46,6 @@ import org.jetbrains.kotlin.types.KotlinType
 import org.jetbrains.kotlin.types.TypeConstructor
 import org.jetbrains.kotlin.types.getAbbreviation
 import org.jetbrains.kotlin.types.typeUtil.supertypes
-import java.io.BufferedOutputStream
-import java.io.File
-import java.nio.file.Paths
 
 /**
  * Kotlin compiler extension that tracks classes (and corresponding classpath jars) needed to
@@ -70,9 +65,10 @@ import java.nio.file.Paths
  * @param configuration the current compilation configuration
  */
 class JdepsGenExtension(
-  val configuration: CompilerConfiguration,
-) :
-  AnalysisHandlerExtension, StorageComponentContainerContributor {
+  configuration: CompilerConfiguration,
+) : BaseJdepsGenExtension(configuration),
+  AnalysisHandlerExtension,
+  StorageComponentContainerContributor {
 
   companion object {
 
@@ -351,136 +347,8 @@ class JdepsGenExtension(
     bindingTrace: BindingTrace,
     files: Collection<KtFile>,
   ): AnalysisResult? {
-    val directDeps = configuration.getList(JdepsGenConfigurationKeys.DIRECT_DEPENDENCIES)
-    val targetLabel = configuration.getNotNull(JdepsGenConfigurationKeys.TARGET_LABEL)
-    val explicitDeps = createDepsMap(explicitClassesCanonicalPaths)
-
-    doWriteJdeps(directDeps, targetLabel, explicitDeps)
-
-    doStrictDeps(configuration, targetLabel, directDeps, explicitDeps)
+    onAnalysisCompleted(explicitClassesCanonicalPaths, implicitClassesCanonicalPaths)
 
     return super.analysisCompleted(project, module, bindingTrace, files)
   }
-
-  /**
-   * Returns a map of jars to classes loaded from those jars.
-   */
-  private fun createDepsMap(classes: Set<String>): Map<String, List<String>> {
-    val jarsToClasses = mutableMapOf<String, MutableList<String>>()
-    classes.forEach {
-      val parts = it.split("!/")
-      val jarPath = parts[0]
-      if (jarPath.endsWith(".jar")) {
-        jarsToClasses.computeIfAbsent(jarPath) { ArrayList() }.add(parts[1])
-      }
-    }
-    return jarsToClasses
-  }
-
-  private fun doWriteJdeps(
-    directDeps: MutableList<String>,
-    targetLabel: String,
-    explicitDeps: Map<String, List<String>>,
-  ) {
-    val implicitDeps = createDepsMap(implicitClassesCanonicalPaths)
-
-    // Build and write out deps.proto
-    val jdepsOutput = configuration.getNotNull(JdepsGenConfigurationKeys.OUTPUT_JDEPS)
-
-    val rootBuilder = Deps.Dependencies.newBuilder()
-    rootBuilder.success = true
-    rootBuilder.ruleLabel = targetLabel
-
-    val unusedDeps = directDeps.subtract(explicitDeps.keys)
-    unusedDeps.forEach { jarPath ->
-      val dependency = Deps.Dependency.newBuilder()
-      dependency.kind = Deps.Dependency.Kind.UNUSED
-      dependency.path = jarPath
-      rootBuilder.addDependency(dependency)
-    }
-
-    explicitDeps.forEach { (jarPath, _) ->
-      val dependency = Deps.Dependency.newBuilder()
-      dependency.kind = Deps.Dependency.Kind.EXPLICIT
-      dependency.path = jarPath
-      rootBuilder.addDependency(dependency)
-    }
-
-    implicitDeps.keys.subtract(explicitDeps.keys).forEach {
-      val dependency = Deps.Dependency.newBuilder()
-      dependency.kind = Deps.Dependency.Kind.IMPLICIT
-      dependency.path = it
-      rootBuilder.addDependency(dependency)
-    }
-
-    BufferedOutputStream(File(jdepsOutput).outputStream()).use {
-      it.write(rootBuilder.buildSorted().toByteArray())
-    }
-  }
-
-  private fun doStrictDeps(
-    compilerConfiguration: CompilerConfiguration,
-    targetLabel: String,
-    directDeps: MutableList<String>,
-    explicitDeps: Map<String, List<String>>,
-  ) {
-    when (compilerConfiguration.getNotNull(JdepsGenConfigurationKeys.STRICT_KOTLIN_DEPS)) {
-      "warn" -> checkStrictDeps(explicitDeps, directDeps, targetLabel)
-      "error" -> {
-        if (checkStrictDeps(explicitDeps, directDeps, targetLabel)) {
-          error(
-            "Strict Deps Violations - please fix",
-          )
-        }
-      }
-    }
-  }
-
-  /**
-   * Prints strict deps warnings and returns true if violations were found.
-   */
-  private fun checkStrictDeps(
-    result: Map<String, List<String>>,
-    directDeps: List<String>,
-    targetLabel: String,
-  ): Boolean {
-    val missingStrictDeps = result.keys
-      .filter { !directDeps.contains(it) }
-      .map { JarOwner.readJarOwnerFromManifest(Paths.get(it)) }
-
-    if (missingStrictDeps.isNotEmpty()) {
-      val missingStrictLabels = missingStrictDeps.mapNotNull { it.label }
-
-      val open = "\u001b[35m\u001b[1m"
-      val close = "\u001b[0m"
-
-      var command =
-        """
-        $open ** Please add the following dependencies:$close
-        ${
-          missingStrictDeps.map { it.label ?: it.jar }.joinToString(" ")
-        } to $targetLabel
-        """
-
-      if (missingStrictLabels.isNotEmpty()) {
-        command += """$open ** You can use the following buildozer command:$close
-        buildozer 'add deps ${
-          missingStrictLabels.joinToString(" ")
-        }' $targetLabel
-        """
-      }
-
-      println(command.trimIndent())
-      return true
-    }
-    return false
-  }
-}
-
-private fun Deps.Dependencies.Builder.buildSorted(): Deps.Dependencies {
-  val sortedDeps = dependencyList.sortedBy { it.path }
-  sortedDeps.forEachIndexed { index, dep ->
-    setDependency(index, dep)
-  }
-  return build()
 }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -414,7 +414,7 @@ class JdepsGenExtension(
     }
 
     BufferedOutputStream(File(jdepsOutput).outputStream()).use {
-      it.write(rootBuilder.build().toByteArray())
+      it.write(rootBuilder.buildSorted().toByteArray())
     }
   }
 
@@ -475,4 +475,12 @@ class JdepsGenExtension(
     }
     return false
   }
+}
+
+private fun Deps.Dependencies.Builder.buildSorted(): Deps.Dependencies {
+  val sortedDeps = dependencyList.sortedBy { it.path }
+  sortedDeps.forEachIndexed { index, dep ->
+    setDependency(index, dep)
+  }
+  return build()
 }

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -23,6 +23,7 @@ import io.bazel.kotlin.builder.Deps.Dep;
 import io.bazel.kotlin.builder.toolchain.CompilationTaskContext;
 import io.bazel.kotlin.model.CompilationTaskInfo;
 import io.bazel.kotlin.model.JvmCompilationTask;
+import io.bazel.kotlin.model.KotlinToolchainInfo;
 
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -155,7 +156,7 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
         }
 
         public TaskBuilder compileKotlin() {
-            taskBuilder.setInfo(CompilationTaskInfo.newBuilder().addDebug("trace").addDebug("timings"));
+            taskBuilder.getInfoBuilder().addDebug("trace").addDebug("timings");
             taskBuilder.setCompileKotlin(true);
             return this;
         }
@@ -241,7 +242,10 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
         }
 
         public TaskBuilder useK2() {
-            taskBuilder.getInfoBuilder().addPassthroughFlags("-Xuse-k2");
+            taskBuilder.getInfoBuilder()
+                    .getToolchainInfoBuilder()
+                    .getCommonBuilder()
+                    .setLanguageVersion("2.0");
             return this;
         }
     }

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -66,7 +66,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
     val jdeps = depsProto(deps)
     val expected = Deps.Dependencies.newBuilder()
       .setRuleLabel("//deps")
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -80,7 +80,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
     val jdeps = depsProto(deps)
     val expected = Deps.Dependencies.newBuilder()
       .setRuleLabel("//deps")
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -104,7 +104,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//dependingTarget")
       .setSuccess(true)
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -132,7 +132,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -162,7 +162,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -215,7 +215,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .addExplicitDep(exceptionTarget.singleCompileJar())
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
       .addImplicitDep(baseExceptionTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -254,7 +254,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -282,7 +282,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -308,7 +308,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -340,7 +340,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -373,7 +373,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addUnusedDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -417,7 +417,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addUnusedDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -457,7 +457,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(connectionNotFoundExceptionDep.singleCompileJar())
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -491,7 +491,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -547,7 +547,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .addExplicitDep(dependentTarget.singleCompileJar())
       .addExplicitDep(transitivePropertyTarget.singleCompileJar())
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -605,7 +605,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(dependentTarget.singleCompileJar())
       .addImplicitDep(transitivePropertyTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -640,7 +640,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -679,7 +679,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -716,7 +716,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -742,7 +742,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -771,7 +771,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel(dependingTarget.label())
       .setSuccess(true)
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -800,7 +800,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
       .addImplicitDep(TEST_FIXTURES2_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -827,7 +827,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
       .addExplicitDep(TEST_FIXTURES2_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -853,7 +853,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -890,7 +890,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(dependentTarget.singleCompileJar())
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -925,7 +925,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
       .addExplicitDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -994,7 +994,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .addExplicitDep(dependentTarget.singleCompileJar())
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
       .addImplicitDep(objectMapperTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1030,7 +1030,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1065,7 +1065,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1102,7 +1102,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1127,7 +1127,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1162,7 +1162,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setRuleLabel("//:dependingTarget")
       .setSuccess(true)
       .addExplicitDep(dependentTarget.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1213,7 +1213,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(directInterfaceDef.singleCompileJar())
       .addImplicitDep(indirectInterfaceDef.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1263,7 +1263,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(explicitSuperClassDep.singleCompileJar())
       .addImplicitDep(implicitSuperClassDep.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1314,7 +1314,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(explicitSuperClassDep.singleCompileJar())
       .addImplicitDep(implicitSuperClassDep.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1370,7 +1370,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(explicitSuperClassDep.singleCompileJar())
       .addImplicitDep(implicitSuperClassDep.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1433,7 +1433,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .addExplicitDep(explicitClassWithTypeParamJavaSuperclassDep.singleCompileJar())
       .addImplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
       .addImplicitDep(implicitSuperClassGenericTypeParamDep.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1489,7 +1489,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(explicitSuperClassDep.singleCompileJar())
       .addImplicitDep(implicitSuperClassDep.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1544,7 +1544,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
       .addExplicitDep(explicitSuperClassDep.singleCompileJar())
       .addImplicitDep(implicitSuperClassDep.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1608,7 +1608,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
       .addExplicitDep(explicitSuperClassDep.singleCompileJar())
       .addImplicitDep(implicitSuperClassDep.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1674,7 +1674,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
       .addImplicitDep(depWithReturnType.singleCompileJar())
       .addImplicitDep(depWithReturnTypesSuperType.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1743,7 +1743,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
       .addImplicitDep(depWithReceiverType.singleCompileJar())
       .addImplicitDep(depWithReceiverTypeSuperType.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1793,7 +1793,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(barDep.singleCompileJar())
       .addImplicitDep(fooDep.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1846,7 +1846,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(depWithFunction.singleCompileJar())
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1898,7 +1898,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
       .addExplicitDep(bar.singleCompileJar())
       .addExplicitDep(foo.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -1968,7 +1968,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .addExplicitDep(depWithReturnType.singleCompileJar())
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
       .addImplicitDep(depWithReturnTypesSuperType.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -2000,7 +2000,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
       .addExplicitDep(TEST_FIXTURES_DEP.singleCompileJar())
-      .build()
+      .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }
 
@@ -2035,5 +2035,13 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
   private fun Deps.Dependencies.Builder.addUnusedDep(depPath: String): Deps.Dependencies.Builder {
     addDependency(Deps.Dependency.newBuilder().setPath(depPath).setKind(Deps.Dependency.Kind.UNUSED))
     return this
+  }
+
+  private fun Deps.Dependencies.Builder.buildSorted(): Deps.Dependencies {
+    val sortedDeps = dependencyList.sortedBy { it.path }
+    sortedDeps.forEachIndexed { index, dep ->
+      setDependency(index, dep)
+    }
+    return build()
   }
 }


### PR DESCRIPTION
This PR makes 3 small changes to the JDeps extension in preparation of adding the K2 impl (#843):

1. Ensure that we set the correct argument to enable K2 in `KotlinJvmTestBuilder.java`. We also avoid resetting the option by modifying the existing infoBuilder instead of using `CompilationTaskInfo.newBuilder()`.
2. Since the K1 & K2 flows will be different, they will track classes in a different order. We need to sort the `deps` in the proto so that we can properly assert their equality.
3. We split out the Jdeps creation logic from `JdepsGenExtension` into a new base class that can be extended by the K2 implementation. There are no logic changes in this refactor.