### PR TITLE
Add .bazelbsp to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ trace.profile.gz
 .idea
 MODULE.bazel.lock
 user.bazelrc
+.bazelbsp


### PR DESCRIPTION
The Jetbrains BSP plugin it's state to this directory. Adding it to the gitignore so that these files don't accidentally get checked in.