### PR TITLE
Kotlin 2.1.10+ prep

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/JdepsK2Utils.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/JdepsK2Utils.kt
@@ -21,7 +21,6 @@ private object RefCache {
   }
 }
 
-
 /**
  * Returns whether class is coming from JVM runtime env. There is no need to track these classes.
  *
@@ -45,11 +44,9 @@ internal fun SourceElement.binaryClass(): String? =
   } else if (this is JvmPackagePartSource) {
     this.knownJvmBinaryClass?.location
   } else if (RefCache.jbseClass != null && RefCache.jbseClass!!.isInstance(this)) {
-    val jClass = RefCache.jbseGetJavaClassMethod?.invoke(this)
-    val virtualFile = jClass?.javaClass?.getMethod("getVirtualFile")?.invoke(jClass)
-    val s = virtualFile?.javaClass?.getMethod("getPath")?.invoke(virtualFile) as? String
-    require(s == (this as JavaBinarySourceElement).javaClass.virtualFile.path)
-    s
+    val jClass = RefCache.jbseGetJavaClassMethod!!.invoke(this)
+    val virtualFile = jClass!!.javaClass.getMethod("getVirtualFile").invoke(jClass)
+    virtualFile.javaClass.getMethod("getPath").invoke(virtualFile) as? String
   } else {
     null
   }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/JdepsK2Utils.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/JdepsK2Utils.kt
@@ -1,7 +1,6 @@
 package io.bazel.kotlin.plugin.jdeps.k2
 
 import org.jetbrains.kotlin.descriptors.SourceElement
-import org.jetbrains.kotlin.fir.java.JavaBinarySourceElement
 import org.jetbrains.kotlin.load.kotlin.JvmPackagePartSource
 import org.jetbrains.kotlin.load.kotlin.KotlinJvmBinarySourceElement
 import org.jetbrains.kotlin.name.ClassId
@@ -15,9 +14,10 @@ private object RefCache {
   }
 
   val jbseGetJavaClassMethod by lazy {
-    jbseClass?.runCatching {
-      getMethod("getJavaClass")
-    }?.getOrNull()
+    jbseClass
+      ?.runCatching {
+        getMethod("getJavaClass")
+      }?.getOrNull()
   }
 }
 


### PR DESCRIPTION
Kotlin 2.1.10 introduced a breaking change where a class that we depend on in `JdepsK2Utils` was renamed and the way you access the virtual file has changed.  Moving over to reflection for backwards compatibility until we can cut ties with the previous class.