### PR TITLE
README + Release Note Refresh

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -35,5 +35,11 @@ http_archive(
     sha256 = "${SHA}",
     url = "https://github.com/bazelbuild/rules_kotlin/releases/download/${TAG}/${ARCHIVE}",
 )
+
+load("@rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")
+kotlin_repositories() # if you want the default. Otherwise see custom kotlinc distribution below
+
+load("@rules_kotlin//kotlin:core.bzl", "kt_register_toolchains")
+kt_register_toolchains() # to use the default toolchain, otherwise see toolchains below
 \`\`\`
 EOF

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ Generated API documentation is available at
 
 # Quick Guide
 
-## `WORKSPACE`
+## Installation
+Copy from the
+[release you wish to use](https://github.com/bazelbuild/rules_kotlin/releases) either the Bzlmod or WORKSPACE snippet into your `MODULE.bazel` or `WORKSPACE` file respectively.
+
+### `WORKSPACE`
 In the project's `WORKSPACE`, declare the external repository and initialize the toolchains, like
 this:
 
@@ -116,6 +120,17 @@ register_toolchains("//:kotlin_toolchain")
 To choose a different `kotlinc` distribution (1.3 and 1.4 variants supported), do the following
 in your `WORKSPACE` file (or import from a `.bzl` file:
 
+### `MODULE.bazel`
+```python
+rules_kotlin_extensions = use_extension("@rules_kotlin//src/main/starlark/core/repositories:bzlmod_setup.bzl", "rules_kotlin_extensions")
+rules_kotlin_extensions.kotlinc_version(
+    version = "1.6.21", # just the numeric version
+    sha256 = "632166fed89f3f430482f5aa07f2e20b923b72ef688c8f5a7df3aa1502c6d8ba"
+)
+use_repo(rules_kotlin_extensions, "com_github_google_ksp", "com_github_jetbrains_kotlin", "com_github_jetbrains_kotlin_git", "com_github_pinterest_ktlint", "kotlinx_serialization_core_jvm", "kotlinx_serialization_json", "kotlinx_serialization_json_jvm")
+```
+
+### `WORKSPACE`
 ```python
 load("@rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "kotlinc_version")
 
@@ -288,7 +303,19 @@ kt_jvm_library(
 ```
 
 To choose a different `ksp_version` distribution,
-do the following in your `WORKSPACE` file (or import from a `.bzl` file):
+do the following in your repository.
+
+### `MODULE.bazel`
+```python
+rules_kotlin_extensions = use_extension("@rules_kotlin//src/main/starlark/core/repositories:bzlmod_setup.bzl", "rules_kotlin_extensions")
+rules_kotlin_extensions.ksp_version(
+    version = "1.8.22-1.0.11",
+    sha256 = "2ce5a08fddd20ef07ac051615905453fe08c3ba3ce5afa5dc43a9b77aa64507d",
+)
+use_repo(rules_kotlin_extensions, "com_github_google_ksp", "com_github_jetbrains_kotlin", "com_github_jetbrains_kotlin_git", "com_github_pinterest_ktlint", "kotlinx_serialization_core_jvm", "kotlinx_serialization_json", "kotlinx_serialization_json_jvm")
+```
+
+### `WORKSPACE` (or import from a `.bzl` file):
 
 ```python
 load("@rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories", "ksp_version")


### PR DESCRIPTION
I noticed that the `README.md` didn't contain any details about bzlmod support + integration so thought it'd be nice to give it a small refresh.

It looked like the repo integration snippet was also out of date so I decided to point it at the releases page instead like many other rulesets do; however it required adding in some of the extra repo function calls. I updated the release prep script with this and left the existing `WORKSPACE` integration snippet for now until the next release is cut with those added function calls.