### PR TITLE
Fix js test and format capabilities

### DIFF
--- a/kotlin/compiler/compiler.bzl
+++ b/kotlin/compiler/compiler.bzl
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@rules_java//java:defs.bzl", "java_import")
+load("@com_github_jetbrains_kotlin//:artifacts.bzl", "KOTLINC_ARTIFACTS")
 load("//kotlin:js.bzl", "kt_js_import")
 load("//kotlin:jvm.bzl", "kt_jvm_import")
 load("//kotlin/internal:defs.bzl", _KT_COMPILER_REPO = "KT_COMPILER_REPO")
-load("@com_github_jetbrains_kotlin//:artifacts.bzl", "KOTLINC_ARTIFACTS")
 
 def _import_artifacts(artifacts, rule_kind):
     _import_labels(artifacts.plugin, rule_kind)
@@ -24,7 +23,16 @@ def _import_artifacts(artifacts, rule_kind):
     _import_labels(artifacts.compile, rule_kind, neverlink = 1)
 
 def _import_labels(labels, rule_kind, **rule_args):
-    for label in labels:
+    for (label, file) in labels.items():
+        if not file.endswith(".jar"):
+            native.filegroup(
+                name = label,
+                srcs = [
+                    "@%s//:%s" % (_KT_COMPILER_REPO, label),
+                ],
+            )
+            return
+
         if "-sources" in label:
             continue
         args = dict(rule_args.items())

--- a/kotlin/internal/js/js.bzl
+++ b/kotlin/internal/js/js.bzl
@@ -152,10 +152,6 @@ kt_js_import = rule(
             cfg = "exec",
         ),
     },
-    outputs = dict(
-        js = "%{module_name}.js",
-        js_map = "%{module_name}.js.map",
-    ),
     implementation = _kt_js_import_impl,
     provides = [_KtJsInfo],
 )

--- a/kotlin/internal/js/js.bzl
+++ b/kotlin/internal/js/js.bzl
@@ -152,6 +152,10 @@ kt_js_import = rule(
             cfg = "exec",
         ),
     },
+    outputs = dict(
+        js = "%{module_name}.js",
+        js_map = "%{module_name}.js.map",
+    ),
     implementation = _kt_js_import_impl,
     provides = [_KtJsInfo],
 )

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
@@ -24,7 +24,6 @@ import org.jetbrains.kotlin.preloading.ClassPreloadingUtils
 import org.jetbrains.kotlin.preloading.Preloader
 import java.io.File
 import java.io.PrintStream
-import java.lang.ClassLoader
 import java.lang.reflect.Method
 import java.nio.file.FileSystems
 import java.nio.file.Path
@@ -259,6 +258,6 @@ class KotlinToolchain private constructor(
     toolchain: KotlinToolchain,
   ) : KotlinCliToolInvoker(
     toolchain.toolchainWithReflect(),
-    "org.jetbrains.kotlin.cli.js.K2JSCompiler",
+    "org.jetbrains.kotlin.cli.js.K2JsIrCompiler",
   )
 }

--- a/src/main/starlark/core/repositories/BUILD
+++ b/src/main/starlark/core/repositories/BUILD
@@ -19,6 +19,7 @@ release_archive(
     srcs = [
         "BUILD.com_github_google_ksp.bazel",
         "BUILD.com_github_jetbrains_kotlin.bazel",
+        "BUILD.kotlin_capabilities.bazel",
         "bzlmod_impl.bzl",
         "compiler.bzl",
         "ksp.bzl",

--- a/src/main/starlark/core/repositories/BUILD.kotlin_capabilities.bazel
+++ b/src/main/starlark/core/repositories/BUILD.kotlin_capabilities.bazel
@@ -11,10 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-package(default_visibility = ["//visibility:public"])
-
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load(":artifacts.bzl", "KOTLINC_ARTIFACT_LIST")
+
+package(default_visibility = ["//visibility:public"])
 
 bzl_library(
     name = "capabilities",

--- a/src/main/starlark/core/repositories/kotlin/BUILD
+++ b/src/main/starlark/core/repositories/kotlin/BUILD
@@ -2,7 +2,10 @@ load("//src/main/starlark/release:packager.bzl", "release_archive")
 
 release_archive(
     name = "pkg",
-    srcs = glob(["capabilities_*.bazel"]),
+    srcs = glob([
+        "capabilities_*.bazel",
+        "artifacts.bzl",
+    ]),
     src_map = {
         "BUILD.release.bazel": "BUILD",
     },

--- a/src/main/starlark/core/repositories/kotlin/artifacts.bzl
+++ b/src/main/starlark/core/repositories/kotlin/artifacts.bzl
@@ -5,6 +5,7 @@ KOTLINC_ARTIFACTS = struct(
         plugin = {},
         runtime = {
             "kotlin-stdlib-js": "lib/kotlin-stdlib-js.jar",
+            "kotlin-stdlib-js-klib": "lib/kotlin-stdlib-js.klib",
             "kotlin-stdlib-js-sources": "lib/kotlin-stdlib-js-sources.jar",
             "kotlin-test-js": "lib/kotlin-test-js.jar",
             "kotlin-test-js-sources": "lib/kotlin-test-js-sources.jar",

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -103,7 +103,7 @@ kt_rules_test(
     name = "KotlinBuilderJsTest",
     srcs = ["js/KotlinBuilderJsTest.java"],
     data = [
-        "//kotlin/compiler:kotlin-stdlib-js.js",
+        "//kotlin/compiler:kotlin-stdlib-js-klib",
     ],
 )
 

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/js/KotlinBuilderJsTest.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/js/KotlinBuilderJsTest.java
@@ -12,7 +12,7 @@ import static com.google.common.truth.Truth.assertThat;
 public class KotlinBuilderJsTest {
   private static final KotlinJsTestBuilder builder = new KotlinJsTestBuilder();
 
-  private Dep stdLib = Dep.fromLabel("@com_github_jetbrains_kotlin//:lib/kotlin-stdlib-js.jar");
+  private Dep stdLib = Dep.fromLabel("//kotlin/compiler:kotlin-stdlib-js-klib");
 
   @Test
   public void testSimpleJsCompile() {


### PR DESCRIPTION
Of interesting note, I discovered the K2JsIrCompiler class that looks like it replaces the K2JSCompiler. At least, it gives better error messages.