### PR TITLE
Add a current_toolchain target to be referenced by kt_toolchain attribute

### DIFF
--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -148,7 +148,7 @@ _implicit_deps = {
     "_kt_toolchain": attr.label(
         doc = """The Kotlin toolchain. it's only purpose is to enable the Intellij
         to discover Kotlin language version""",
-        default = Label("//kotlin/internal:default_toolchain_impl"),
+        default = Label("//kotlin/internal:current_toolchain"),
         cfg = "target",
     ),
     "_java_toolchain": attr.label(

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -342,6 +342,18 @@ def define_kt_toolchain(
         target_settings = target_settings or [],
     )
 
+def _kt_toolchain_alias_impl(ctx):
+    toolchain_info = ctx.toolchains[_TOOLCHAIN_TYPE]
+
+    return [
+        toolchain_info,
+    ]
+
+_kt_toolchain_alias = rule(
+    implementation = _kt_toolchain_alias_impl,
+    toolchains = [_TOOLCHAIN_TYPE],
+)
+
 def kt_configure_toolchains():
     """
     Defines the toolchain_type and default toolchain for kotlin compilation.
@@ -397,4 +409,9 @@ def kt_configure_toolchains():
 
     define_kt_toolchain(
         name = "default_toolchain",
+    )
+
+    _kt_toolchain_alias(
+        name = "current_toolchain",
+        visibility = ["//visibility:public"],
     )


### PR DESCRIPTION
Fixes https://github.com/bazelbuild/rules_kotlin/issues/1238

I copied the approach that `rules_java` takes [here](https://github.com/bazelbuild/rules_java/blob/084b75a46739eb531aa3da9ab9fe52c8d44b7b34/toolchains/java_toolchain_alias.bzl#L95).

This will require an accompanying change in the IntelliJ plugin too.