### PR TITLE
Add support for experimental treatInternalAsPrivate

### DIFF
--- a/CompileAvoidance.md
+++ b/CompileAvoidance.md
@@ -38,3 +38,28 @@ kt_jvm_library(
     tags = ["kt_abi_plugin_incompatible"],
 )
 ```
+
+Depending on your compiler version you may find non-public symbols in your ABI jar such as [internal declarations](https://youtrack.jetbrains.com/issue/KT-65690) or [effectively private classes](https://youtrack.jetbrains.com/issue/KT-64590). 
+Exclusion of these symbols from the ABI jar can be enabled through the `experimental_use_public_only_abi_jars` flag in addition to `experimental_use_abi_jars` flag when defining the toolchain as follows
+
+```python
+load("//kotlin:core.bzl", "define_kt_toolchain")
+
+
+define_kt_toolchain(
+    name = "kotlin_toolchain",
+    experimental_use_abi_jars = True,
+    experimental_use_public_only_abi_jars = True,
+)
+```
+
+If you encounter bugs in older compiler versions such as [KT-71525](https://youtrack.jetbrains.com/issue/KT-71525) then ABI generation with only public symbols can be disabled on a per target basis by setting the following tag
+
+```python
+load("//kotlin:jvm.bzl", "kt_jvm_library")
+
+kt_jvm_library(
+    name = "framework",
+    tags = ["kt_public_only_in_abi_plugin_incompatible"],
+)
+```

--- a/CompileAvoidance.md
+++ b/CompileAvoidance.md
@@ -40,7 +40,7 @@ kt_jvm_library(
 ```
 
 Depending on your compiler version you may find non-public symbols in your ABI jar such as [internal declarations](https://youtrack.jetbrains.com/issue/KT-65690) or [effectively private classes](https://youtrack.jetbrains.com/issue/KT-64590). 
-Exclusion of these symbols from the ABI jar can be enabled through the `experimental_use_public_only_abi_jars` flag in addition to `experimental_use_abi_jars` flag when defining the toolchain as follows
+Exclusion of these symbols from the ABI jar can be enabled through the `experimental_treat_internal_as_private_in_abi_jars` and `experimental_remove_private_classes_in_abi_jars` flags in addition to `experimental_use_abi_jars` flag when defining the toolchain as follows
 
 ```python
 load("//kotlin:core.bzl", "define_kt_toolchain")
@@ -49,17 +49,18 @@ load("//kotlin:core.bzl", "define_kt_toolchain")
 define_kt_toolchain(
     name = "kotlin_toolchain",
     experimental_use_abi_jars = True,
-    experimental_use_public_only_abi_jars = True,
+    experimental_treat_internal_as_private_in_abi_jars = True,
+    experimental_remove_private_classes_in_abi_jars = True,
 )
 ```
 
-If you encounter bugs in older compiler versions such as [KT-71525](https://youtrack.jetbrains.com/issue/KT-71525) then ABI generation with only public symbols can be disabled on a per target basis by setting the following tag
+If you encounter bugs in older compiler versions such as [KT-71525](https://youtrack.jetbrains.com/issue/KT-71525) then ABI generation with only public symbols can be disabled on a per target basis by setting the following tags
 
 ```python
 load("//kotlin:jvm.bzl", "kt_jvm_library")
 
 kt_jvm_library(
     name = "framework",
-    tags = ["kt_public_only_in_abi_plugin_incompatible"],
+    tags = ["kt_treat_internal_as_private_in_abi_plugin_incompatible", "kt_remove_private_classes_in_abi_plugin_incompatible"],
 )
 ```

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -508,10 +508,11 @@ This allows setting options and dependencies independently from the initial plug
 load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 
 define_kt_toolchain(<a href="#define_kt_toolchain-name">name</a>, <a href="#define_kt_toolchain-language_version">language_version</a>, <a href="#define_kt_toolchain-api_version">api_version</a>, <a href="#define_kt_toolchain-jvm_target">jvm_target</a>, <a href="#define_kt_toolchain-experimental_use_abi_jars">experimental_use_abi_jars</a>,
-                    <a href="#define_kt_toolchain-experimental_strict_kotlin_deps">experimental_strict_kotlin_deps</a>, <a href="#define_kt_toolchain-experimental_report_unused_deps">experimental_report_unused_deps</a>,
-                    <a href="#define_kt_toolchain-experimental_reduce_classpath_mode">experimental_reduce_classpath_mode</a>, <a href="#define_kt_toolchain-experimental_multiplex_workers">experimental_multiplex_workers</a>, <a href="#define_kt_toolchain-javac_options">javac_options</a>,
-                    <a href="#define_kt_toolchain-kotlinc_options">kotlinc_options</a>, <a href="#define_kt_toolchain-jvm_stdlibs">jvm_stdlibs</a>, <a href="#define_kt_toolchain-jvm_runtime">jvm_runtime</a>, <a href="#define_kt_toolchain-jacocorunner">jacocorunner</a>, <a href="#define_kt_toolchain-exec_compatible_with">exec_compatible_with</a>,
-                    <a href="#define_kt_toolchain-target_compatible_with">target_compatible_with</a>, <a href="#define_kt_toolchain-target_settings">target_settings</a>)
+                    <a href="#define_kt_toolchain-experimental_use_public_only_abi_jars">experimental_use_public_only_abi_jars</a>, <a href="#define_kt_toolchain-experimental_strict_kotlin_deps">experimental_strict_kotlin_deps</a>,
+                    <a href="#define_kt_toolchain-experimental_report_unused_deps">experimental_report_unused_deps</a>, <a href="#define_kt_toolchain-experimental_reduce_classpath_mode">experimental_reduce_classpath_mode</a>,
+                    <a href="#define_kt_toolchain-experimental_multiplex_workers">experimental_multiplex_workers</a>, <a href="#define_kt_toolchain-javac_options">javac_options</a>, <a href="#define_kt_toolchain-kotlinc_options">kotlinc_options</a>, <a href="#define_kt_toolchain-jvm_stdlibs">jvm_stdlibs</a>,
+                    <a href="#define_kt_toolchain-jvm_runtime">jvm_runtime</a>, <a href="#define_kt_toolchain-jacocorunner">jacocorunner</a>, <a href="#define_kt_toolchain-exec_compatible_with">exec_compatible_with</a>, <a href="#define_kt_toolchain-target_compatible_with">target_compatible_with</a>,
+                    <a href="#define_kt_toolchain-target_settings">target_settings</a>)
 </pre>
 
 Define the Kotlin toolchain.
@@ -526,6 +527,7 @@ Define the Kotlin toolchain.
 | <a id="define_kt_toolchain-api_version"></a>api_version |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-jvm_target"></a>jvm_target |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_use_abi_jars"></a>experimental_use_abi_jars |  <p align="center"> - </p>   |  `False` |
+| <a id="define_kt_toolchain-experimental_use_public_only_abi_jars"></a>experimental_use_public_only_abi_jars |  <p align="center"> - </p>   |  `False` |
 | <a id="define_kt_toolchain-experimental_strict_kotlin_deps"></a>experimental_strict_kotlin_deps |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_report_unused_deps"></a>experimental_report_unused_deps |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_reduce_classpath_mode"></a>experimental_reduce_classpath_mode |  <p align="center"> - </p>   |  `None` |

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -508,7 +508,8 @@ This allows setting options and dependencies independently from the initial plug
 load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 
 define_kt_toolchain(<a href="#define_kt_toolchain-name">name</a>, <a href="#define_kt_toolchain-language_version">language_version</a>, <a href="#define_kt_toolchain-api_version">api_version</a>, <a href="#define_kt_toolchain-jvm_target">jvm_target</a>, <a href="#define_kt_toolchain-experimental_use_abi_jars">experimental_use_abi_jars</a>,
-                    <a href="#define_kt_toolchain-experimental_use_public_only_abi_jars">experimental_use_public_only_abi_jars</a>, <a href="#define_kt_toolchain-experimental_strict_kotlin_deps">experimental_strict_kotlin_deps</a>,
+                    <a href="#define_kt_toolchain-experimental_treat_internal_as_private_in_abi_jars">experimental_treat_internal_as_private_in_abi_jars</a>,
+                    <a href="#define_kt_toolchain-experimental_remove_private_classes_in_abi_jars">experimental_remove_private_classes_in_abi_jars</a>, <a href="#define_kt_toolchain-experimental_strict_kotlin_deps">experimental_strict_kotlin_deps</a>,
                     <a href="#define_kt_toolchain-experimental_report_unused_deps">experimental_report_unused_deps</a>, <a href="#define_kt_toolchain-experimental_reduce_classpath_mode">experimental_reduce_classpath_mode</a>,
                     <a href="#define_kt_toolchain-experimental_multiplex_workers">experimental_multiplex_workers</a>, <a href="#define_kt_toolchain-javac_options">javac_options</a>, <a href="#define_kt_toolchain-kotlinc_options">kotlinc_options</a>, <a href="#define_kt_toolchain-jvm_stdlibs">jvm_stdlibs</a>,
                     <a href="#define_kt_toolchain-jvm_runtime">jvm_runtime</a>, <a href="#define_kt_toolchain-jacocorunner">jacocorunner</a>, <a href="#define_kt_toolchain-exec_compatible_with">exec_compatible_with</a>, <a href="#define_kt_toolchain-target_compatible_with">target_compatible_with</a>,
@@ -527,7 +528,8 @@ Define the Kotlin toolchain.
 | <a id="define_kt_toolchain-api_version"></a>api_version |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-jvm_target"></a>jvm_target |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_use_abi_jars"></a>experimental_use_abi_jars |  <p align="center"> - </p>   |  `False` |
-| <a id="define_kt_toolchain-experimental_use_public_only_abi_jars"></a>experimental_use_public_only_abi_jars |  <p align="center"> - </p>   |  `False` |
+| <a id="define_kt_toolchain-experimental_treat_internal_as_private_in_abi_jars"></a>experimental_treat_internal_as_private_in_abi_jars |  <p align="center"> - </p>   |  `False` |
+| <a id="define_kt_toolchain-experimental_remove_private_classes_in_abi_jars"></a>experimental_remove_private_classes_in_abi_jars |  <p align="center"> - </p>   |  `False` |
 | <a id="define_kt_toolchain-experimental_strict_kotlin_deps"></a>experimental_strict_kotlin_deps |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_report_unused_deps"></a>experimental_report_unused_deps |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_reduce_classpath_mode"></a>experimental_reduce_classpath_mode |  <p align="center"> - </p>   |  `None` |

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -536,7 +536,7 @@ def _run_kt_builder_action(
         omit_if_empty = True,
     )
 
-    if toolchains.kt.experimental_use_public_only_abi_jars == True:
+    if not "kt_public_only_in_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_use_public_only_abi_jars == True:
         args.add("--public_only_in_abi_jar", "true")
 
     args.add("--build_kotlin", build_kotlin)

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -536,6 +536,9 @@ def _run_kt_builder_action(
         omit_if_empty = True,
     )
 
+    if toolchains.kt.experimental_use_public_only_abi_jars == True:
+        args.add("--public_only_in_abi_jar", "true")
+
     args.add("--build_kotlin", build_kotlin)
 
     progress_message = "%s %%{label} { kt: %d, java: %d, srcjars: %d } for %s" % (

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -536,8 +536,11 @@ def _run_kt_builder_action(
         omit_if_empty = True,
     )
 
-    if not "kt_public_only_in_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_use_public_only_abi_jars == True:
-        args.add("--public_only_in_abi_jar", "true")
+    if not "kt_treat_internal_as_private_in_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_treat_internal_as_private_in_abi_jars == True:
+        args.add("--treat_internal_as_private_in_abi_jar", "true")
+
+    if not "kt_remove_private_classes_in_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_remove_private_classes_in_abi_jars == True:
+        args.add("--remove_private_classes_in_abi_jar", "true")
 
     args.add("--build_kotlin", build_kotlin)
 

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -536,11 +536,19 @@ def _run_kt_builder_action(
         omit_if_empty = True,
     )
 
-    if not "kt_treat_internal_as_private_in_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_treat_internal_as_private_in_abi_jars == True:
-        args.add("--treat_internal_as_private_in_abi_jar", "true")
-
     if not "kt_remove_private_classes_in_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_remove_private_classes_in_abi_jars == True:
         args.add("--remove_private_classes_in_abi_jar", "true")
+
+    if not "kt_treat_internal_as_private_in_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_treat_internal_as_private_in_abi_jars == True:
+        if not "kt_remove_private_classes_in_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_remove_private_classes_in_abi_jars == True:
+            args.add("--treat_internal_as_private_in_abi_jar", "true")
+        else:
+            fail(
+                "experimental_treat_internal_as_private_in_abi_jars without experimental_remove_private_classes_in_abi_jars is invalid." +
+                "\nTo remove internal symbols from kotlin abi jars ensure experimental_remove_private_classes_in_abi_jars " +
+                "and experimental_treat_internal_as_private_in_abi_jars are both enabled in define_kt_toolchain." +
+                "\nAdditionally ensure the target does not contain the kt_remove_private_classes_in_abi_plugin_incompatible tag.",
+            )
 
     args.add("--build_kotlin", build_kotlin)
 

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -86,7 +86,8 @@ def _kotlin_toolchain_impl(ctx):
             "supports-multiplex-workers": "1" if ctx.attr.experimental_multiplex_workers else "0",
         },
         experimental_use_abi_jars = ctx.attr.experimental_use_abi_jars,
-        experimental_use_public_only_abi_jars = ctx.attr.experimental_use_public_only_abi_jars,
+        experimental_treat_internal_as_private_in_abi_jars = ctx.attr.experimental_treat_internal_as_private_in_abi_jars,
+        experimental_remove_private_classes_in_abi_jars = ctx.attr.experimental_remove_private_classes_in_abi_jars,
         experimental_strict_kotlin_deps = ctx.attr.experimental_strict_kotlin_deps,
         experimental_report_unused_deps = ctx.attr.experimental_report_unused_deps,
         experimental_reduce_classpath_mode = ctx.attr.experimental_reduce_classpath_mode,
@@ -203,13 +204,18 @@ _kt_toolchain = rule(
             `kt_abi_plugin_incompatible`""",
             default = False,
         ),
-        "experimental_use_public_only_abi_jars": attr.bool(
-            doc = """Compile using public only abi jars.
-            This effectively applies the following two compiler plugin options:
+        "experimental_treat_internal_as_private_in_abi_jars": attr.bool(
+            doc = """This applies the following compiler plugin option:
               plugin:org.jetbrains.kotlin.jvm.abi:treatInternalAsPrivate=true
+            Can be disabled for an individual target using the tag.
+            `kt_treat_internal_as_private_in_abi_plugin_incompatible`""",
+            default = False,
+        ),
+        "experimental_remove_private_classes_in_abi_jars": attr.bool(
+            doc = """This applies the following compiler plugin option:
               plugin:org.jetbrains.kotlin.jvm.abi:removePrivateClasses=true
             Can be disabled for an individual target using the tag.
-            `kt_public_only_in_abi_plugin_incompatible`""",
+            `kt_remove_private_classes_in_abi_plugin_incompatible`""",
             default = False,
         ),
         "experimental_strict_kotlin_deps": attr.string(
@@ -298,7 +304,8 @@ def define_kt_toolchain(
         api_version = None,
         jvm_target = None,
         experimental_use_abi_jars = False,
-        experimental_use_public_only_abi_jars = False,
+        experimental_treat_internal_as_private_in_abi_jars = False,
+        experimental_remove_private_classes_in_abi_jars = False,
         experimental_strict_kotlin_deps = None,
         experimental_report_unused_deps = None,
         experimental_reduce_classpath_mode = None,
@@ -325,7 +332,8 @@ def define_kt_toolchain(
             _NOEXPERIMENTAL_USE_ABI_JARS: False,
             "//conditions:default": experimental_use_abi_jars,
         }),
-        experimental_use_public_only_abi_jars = experimental_use_public_only_abi_jars,
+        experimental_treat_internal_as_private_in_abi_jars = experimental_treat_internal_as_private_in_abi_jars,
+        experimental_remove_private_classes_in_abi_jars = experimental_remove_private_classes_in_abi_jars,
         experimental_multiplex_workers = experimental_multiplex_workers,
         experimental_strict_kotlin_deps = experimental_strict_kotlin_deps,
         experimental_report_unused_deps = experimental_report_unused_deps,

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -86,6 +86,7 @@ def _kotlin_toolchain_impl(ctx):
             "supports-multiplex-workers": "1" if ctx.attr.experimental_multiplex_workers else "0",
         },
         experimental_use_abi_jars = ctx.attr.experimental_use_abi_jars,
+        experimental_use_public_only_abi_jars = ctx.attr.experimental_use_public_only_abi_jars,
         experimental_strict_kotlin_deps = ctx.attr.experimental_strict_kotlin_deps,
         experimental_report_unused_deps = ctx.attr.experimental_report_unused_deps,
         experimental_reduce_classpath_mode = ctx.attr.experimental_reduce_classpath_mode,
@@ -202,6 +203,15 @@ _kt_toolchain = rule(
             `kt_abi_plugin_incompatible`""",
             default = False,
         ),
+        "experimental_use_public_only_abi_jars": attr.bool(
+            doc = """Compile using public only abi jars.
+            This effectively applies the following two compiler plugin options.
+            plugin:org.jetbrains.kotlin.jvm.abi:treatInternalAsPrivate=true
+            plugin:org.jetbrains.kotlin.jvm.abi:removePrivateClasses=true
+            Can be disabled for an individual target using the tag.
+            `kt_abi_plugin_incompatible`""",
+            default = False,
+        ),
         "experimental_strict_kotlin_deps": attr.string(
             doc = "Report strict deps violations",
             default = "off",
@@ -288,6 +298,7 @@ def define_kt_toolchain(
         api_version = None,
         jvm_target = None,
         experimental_use_abi_jars = False,
+        experimental_use_public_only_abi_jars = False,
         experimental_strict_kotlin_deps = None,
         experimental_report_unused_deps = None,
         experimental_reduce_classpath_mode = None,
@@ -314,6 +325,7 @@ def define_kt_toolchain(
             _NOEXPERIMENTAL_USE_ABI_JARS: False,
             "//conditions:default": experimental_use_abi_jars,
         }),
+        experimental_use_public_only_abi_jars = experimental_use_public_only_abi_jars,
         experimental_multiplex_workers = experimental_multiplex_workers,
         experimental_strict_kotlin_deps = experimental_strict_kotlin_deps,
         experimental_report_unused_deps = experimental_report_unused_deps,

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -205,11 +205,11 @@ _kt_toolchain = rule(
         ),
         "experimental_use_public_only_abi_jars": attr.bool(
             doc = """Compile using public only abi jars.
-            This effectively applies the following two compiler plugin options.
-            plugin:org.jetbrains.kotlin.jvm.abi:treatInternalAsPrivate=true
-            plugin:org.jetbrains.kotlin.jvm.abi:removePrivateClasses=true
+            This effectively applies the following two compiler plugin options:
+              plugin:org.jetbrains.kotlin.jvm.abi:treatInternalAsPrivate=true
+              plugin:org.jetbrains.kotlin.jvm.abi:removePrivateClasses=true
             Can be disabled for an individual target using the tag.
-            `kt_abi_plugin_incompatible`""",
+            `kt_public_only_in_abi_plugin_incompatible`""",
             default = False,
         ),
         "experimental_strict_kotlin_deps": attr.string(

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -77,6 +77,7 @@ class KotlinBuilder
         DEBUG("--kotlin_debug_tags"),
         TASK_ID("--kotlin_task_id"),
         ABI_JAR("--abi_jar"),
+        PUBLIC_ABI_JAR("--public_only_in_abi_jar"),
         GENERATED_JAVA_SRC_JAR("--generated_java_srcjar"),
         GENERATED_JAVA_STUB_JAR("--kapt_generated_stub_jar"),
         GENERATED_CLASS_JAR("--kapt_generated_class_jar"),
@@ -161,6 +162,9 @@ class KotlinBuilder
           argMap.mandatorySingle(KotlinBuilderFlags.LANGUAGE_VERSION)
         strictKotlinDeps = argMap.mandatorySingle(KotlinBuilderFlags.STRICT_KOTLIN_DEPS)
         reducedClasspathMode = argMap.mandatorySingle(KotlinBuilderFlags.REDUCED_CLASSPATH_MODE)
+        argMap.optionalSingle(KotlinBuilderFlags.PUBLIC_ABI_JAR)?.let { includePublicOnlyInAbiJar =
+          it == "true"
+        }
         this
       }
 

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -162,8 +162,8 @@ class KotlinBuilder
           argMap.mandatorySingle(KotlinBuilderFlags.LANGUAGE_VERSION)
         strictKotlinDeps = argMap.mandatorySingle(KotlinBuilderFlags.STRICT_KOTLIN_DEPS)
         reducedClasspathMode = argMap.mandatorySingle(KotlinBuilderFlags.REDUCED_CLASSPATH_MODE)
-        argMap.optionalSingle(KotlinBuilderFlags.PUBLIC_ABI_JAR)?.let { includePublicOnlyInAbiJar =
-          it == "true"
+        argMap.optionalSingle(KotlinBuilderFlags.PUBLIC_ABI_JAR)?.let {
+          includePublicOnlyInAbiJar = it == "true"
         }
         this
       }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -77,7 +77,8 @@ class KotlinBuilder
         DEBUG("--kotlin_debug_tags"),
         TASK_ID("--kotlin_task_id"),
         ABI_JAR("--abi_jar"),
-        PUBLIC_ABI_JAR("--public_only_in_abi_jar"),
+        ABI_JAR_INTERNAL_AS_PRIVATE("--treat_internal_as_private_in_abi_jar"),
+        ABI_JAR_REMOVE_PRIVATE_CLASSES("--remove_private_classes_in_abi_jar"),
         GENERATED_JAVA_SRC_JAR("--generated_java_srcjar"),
         GENERATED_JAVA_STUB_JAR("--kapt_generated_stub_jar"),
         GENERATED_CLASS_JAR("--kapt_generated_class_jar"),
@@ -162,8 +163,11 @@ class KotlinBuilder
           argMap.mandatorySingle(KotlinBuilderFlags.LANGUAGE_VERSION)
         strictKotlinDeps = argMap.mandatorySingle(KotlinBuilderFlags.STRICT_KOTLIN_DEPS)
         reducedClasspathMode = argMap.mandatorySingle(KotlinBuilderFlags.REDUCED_CLASSPATH_MODE)
-        argMap.optionalSingle(KotlinBuilderFlags.PUBLIC_ABI_JAR)?.let {
-          includePublicOnlyInAbiJar = it == "true"
+        argMap.optionalSingle(KotlinBuilderFlags.ABI_JAR_INTERNAL_AS_PRIVATE)?.let {
+          treatInternalAsPrivateInAbiJar = it == "true"
+        }
+        argMap.optionalSingle(KotlinBuilderFlags.ABI_JAR_REMOVE_PRIVATE_CLASSES)?.let {
+          removePrivateClassesInAbiJar = it == "true"
         }
         this
       }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -87,7 +87,7 @@ class KotlinJvmTaskExecutor
                         .notEmpty {
                           plugin(plugins.jvmAbiGen) {
                             flag("outputDir", directories.abiClasses)
-                            if(info.includePublicOnlyInAbiJar) {
+                            if (info.includePublicOnlyInAbiJar) {
                               flag("removePrivateClasses", "true")
                               flag("treatInternalAsPrivate", "true")
                             }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -87,6 +87,10 @@ class KotlinJvmTaskExecutor
                         .notEmpty {
                           plugin(plugins.jvmAbiGen) {
                             flag("outputDir", directories.abiClasses)
+                            if(info.includePublicOnlyInAbiJar) {
+                              flag("removePrivateClasses", "true")
+                              flag("treatInternalAsPrivate", "true")
+                            }
                           }
                           given(outputs.jar).empty {
                             plugin(plugins.skipCodeGen)

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -87,9 +87,11 @@ class KotlinJvmTaskExecutor
                         .notEmpty {
                           plugin(plugins.jvmAbiGen) {
                             flag("outputDir", directories.abiClasses)
-                            if (info.includePublicOnlyInAbiJar) {
-                              flag("removePrivateClasses", "true")
+                            if (info.treatInternalAsPrivateInAbiJar) {
                               flag("treatInternalAsPrivate", "true")
+                            }
+                            if (info.removePrivateClassesInAbiJar) {
+                              flag("removePrivateClasses", "true")
                             }
                           }
                           given(outputs.jar).empty {

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -81,6 +81,8 @@ message CompilationTaskInfo {
     string strict_kotlin_deps = 10;
     // Optimize classpath by removing dependencies not required for compilation
     string reduced_classpath_mode = 11;
+    // Include only public symbols in abi.jar
+    bool include_public_only_in_abi_jar = 12;
 }
 
 // Nested messages not marked with stable could be refactored.

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -81,8 +81,10 @@ message CompilationTaskInfo {
     string strict_kotlin_deps = 10;
     // Optimize classpath by removing dependencies not required for compilation
     string reduced_classpath_mode = 11;
-    // Include only public symbols in abi.jar
-    bool include_public_only_in_abi_jar = 12;
+    // Internal declarations are treaded as private for abi.jar generation
+    bool treat_internal_as_private_in_abi_jar = 12;
+    // Private classes are removed in abi.jar generation
+    bool remove_private_classes_in_abi_jar = 13;
 }
 
 // Nested messages not marked with stable could be refactored.

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -229,7 +229,7 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
         }
 
         public TaskBuilder publicOnlyAbiJar() {
-            taskBuilder.getInfoBuilder().setIncludePublicOnlyInAbiJar(true);
+            taskBuilder.getInfoBuilder().setTreatInternalAsPrivateInAbiJar(true).setRemovePrivateClassesInAbiJar(true);
             return this;
         }
 

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -228,6 +228,11 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
             return this;
         }
 
+        public TaskBuilder publicOnlyAbiJar() {
+            taskBuilder.getInfoBuilder().setIncludePublicOnlyInAbiJar(true);
+            return this;
+        }
+
         public TaskBuilder generatedSourceJar() {
             taskBuilder.getOutputsBuilder()
                     .setGeneratedJavaSrcJar(instanceRoot().resolve("gen-src.jar").toAbsolutePath().toString());


### PR DESCRIPTION
Adds support for experimental options when producing abi.jar, specifically [KT-65690](https://youtrack.jetbrains.com/issue/KT-65690) and [KT-64590](https://youtrack.jetbrains.com/issue/KT-64590) as discussed in  #1245

Have added a couple of integration tests to perform basic checks of flags being applied

I expect there is more to do here and happy to work on it if its considered for merging
