### PR TITLE
Remove bazel_tools android usage

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,5 @@
 common --enable_bzlmod=true
+common --experimental_google_legacy_api
 
 common:rbe --java_runtime_version=11
 common:rbe --tool_java_runtime_version=11

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_java", version = "7.2.0")
 bazel_dep(name = "rules_python", version = "0.23.1")
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_android", version = "0.1.1")
+bazel_dep(name = "rules_android", version = "0.5.1")
 
 rules_kotlin_extensions = use_extension("//src/main/starlark/core/repositories:bzlmod_setup.bzl", "rules_kotlin_extensions")
 use_repo(
@@ -41,10 +41,6 @@ register_toolchains("@released_rules_kotlin//kotlin/internal:default_toolchain")
 
 # Back to the regularly scheduled configuration.
 register_toolchains("//kotlin/internal:default_toolchain")
-
-# TODO(bencodes) We should be able to remove this once rules_android has rolled out official Bzlmod support
-remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
-use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
 
 # Development dependencies
 # TODO(bencodes) A bunch of these dependencies need to be marked as dev_dependencies but before we can do that

--- a/MODULE.release.bazel
+++ b/MODULE.release.bazel
@@ -10,7 +10,7 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "rules_java", version = "7.2.0")
 bazel_dep(name = "rules_python", version = "0.23.1")
 bazel_dep(name = "rules_cc", version = "0.0.8")
-bazel_dep(name = "rules_android", version = "0.1.1")
+bazel_dep(name = "rules_android", version = "0.5.1")
 
 rules_kotlin_extensions = use_extension(
     "//src/main/starlark/core/repositories:bzlmod_setup.bzl",
@@ -27,9 +27,5 @@ use_repo(
 )
 
 register_toolchains("//kotlin/internal:default_toolchain")
-
-# TODO(bencodes) We should be able to remove this once rules_android has rolled out official Bzlmod support
-remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
-use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
 
 bazel_dep(name = "rules_proto", version = "5.3.0-21.7")

--- a/examples/android/MODULE.bazel
+++ b/examples/android/MODULE.bazel
@@ -1,9 +1,6 @@
 module(name = "android-example")
 
-remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
-use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
-
-bazel_dep(name = "rules_android", version = "0.1.1")
+bazel_dep(name = "rules_android", version = "0.5.1")
 bazel_dep(name = "bazel_skylib", version = "1.2.1")
 bazel_dep(name = "rules_robolectric", version = "4.10.3", repo_name = "robolectric")
 bazel_dep(name = "rules_java", version = "6.4.0")

--- a/examples/multiplex/MODULE.bazel
+++ b/examples/multiplex/MODULE.bazel
@@ -1,8 +1,6 @@
 module(name = "multiplex-example")
 
-remote_android_extensions = use_extension("@bazel_tools//tools/android:android_extensions.bzl", "remote_android_tools_extensions")
-use_repo(remote_android_extensions, "android_gmaven_r8", "android_tools")
-
+bazel_dep(name = "rules_android", version = "0.5.1")
 bazel_dep(name = "rules_java", version = "6.4.0")
 bazel_dep(name = "rules_kotlin", version = "1.9.5")
 bazel_dep(name = "rules_jvm_external", version = "5.3")


### PR DESCRIPTION
This was removed with bazel 8.x and exists in rules_android now
