### PR TITLE
Fixes for Windows issues found in the course of updating rules_jvm_external to use Starlark Android rules

### DIFF
--- a/kotlin/compiler/compiler.bzl
+++ b/kotlin/compiler/compiler.bzl
@@ -16,6 +16,15 @@ load("@com_github_jetbrains_kotlin//:artifacts.bzl", "KOTLINC_ARTIFACTS")
 load("//kotlin:jvm.bzl", "kt_jvm_import")
 load("//kotlin/internal:defs.bzl", _KT_COMPILER_REPO = "KT_COMPILER_REPO")
 
+KOTLIN_STDLIBS = [
+    "//kotlin/compiler:annotations",
+    "//kotlin/compiler:kotlin-stdlib",
+    "//kotlin/compiler:kotlin-stdlib-jdk7",
+    "//kotlin/compiler:kotlin-stdlib-jdk8",
+    "//kotlin/compiler:kotlinx-coroutines-core-jvm",
+    "//kotlin/compiler:trove4j",
+]
+
 def _import_artifacts(artifacts, rule_kind):
     _import_labels(artifacts.plugin, rule_kind)
     _import_labels(artifacts.runtime, rule_kind)

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -74,7 +74,7 @@ def _kotlin_toolchain_impl(ctx):
         kotlinbuilder = ctx.attr.kotlinbuilder,
         builder_args = [
             "--wrapper_script_flag=--main_advice_classpath=%s" % (
-                ctx.configuration.host_path_separator.join([f.short_path for f in ctx.files.jvm_stdlibs])
+                ctx.configuration.host_path_separator.join([f.path for f in ctx.files.jvm_stdlibs])
             ),
         ],
         jdeps_merger = ctx.attr.jdeps_merger,

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -74,7 +74,7 @@ def _kotlin_toolchain_impl(ctx):
         kotlinbuilder = ctx.attr.kotlinbuilder,
         builder_args = [
             "--wrapper_script_flag=--main_advice_classpath=%s" % (
-                ":".join([f.path for f in ctx.files.jvm_stdlibs])
+                ctx.configuration.host_path_separator.join([f.short_path for f in ctx.files.jvm_stdlibs])
             ),
         ],
         jdeps_merger = ctx.attr.jdeps_merger,

--- a/src/main/kotlin/io/bazel/kotlin/builder/cmd/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/builder/cmd/BUILD.bazel
@@ -1,13 +1,5 @@
+load("//kotlin/compiler:compiler.bzl", _KOTLIN_STDLIBS = "KOTLIN_STDLIBS")
 load("//src/main/kotlin:bootstrap.bzl", "kt_bootstrap_binary", "kt_bootstrap_library")
