### PR TITLE
Import rules_android in MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,6 +10,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_java", version = "7.2.0")
 bazel_dep(name = "rules_python", version = "0.23.1")
 bazel_dep(name = "rules_cc", version = "0.0.8")
+bazel_dep(name = "rules_android", version = "0.1.1")
 
 rules_kotlin_extensions = use_extension("//src/main/starlark/core/repositories:bzlmod_setup.bzl", "rules_kotlin_extensions")
 use_repo(
@@ -19,7 +20,6 @@ use_repo(
     "com_github_jetbrains_kotlin",
     "com_github_pinterest_ktlint",
     "released_rules_kotlin",
-    "rules_android",
 )
 
 # Once the released rules_koltin is defined, configure it.

--- a/MODULE.release.bazel
+++ b/MODULE.release.bazel
@@ -10,6 +10,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_java", version = "7.2.0")
 bazel_dep(name = "rules_python", version = "0.23.1")
 bazel_dep(name = "rules_cc", version = "0.0.8")
+bazel_dep(name = "rules_android", version = "0.1.1")
 
 rules_kotlin_extensions = use_extension(
     "//src/main/starlark/core/repositories:bzlmod_setup.bzl",
@@ -20,7 +21,6 @@ use_repo(
     "com_github_google_ksp",
     "com_github_jetbrains_kotlin",
     "com_github_pinterest_ktlint",
-    "rules_android",
 )
 
 register_toolchains("//kotlin/internal:default_toolchain")

--- a/src/main/starlark/core/repositories/initialize.release.bzl
+++ b/src/main/starlark/core/repositories/initialize.release.bzl
@@ -71,6 +71,9 @@ def kotlin_repositories(
         executable = True,
     )
 
+    if is_bzlmod:
+        return
+
     maybe(
         http_archive,
         name = "rules_android",
@@ -78,9 +81,6 @@ def kotlin_repositories(
         strip_prefix = "rules_android-%s" % versions.ANDROID.VERSION,
         urls = versions.ANDROID.URLS,
     )
-
-    if is_bzlmod:
-        return
 
     versions.use_repository(
         name = "rules_python",


### PR DESCRIPTION
This should be loaded using the Bazel central registry and not an http repository. Removing this from the downloader.bzl also means that users don't have to declare this namespace in their modules if they use our extensions.