### PR TITLE
Restrict unecessary inputs to 'JdepsMerge' actions

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -346,8 +346,10 @@ def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps):
         len(jdeps),
     )
 
-    # For sandboxing to work, and for this action to be deterministic, the compile jars need to be passed as inputs
-    inputs = depset(jdeps, transitive = [depset([], transitive = [dep.transitive_compile_time_jars for dep in deps])])
+    inputs = depset(jdeps)
+    if not toolchains.kt.experimental_report_unused_deps == "off":
+        # For sandboxing to work, and for this action to be deterministic, the compile jars need to be passed as inputs
+        inputs = depset(jdeps, transitive = [depset([], transitive = [dep.transitive_compile_time_jars for dep in deps])])
 
     ctx.actions.run(
         mnemonic = mnemonic,


### PR DESCRIPTION
Suppress JDepsMerge action re-execution in incremental build when dependencies API changes. 