### PR TITLE
Shade Guava to avoid conflicts with ksp plugins

### DIFF
--- a/src/main/kotlin/shade.jarjar
+++ b/src/main/kotlin/shade.jarjar
@@ -1,1 +1,2 @@
 rule dagger.** io.bazel.kotlin.builder.dagger.@1
+rule com.google.common.** io.bazel.kotlin.builder.guava.@1


### PR DESCRIPTION
We have a KSP plugin locally that uses Guava, and would conflict at class load time.

I'm not 100% sure if this rule is the best rule, but experimentally `com.google.common.base.*` and `com.google.*` both broke other parts of the build process.