-
-_KOTLIN_STDLIBS = [
-    "//kotlin/compiler:annotations",
-    "//kotlin/compiler:kotlin-stdlib",
-    "//kotlin/compiler:kotlin-stdlib-jdk7",
-    "//kotlin/compiler:kotlin-stdlib-jdk8",
-    "//kotlin/compiler:kotlinx-coroutines-core-jvm",
-    "//kotlin/compiler:trove4j",
-]
 
 kt_bootstrap_library(
     name = "build_lib",

--- a/src/main/kotlin/io/bazel/kotlin/builder/cmd/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/builder/cmd/BUILD.bazel
@@ -1,5 +1,14 @@
 load("//src/main/kotlin:bootstrap.bzl", "kt_bootstrap_binary", "kt_bootstrap_library")
 
+_KOTLIN_STDLIBS = [
+    "//kotlin/compiler:annotations",
+    "//kotlin/compiler:kotlin-stdlib",
+    "//kotlin/compiler:kotlin-stdlib-jdk7",
+    "//kotlin/compiler:kotlin-stdlib-jdk8",
+    "//kotlin/compiler:kotlinx-coroutines-core-jvm",
+    "//kotlin/compiler:trove4j",
+]
+
 kt_bootstrap_library(
     name = "build_lib",
     srcs = ["Build.kt"],
@@ -28,7 +37,7 @@ kt_bootstrap_binary(
         "@kotlinx_serialization_core_jvm//jar",
         "@kotlinx_serialization_json//jar",
         "@kotlinx_serialization_json_jvm//jar",
-    ],
+    ] + _KOTLIN_STDLIBS,
     jvm_flags = [
         "-D@com_github_jetbrains_kotlinx...serialization-core-jvm=$(rlocationpath @kotlinx_serialization_core_jvm//jar)",
         "-D@com_github_jetbrains_kotlinx...serialization-json=$(rlocationpath @kotlinx_serialization_json//jar)",
@@ -67,7 +76,7 @@ kt_bootstrap_library(
 
 kt_bootstrap_binary(
     name = "merge_jdeps",
-    data = [],
+    data = _KOTLIN_STDLIBS,
     main_class = "io.bazel.kotlin.builder.cmd.MergeJdeps",
     shade_rules = "//src/main/kotlin:shade.jarjar",
     visibility = ["//src:__subpackages__"],

--- a/src/main/starlark/core/compile/cli/BUILD.bazel
+++ b/src/main/starlark/core/compile/cli/BUILD.bazel
@@ -21,9 +21,9 @@ _KOTLIN_STDLIBS = [
 
 java_binary(
     name = "kotlinc",
+    data = _KOTLIN_STDLIBS,
     main_class = "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler",
     runtime_deps = [":kotlinc_jar"],
-    data = _KOTLIN_STDLIBS,
 )
 
 cli_toolchain(

--- a/src/main/starlark/core/compile/cli/BUILD.bazel
+++ b/src/main/starlark/core/compile/cli/BUILD.bazel
@@ -10,24 +10,27 @@ java_import(
     deps = [],
 )
 
+_KOTLIN_STDLIBS = [
+    "//kotlin/compiler:annotations",
+    "//kotlin/compiler:kotlin-stdlib",
+    "//kotlin/compiler:kotlin-stdlib-jdk7",
+    "//kotlin/compiler:kotlin-stdlib-jdk8",
+    "//kotlin/compiler:kotlinx-coroutines-core-jvm",
+    "//kotlin/compiler:trove4j",
+]
+
 java_binary(
     name = "kotlinc",
     main_class = "org.jetbrains.kotlin.cli.jvm.K2JVMCompiler",
     runtime_deps = [":kotlinc_jar"],
+    data = _KOTLIN_STDLIBS,
 )
 
 cli_toolchain(
     name = "cli_toolchain",
     api_version = versions.KOTLIN_CURRENT_COMPILER_RELEASE.version,
     jvm_target = "11",
-    kotlin_stdlibs = [
-        "//kotlin/compiler:annotations",
-        "//kotlin/compiler:kotlin-stdlib",
-        "//kotlin/compiler:kotlin-stdlib-jdk7",
-        "//kotlin/compiler:kotlin-stdlib-jdk8",
-        "//kotlin/compiler:kotlinx-coroutines-core-jvm",
-        "//kotlin/compiler:trove4j",
-    ],
+    kotlin_stdlibs = _KOTLIN_STDLIBS,
     kotlinc = ":kotlinc",
     language_version = versions.KOTLIN_CURRENT_COMPILER_RELEASE.version,
     zip = "@bazel_tools//tools/zip:zipper",

--- a/src/main/starlark/core/compile/cli/BUILD.bazel
+++ b/src/main/starlark/core/compile/cli/BUILD.bazel
@@ -1,3 +1,4 @@
+load("//kotlin/compiler:compiler.bzl", _KOTLIN_STDLIBS = "KOTLIN_STDLIBS")
 load("//src/main/starlark/core/compile:common.bzl", "TYPE")
 load("//src/main/starlark/core/repositories:versions.bzl", "versions")
 load(":toolchain.bzl", "cli_toolchain")
@@ -9,15 +10,6 @@ java_import(
     ],
     deps = [],
 )
-
-_KOTLIN_STDLIBS = [
-    "//kotlin/compiler:annotations",
-    "//kotlin/compiler:kotlin-stdlib",
-    "//kotlin/compiler:kotlin-stdlib-jdk7",
-    "//kotlin/compiler:kotlin-stdlib-jdk8",
-    "//kotlin/compiler:kotlinx-coroutines-core-jvm",
-    "//kotlin/compiler:trove4j",
-]
 
 java_binary(
     name = "kotlinc",

--- a/src/main/starlark/core/compile/cli/compile.bzl
+++ b/src/main/starlark/core/compile/cli/compile.bzl
@@ -31,7 +31,7 @@ def compile_kotlin_for_jvm(
 
     # Set the stdlib for the compiler to run on.
     args = actions.args().add("--wrapper_script_flag=--main_advice_classpath=%s" % (
-        ":".join([f.path for f in toolchain_info.kotlin_stdlib.transitive_compile_time_jars.to_list()])
+        path_separator.join([f.short_path for f in toolchain_info.kotlin_stdlib.transitive_compile_time_jars.to_list()])
     ))
     args.add("-d", class_jar)
     args.add("-jdk-home", toolchain_info.java_runtime.java_home)

--- a/src/main/starlark/core/compile/cli/compile.bzl
+++ b/src/main/starlark/core/compile/cli/compile.bzl
@@ -31,7 +31,7 @@ def compile_kotlin_for_jvm(
 
     # Set the stdlib for the compiler to run on.
     args = actions.args().add("--wrapper_script_flag=--main_advice_classpath=%s" % (
-        path_separator.join([f.short_path for f in toolchain_info.kotlin_stdlib.transitive_compile_time_jars.to_list()])
+        path_separator.join([f.path for f in toolchain_info.kotlin_stdlib.transitive_compile_time_jars.to_list()])
     ))
     args.add("-d", class_jar)
     args.add("-jdk-home", toolchain_info.java_runtime.java_home)


### PR DESCRIPTION
In the course of updating rules_jvm_external to use the Starlark Android rules here: https://github.com/bazel-contrib/rules_jvm_external/pull/1297 a couple issues were found in rules_jvm_external's Windows tests:

1) Use platform-specific path separators
2) Add Kotlin standard library jars to the `data` of tool targets so that the Windows Java launcher can find them in the runfiles manifest

This fixes issues like this in Kotlin tools:
`LAUNCHER ERROR: Rlocation failed on _main/external/rules_kotlin++rules_kotlin_extensions+com_github_jetbrains_kotlin_git/lib/annotations-13.0.jar, path doesn't exist in MANIFEST file`