### PR TITLE
Invert withTracing log output

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
@@ -278,7 +278,7 @@ private fun JvmCompilationTask.runKaptPlugin(
         context.executeCompilerTask(
           args,
           compiler::compile,
-          printOnSuccess = context.whenTracing { false } ?: true,
+          printOnSuccess = context.whenTracing { true } ?: false,
         )
       }.let { outputLines ->
         // if tracing is enabled the output should be formatted in a special way, if we aren't
@@ -315,7 +315,7 @@ private fun JvmCompilationTask.runKspPlugin(
         context.executeCompilerTask(
           args,
           compiler::compile,
-          printOnSuccess = context.whenTracing { false } ?: true,
+          printOnSuccess = context.whenTracing { true } ?: false,
         )
       }.let { outputLines ->
         // if tracing is enabled the output should be formatted in a special way, if we aren't


### PR DESCRIPTION
It seems that the booleans are inverted here for `printOnSuccess` as the compilation output is quite verbose for KSP and KAPT compilations. This logic also seems to mirror how tracing is intended to print in the rest of the codebase.