### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,7 @@ Additionally, you can add options for both tracing and timing of the bazel build
 KSP is officially supported as of `rules_kotlin` 1.8 and can be declared using the new
 `kt_ksp_plugin` rule. 
 
-A few things to note:
-- As of now `rules_kotlin` only supports KSP plugins that generate Kotlin code.
+Note:
 - KSP is [not yet thread safe](https://github.com/google/ksp/issues/1385) and will likely fail if you are using it in a build that has multiplex workers enabled. To work around this add the following flag to your Bazelrc:
   ```
   build --experimental_worker_max_multiplex_instances=KotlinKsp=1


### PR DESCRIPTION
As of bazelbuild/rules_kotlin#1139 ksp plugins which generate Java seem to be supported.