### PR TITLE
Update JC plugin to support AS Layout Inspector

### DIFF
--- a/examples/jetpack_compose/BUILD
+++ b/examples/jetpack_compose/BUILD
@@ -18,7 +18,10 @@ define_kt_toolchain(
 
 kt_compiler_plugin(
     name = "jetpack_compose_compiler_plugin",
-    id = "androidx.compose.compiler",
+    id = "androidx.compose.compiler.plugins.kotlin",
+    options = {
+        "sourceInformation": "true",  # Required for AS Layout Inspector, disable for release builds
+    },
     target_embedded_compiler = True,
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
### What has changed
- Updated JC plugin id to correct one
- Added `sourceInformation` option for JC compiler plugin

> If true, include source information in generated code.
> 
> Records source information that can be used for tooling to determine the source location of the corresponding composable function. This option does not affect the presence of symbols or line information normally added by the Kotlin compiler; it only controls source information added by the Compose compiler.

### Why this was changed
- To support Compose recompositon tracking in AS Layout Inspector
- With gradle it's being handled by AGP:
https://android.googlesource.com/platform/tools/base/+/refs/heads/mirror-goog-studio-master-dev/build-system/gradle-core/src/main/java/com/android/build/gradle/internal/utils/kgpUtils.kt#149

### Requires
https://github.com/bazelbuild/rules_android/pull/356