### PR TITLE
Remove Guava shade

### DIFF
--- a/src/main/kotlin/shade.jarjar
+++ b/src/main/kotlin/shade.jarjar
@@ -1,2 +1,1 @@
 rule dagger.** io.bazel.kotlin.builder.dagger.@1
-rule com.google.common.** io.bazel.kotlin.builder.guava.@1


### PR DESCRIPTION
I had made this addition with #1167, which addressed at the time a class load conflict with an internal KSP plugin we have.

This did not solve all of our class loader problems with KSP, and eventually needed to apply a patch from #1168. I don't believe this rule should be necessary, so I'm proposing to revert.