### PR TITLE
Fix android_sdk import path to use rules_android

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -77,7 +77,7 @@ java_binary(
 # TODO(bazelbuild/rules_kotlin/issues/273): Remove android_sdk import.
 java_import(
     name = "android_sdk",
-    jars = ["@bazel_tools//tools/android:android_jar"],
+    jars = ["@rules_android//tools/android:android_jar"],
     neverlink = 1,
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This change updates the `android_sdk` import path in the `third_party/BUILD` file of `rules_kotlin` to use the `rules_android` repository instead of the deprecated `bazel_tools` path. This is necessary for compatibility with Bazel 8.x, as the target `@bazel_tools//tools/android:android_jar` is no longer usable.

Fixes #1291 