### PR TITLE
Resolve compiler warning

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -175,23 +175,21 @@ class JdepsGenExtension(
 
       // Finally, collect types that depend on the type of the ResultingDescriptor and note that
       // these descriptors may be composed of multiple classes that we need to extract types from
-      if (resultingDescriptor is DeclarationDescriptor) {
-        val containingDeclaration = resultingDescriptor.containingDeclaration
-        if (containingDeclaration is ClassDescriptor) {
-          collectTypeReferences(containingDeclaration.defaultType)
-        }
+      val containingDeclaration = resultingDescriptor.containingDeclaration
+      if (containingDeclaration is ClassDescriptor) {
+        collectTypeReferences(containingDeclaration.defaultType)
+      }
 
-        if (resultingDescriptor is PropertyDescriptor) {
-          (
-            resultingDescriptor.getter
-              ?.correspondingProperty as? SyntheticJavaPropertyDescriptor
-          )?.let { syntheticJavaPropertyDescriptor ->
-            collectTypeReferences(syntheticJavaPropertyDescriptor.type, isExplicit = false)
+      if (resultingDescriptor is PropertyDescriptor) {
+        (
+          resultingDescriptor.getter
+            ?.correspondingProperty as? SyntheticJavaPropertyDescriptor
+        )?.let { syntheticJavaPropertyDescriptor ->
+          collectTypeReferences(syntheticJavaPropertyDescriptor.type, isExplicit = false)
 
-            val functionDescriptor = syntheticJavaPropertyDescriptor.getMethod
-            functionDescriptor.dispatchReceiverParameter?.type?.let { dispatchReceiverType ->
-              collectTypeReferences(dispatchReceiverType, isExplicit = false)
-            }
+          val functionDescriptor = syntheticJavaPropertyDescriptor.getMethod
+          functionDescriptor.dispatchReceiverParameter?.type?.let { dispatchReceiverType ->
+            collectTypeReferences(dispatchReceiverType, isExplicit = false)
           }
         }
       }


### PR DESCRIPTION
I've been getting Kotlin compiler warnings for quite some time about `resultingDescriptor is DeclarationDescriptor` always being true, so going to just remove this check for now. 