### PR TITLE
Add support for strict associate deps

### DIFF
--- a/kotlin/internal/jvm/associates.bzl
+++ b/kotlin/internal/jvm/associates.bzl
@@ -30,14 +30,14 @@ def _collect_associates(ctx, toolchains, associate):
     them as a depset.
 
     There are two outcomes for this marco:
-    1. When `experimental_prune_transitive_deps` is enabled and the tag override has not been provided, only the
+    1. When `experimental_strict_associate_dependencies` is enabled and the tag override has not been provided, only the
         direct java_output compile jars will be collected for each associate target.
-    2. When `experimental_prune_transitive_deps` is disabled, the complete transitive set of compile jars will
+    2. When `experimental_strict_associate_dependencies` is disabled, the complete transitive set of compile jars will
         be collected for each assoicate target.
     """
     jars_depset = None
-    if (toolchains.kt.experimental_prune_transitive_deps and
-        "kt_experimental_prune_transitive_deps_incompatible" not in ctx.attr.tags):
+    if (toolchains.kt.experimental_strict_associate_dependencies and
+        "kt_experimental_strict_associate_dependencies_incompatible" not in ctx.attr.tags):
         jars_depset = depset(direct = [a.compile_jar for a in associate[JavaInfo].java_outputs])
     else:
         jars_depset = depset(transitive = [associate[JavaInfo].compile_jars])

--- a/kotlin/internal/jvm/associates.bzl
+++ b/kotlin/internal/jvm/associates.bzl
@@ -25,11 +25,28 @@ load(
     _utils = "utils",
 )
 
-def _get_associates(ctx, associates):
+def _collect_associates(ctx, toolchains, associate):
+    """Collects the associate jars from the provided dependency and returns
+    them as a depset.
+
+    There are two outcomes for this marco:
+    1. When `experimental_prune_transitive_deps` is enabled and the tag override has not been provided, only the
+        direct java_output compile jars will be collected for each associate target.
+    2. When `experimental_prune_transitive_deps` is disabled, the complete transitive set of compile jars will
+        be collected for each assoicate target.
+    """
+    jars_depset = None
+    if (toolchains.kt.experimental_prune_transitive_deps and
+        "kt_experimental_prune_transitive_deps_incompatible" not in ctx.attr.tags):
+        jars_depset = depset(direct = [a.compile_jar for a in associate[JavaInfo].java_outputs])
+    else:
+        jars_depset = depset(transitive = [associate[JavaInfo].compile_jars])
+    return jars_depset
+
+def _get_associates(ctx, toolchains, associates):
     """Creates a struct of associates meta data"""
     if not associates:
         return struct(
-            targets = [],
             module_name = _utils.derive_module_name(ctx),
             jars = depset(),
         )
@@ -39,7 +56,7 @@ def _get_associates(ctx, associates):
         jars = []
         module_names = []
         for a in associates:
-            jars.append(depset(transitive = [a[JavaInfo].compile_jars, a[_KtJvmInfo].module_jars]))
+            jars.append(_collect_associates(ctx = ctx, toolchains = toolchains, associate = a))
             module_names.append(a[_KtJvmInfo].module_name)
         module_names = list(_sets.copy_of(module_names))
 

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -115,7 +115,7 @@ def _jvm_deps(ctx, toolchains, associate_deps, deps, exports = [], runtime_deps 
         )
     dep_infos = [_java_info(d) for d in associate_deps + deps] + [toolchains.kt.jvm_stdlibs]
 
-    associates = _associate_utils.get_associates(ctx, associates = associate_deps)
+    associates = _associate_utils.get_associates(ctx, toolchains = toolchains, associates = associate_deps)
 
     # Reduced classpath, exclude transitive deps from compilation
     if (toolchains.kt.experimental_prune_transitive_deps and

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -95,6 +95,7 @@ def _kotlin_toolchain_impl(ctx):
         empty_jdeps = ctx.file._empty_jdeps,
         jacocorunner = ctx.attr.jacocorunner,
         experimental_prune_transitive_deps = ctx.attr._experimental_prune_transitive_deps[BuildSettingInfo].value,
+        experimental_strict_associate_dependencies = ctx.attr._experimental_strict_associate_dependencies[BuildSettingInfo].value,
     )
 
     return [
@@ -258,6 +259,14 @@ _kt_toolchain = rule(
             Transitive deps required for compilation must be explicitly added. Using
             kt_experimental_prune_transitive_deps_incompatible tag allows to exclude specific targets""",
             default = Label("//kotlin/settings:experimental_prune_transitive_deps"),
+        ),
+        "_experimental_strict_associate_dependencies": attr.label(
+            doc = """
+            If enabled, only the direct compile jars will be collected for each listed associate target
+            instead of the compelte transitive set of jars. This helps prevent Kotlin internals from leaking beyond
+            their intended exposure by only exposing the direct java outputs. Using
+            kt_experimental_prune_transitive_deps_incompatible tag allows to exclude specific targets""",
+            default = Label("//kotlin/settings:experimental_strict_associate_dependencies"),
         ),
         "_jvm_emit_jdeps": attr.label(default = "//kotlin/settings:jvm_emit_jdeps"),
     },

--- a/kotlin/settings/BUILD.bazel
+++ b/kotlin/settings/BUILD.bazel
@@ -25,14 +25,20 @@ release_archive(
 # Flag that controls the emission of jdeps files during kotlin jvm compilation.
 bool_flag(
     name = "jvm_emit_jdeps",
-    build_setting_default = True,
+    build_setting_default = True,  # Upstream default behavior
     visibility = ["//visibility:public"],
 )
 
-# Kotlin strict deps can be enabled by setting the following value on the command line
 # --@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps=True
 bool_flag(
     name = "experimental_prune_transitive_deps",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+# --@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies=True
+bool_flag(
+    name = "experimental_strict_associate_dependencies",
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )

--- a/kotlin/settings/BUILD.release.bazel
+++ b/kotlin/settings/BUILD.release.bazel
@@ -20,10 +20,16 @@ bool_flag(
     visibility = ["//visibility:public"],
 )
 
-# Kotlin strict deps can be enabled by setting the following value on the command line
 # --@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps=True
 bool_flag(
     name = "experimental_prune_transitive_deps",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+# --@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies=True
+bool_flag(
+    name = "experimental_strict_associate_dependencies",
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Enables support for strict Kotlin associate dependencies.

When `--@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies=True` is enabled, `rules_kotlin` will collect ONLY the direct `java_output.compile_jar` for each given associate dependency, ensuring that only the Kotlin internals for the targets explicitly listed out as associates will be exposed.

This behavior differs from what's currently in `rules_kotlin` where it collects the entire transitive compile jars classpath for each associate dependency, which technically leaks the Kotlin internals of the entire classpath for each associate dependency.

https://github.com/bazelbuild/rules_kotlin/issues/1021