### PR TITLE
Add 8.x to presubmit CI

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform: ["macos", "ubuntu2004"]
-  bazel: ["6.x", "7.x", "rolling"]
+  bazel: ["6.x", "7.x", "8.x", "rolling"]
 tasks:
   verify_targets:
     name: "Verify build targets"


### PR DESCRIPTION
Backfilling 8.x releases into our BCR pre-submit file now that the rolling releases are on 9.x.