### PR TITLE
Resolve #1168 by way of a makeshift, in absence of better isolation of the ksp environment.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -52,8 +52,8 @@ maven.install(
     artifacts = [
         "com.google.code.findbugs:jsr305:3.0.2",
         "junit:junit:4.13-beta-3",
-        "com.google.protobuf:protobuf-java:3.6.0",
-        "com.google.protobuf:protobuf-java-util:3.6.0",
+        "com.google.protobuf:protobuf-java:3.25.6",
+        "com.google.protobuf:protobuf-java-util:3.26.6",
         "com.google.guava:guava:27.1-jre",
         "com.google.truth:truth:0.45",
         "com.google.auto.service:auto-service:1.1.1",

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/CompilationTaskContext.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/CompilationTaskContext.kt
@@ -93,7 +93,7 @@ class CompilationTaskContext(
     header: String,
     msg: MessageOrBuilder,
   ) {
-    printLines(header, TextFormat.printToString(msg).split("\n"), filterEmpty = true)
+    printLines(header, TextFormat.printer().printToString(msg).split("\n"), filterEmpty = true)
   }
 
   /**

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
@@ -234,8 +234,10 @@ class KotlinToolchain private constructor(
         },
         Preloader.DEFAULT_CLASS_NUMBER_ESTIMATE,
         classLoader,
-        null,
-      )
+      ) { className ->
+        // Preload guava to avoid weird isolation issues.
+        className.startsWith("com.google.common.")
+      }
     }.onFailure {
       throw RuntimeException("$javaHome, $baseJars", it)
     }.getOrThrow()


### PR DESCRIPTION
Guava is used in a lot of different environments. This causes classloader problems at times, in that parts of guava get loaded early, but other parts are loaded late, in other classloaders, and you end up with conflicts around the boundary.

In #1168 @xinzhengzhang suggested a fix (implemented here) to preload guava, so it is fully loaded and can be resolved without crossing classloader boundaries.

While better classloader isolation is preferable, this at least unblocks folks while a more robust isolation scheme is explored. 