### PR TITLE
Fix typo in src/main/starlark/core/compile/BUILD.release.bazel

### DIFF
--- a/src/main/starlark/core/compile/BUILD.release.bazel
+++ b/src/main/starlark/core/compile/BUILD.release.bazel
@@ -19,7 +19,7 @@ bzl_library(
     srcs = [
         "common.bzl",
     ],
-    visiblity = [
+    visibility = [
         "//visibility:public",
     ],
 )


### PR DESCRIPTION
BCR builds are failing because of this:

```
(16:19:35) ERROR: /private/var/tmp/_bazel_buildkite/2468529c3fc7810801bfdfca69cfe94c/external/rules_kotlin~2.1.0/src/main/starlark/core/compile/BUILD.bazel:17:12: @rules_kotlin~2.1.0//src/main/starlark/core/compile:compile: no such attribute 'visiblity' in 'bzl_library' rule (did you mean 'visibility'?)
```