### PR TITLE
Support testing with coverage in dev mode

### DIFF
--- a/src/main/kotlin/bootstrap.bzl
+++ b/src/main/kotlin/bootstrap.bzl
@@ -57,7 +57,7 @@ def kt_bootstrap_library(name, deps = [], neverlink_deps = [], srcs = [], visibi
 def kt_bootstrap_binary(
         name,
         main_class,
-        runtime_library,
+        runtime_deps,
         shade_rules,
         jvm_flags = [],
         data = [],
@@ -68,7 +68,7 @@ def kt_bootstrap_binary(
     java_binary(
         name = raw,
         create_executable = False,
-        runtime_deps = [runtime_library],
+        runtime_deps = runtime_deps,
     )
 
     # Shaded to ensure that libraries it uses are not leaked to

--- a/src/main/kotlin/io/bazel/kotlin/builder/cmd/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/builder/cmd/BUILD.bazel
@@ -39,9 +39,12 @@ kt_bootstrap_binary(
         "-XX:-MaxFDLimit",
     ],
     main_class = "io.bazel.kotlin.builder.cmd.Build",
-    runtime_library = ":build_lib",
     shade_rules = "//src/main/kotlin:shade.jarjar",
     visibility = ["//src:__subpackages__"],
+    runtime_deps = [
+        ":build_lib",
+        "@bazel_tools//tools/jdk:JacocoCoverage",
+    ],
 )
 
 kt_bootstrap_library(
@@ -60,7 +63,7 @@ kt_bootstrap_binary(
     name = "merge_jdeps",
     data = [],
     main_class = "io.bazel.kotlin.builder.cmd.MergeJdeps",
-    runtime_library = ":merge_jdeps_lib",
     shade_rules = "//src/main/kotlin:shade.jarjar",
     visibility = ["//src:__subpackages__"],
+    runtime_deps = [":merge_jdeps_lib"],
 )


### PR DESCRIPTION
Mirrors the release behavior by adding the jacoco instrumentation library to the worker runtime dependencies so that coverage works locally while iterating against `rules_kotlin` directly.

```
java.lang.NoClassDefFoundError: org/jacoco/core/instr/Instrumenter
        at io.bazel.kotlin.builder.tasks.jvm.JacocoInstrumentationKt.createCoverageInstrumentedJar(JacocoInstrumentation.kt:19)
        at io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor$execute$1$1$6.invoke(KotlinJvmTaskExecutor.kt:112)
        at io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor$execute$1$1$6.invoke(KotlinJvmTaskExecutor.kt:112)
        at io.bazel.kotlin.builder.toolchain.CompilationTaskContext.execute(CompilationTaskContext.kt:153)
        at io.bazel.kotlin.builder.toolchain.CompilationTaskContext.execute(CompilationTaskContext.kt:145)
        at io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor$execute$1.invoke(KotlinJvmTaskExecutor.kt:112)
        at io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor$execute$1.invoke(KotlinJvmTaskExecutor.kt:54)
        at io.bazel.kotlin.builder.toolchain.CompilationTaskContext.execute(CompilationTaskContext.kt:153)
        at io.bazel.kotlin.builder.toolchain.CompilationTaskContext.execute(CompilationTaskContext.kt:145)
        at io.bazel.kotlin.builder.tasks.jvm.KotlinJvmTaskExecutor.execute(KotlinJvmTaskExecutor.kt:54)
        at io.bazel.kotlin.builder.tasks.KotlinBuilder.executeJvmTask(KotlinBuilder.kt:211)
        at io.bazel.kotlin.builder.tasks.KotlinBuilder.build(KotlinBuilder.kt:104)
        at io.bazel.kotlin.builder.tasks.CompileKotlin.invoke(CompileKotlin.kt:27)
        at io.bazel.worker.PersistentWorker$workTo$1.invoke(PersistentWorker.kt:97)
        at io.bazel.worker.PersistentWorker$workTo$1.invoke(PersistentWorker.kt:97)
        at io.bazel.worker.WorkerContext$TaskContext.resultOf(WorkerContext.kt:128)
        at io.bazel.worker.WorkerContext.doTask(WorkerContext.kt:156)
        at io.bazel.worker.PersistentWorker$start$1$1$producer$1$1$1.call(PersistentWorker.kt:70)
        at io.bazel.worker.PersistentWorker$start$1$1$producer$1$1$1.call(PersistentWorker.kt:69)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.ClassNotFoundException: org.jacoco.core.instr.Instrumenter
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
        ... 25 more
```