### PR TITLE
Mark kotlin extension as reproducible

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -6,7 +6,7 @@ module(
 )
 
 bazel_dep(name = "platforms", version = "0.0.6")
-bazel_dep(name = "bazel_skylib", version = "1.4.2")
+bazel_dep(name = "bazel_skylib", version = "1.6.1")
 bazel_dep(name = "rules_java", version = "7.2.0")
 bazel_dep(name = "rules_python", version = "0.23.1")
 bazel_dep(name = "rules_cc", version = "0.0.8")

--- a/src/main/starlark/core/repositories/bzlmod_setup.bzl
+++ b/src/main/starlark/core/repositories/bzlmod_setup.bzl
@@ -1,5 +1,6 @@
 """Definitions for bzlmod module extensions."""
 
+load("@bazel_skylib//lib:modules.bzl", "modules")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     "//src/main/starlark/core/repositories:initialize.release.bzl",
@@ -37,6 +38,8 @@ def _rules_kotlin_extensions_impl(mctx):
         name = "buildkite_config",
         urls = _versions.RBE.URLS,
     )
+
+    return modules.use_all_repos(mctx, reproducible = True)
 
 rules_kotlin_extensions = module_extension(
     implementation = _rules_kotlin_extensions_impl,

--- a/src/main/starlark/core/repositories/versions.bzl
+++ b/src/main/starlark/core/repositories/versions.bzl
@@ -31,8 +31,8 @@ versions = struct(
     # 1. Download archive
     # 2. Download dependencies and Configure rules
     # --> 3. Configure dependencies <--
-    SKYLIB_VERSION = "1.4.2",
-    SKYLIB_SHA = "66ffd9315665bfaafc96b52278f57c7e2dd09f5ede279ea6d39b2be471e7e3aa",
+    SKYLIB_VERSION = "1.6.1",
+    SKYLIB_SHA = "9f38886a40548c6e96c106b752f242130ee11aaa068a56ba7e56f4511f33e4f2",
     PROTOBUF_VERSION = "3.11.3",
     PROTOBUF_SHA = "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
     RULES_JVM_EXTERNAL_TAG = "5.3",


### PR DESCRIPTION
This removes an unnecessary entry from the lockfiles of rules_kotlin users.

Also provides support for managing the corresponding `use_repo` call with `bazel mod tidy` during development.