### PR TITLE
Limit compiler version target to (major, minor) for capabilities

### DIFF
--- a/src/main/starlark/core/repositories/compiler.bzl
+++ b/src/main/starlark/core/repositories/compiler.bzl
@@ -70,6 +70,8 @@ def _parse_version(basename):
 def _get_capability_template(compiler_version, templates):
     version_index = {}
     target = _version(compiler_version)
+    if len(target) > 2:
+        target = target[0:2]
     for template in templates:
         version = _parse_version(template.basename)
         if not version:


### PR DESCRIPTION
Otherwise, this fails when specifying a compiler version with a patch version. Specifying a patch version is important for e.g. Jetpack Compose, where versions are tied explicitly to compiler verions specifying the patch version. But AFAIK we shoudln't need to distinguish different capabilities across patch versions.