### PR TITLE
Query the release target in the integration tests

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/test/BazelIntegrationTestRunner.kt
+++ b/src/main/kotlin/io/bazel/kotlin/test/BazelIntegrationTestRunner.kt
@@ -93,7 +93,7 @@ object BazelIntegrationTestRunner {
         "--bazelrc=$bazelrc",
         "query",
         overrideFlag,
-        "//...",
+        "@rules_kotlin//...",
         *version.workspaceFlag(bzlmod)
       ).onFailThrow()
       bazel.run(

--- a/src/main/kotlin/io/bazel/kotlin/test/BazelIntegrationTestRunner.kt
+++ b/src/main/kotlin/io/bazel/kotlin/test/BazelIntegrationTestRunner.kt
@@ -92,6 +92,14 @@ object BazelIntegrationTestRunner {
         workspace,
         "--bazelrc=$bazelrc",
         "query",
+        overrideFlag,
+        "//...",
+        *version.workspaceFlag(bzlmod)
+      ).onFailThrow()
+      bazel.run(
+        workspace,
+        "--bazelrc=$bazelrc",
+        "query",
         *version.workspaceFlag(bzlmod),
         overrideFlag,
         "kind(\".*_test\", \"//...\")",


### PR DESCRIPTION
Adding a Bazel query to make sure that the release archive is structurally sound.