### PR TITLE
Fix stardoc breakage in bazel @ HEAD

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,6 @@
 ---
 validate_config: 1
-bazel: 7.1.1
+bazel: 880c17c67a9b4e17e9753a5c6e2a759bff5a2cfe
 buildifier:
   version: 7.1.1
   # no lint warnings for the moment. They are basically a smoke alarm in hell.

--- a/kotlin/internal/jvm/BUILD
+++ b/kotlin/internal/jvm/BUILD
@@ -32,5 +32,6 @@ bzl_library(
     deps = [
         "//third_party:bzl",
         "@bazel_skylib//rules:common_settings",
+        "@rules_java//java:rules",
     ],
 )

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -12,17 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 load(
-    "@bazel_tools//tools/jdk:toolchain_utils.bzl",
-    "find_java_runtime_toolchain",
-    "find_java_toolchain",
-)
-load(
     "@rules_java//java:defs.bzl",
     "JavaInfo",
     "java_common",
 )
 load(
     "//kotlin/internal:defs.bzl",
+    _JAVA_RUNTIME_TOOLCHAIN_TYPE = "JAVA_RUNTIME_TOOLCHAIN_TYPE",
+    _JAVA_TOOLCHAIN_TYPE = "JAVA_TOOLCHAIN_TYPE",
     _KtCompilerPluginInfo = "KtCompilerPluginInfo",
     _KtJvmInfo = "KtJvmInfo",
     _KtPluginConfiguration = "KtPluginConfiguration",
@@ -54,6 +51,15 @@ load(
 )
 
 # UTILITY ##############################################################################################################
+def find_java_toolchain(ctx, target):
+    if _JAVA_TOOLCHAIN_TYPE in ctx.toolchains:
+        return ctx.toolchains[_JAVA_TOOLCHAIN_TYPE].java
+    return target[java_common.JavaToolchainInfo]
+
+def find_java_runtime_toolchain(ctx, target):
+    if _JAVA_RUNTIME_TOOLCHAIN_TYPE in ctx.toolchains:
+        return ctx.toolchains[_JAVA_RUNTIME_TOOLCHAIN_TYPE].java_runtime
+    return target[java_common.JavaRuntimeInfo]
 
 def _java_info(target):
     return target[JavaInfo] if JavaInfo in target else None


### PR DESCRIPTION
bazel @ head has an added dependency @rule_java_builtin java_common that is not satisfiable via import the built-in bazel srcs.

The simplest solution it to stop using the toolchain utilities, and resolve the toolchains in a backwards compatible manner.

Still a potential problem in third_party, as it will pick up toolchain_utils from `bazel_tools` -- unfortunately, the `filegroup` that won't pull in the toolchain_utils is private. :/

fixes: #1180 