### PR TITLE
Add x_suppress_warning to kotlinc options

### DIFF
--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -387,8 +387,8 @@ kt_kotlinc_options(<a href="#kt_kotlinc_options-name">name</a>, <a href="#kt_kot
                    <a href="#kt_kotlinc_options-x_lambdas">x_lambdas</a>, <a href="#kt_kotlinc_options-x_multi_platform">x_multi_platform</a>, <a href="#kt_kotlinc_options-x_no_call_assertions">x_no_call_assertions</a>, <a href="#kt_kotlinc_options-x_no_optimize">x_no_optimize</a>,
                    <a href="#kt_kotlinc_options-x_no_param_assertions">x_no_param_assertions</a>, <a href="#kt_kotlinc_options-x_no_receiver_assertions">x_no_receiver_assertions</a>, <a href="#kt_kotlinc_options-x_no_source_debug_extension">x_no_source_debug_extension</a>,
                    <a href="#kt_kotlinc_options-x_optin">x_optin</a>, <a href="#kt_kotlinc_options-x_report_perf">x_report_perf</a>, <a href="#kt_kotlinc_options-x_sam_conversions">x_sam_conversions</a>, <a href="#kt_kotlinc_options-x_skip_prerelease_check">x_skip_prerelease_check</a>,
-                   <a href="#kt_kotlinc_options-x_suppress_version_warnings">x_suppress_version_warnings</a>, <a href="#kt_kotlinc_options-x_type_enhancement_improvements_strict_mode">x_type_enhancement_improvements_strict_mode</a>,
-                   <a href="#kt_kotlinc_options-x_use_fir_lt">x_use_fir_lt</a>, <a href="#kt_kotlinc_options-x_use_k2">x_use_k2</a>)
+                   <a href="#kt_kotlinc_options-x_suppress_version_warnings">x_suppress_version_warnings</a>, <a href="#kt_kotlinc_options-x_suppress_warning">x_suppress_warning</a>,
+                   <a href="#kt_kotlinc_options-x_type_enhancement_improvements_strict_mode">x_type_enhancement_improvements_strict_mode</a>, <a href="#kt_kotlinc_options-x_use_fir_lt">x_use_fir_lt</a>, <a href="#kt_kotlinc_options-x_use_k2">x_use_k2</a>)
 </pre>
 
 Define kotlin compiler options.
@@ -427,6 +427,7 @@ Define kotlin compiler options.
 | <a id="kt_kotlinc_options-x_sam_conversions"></a>x_sam_conversions |  Change codegen behavior of SAM/functional interfaces   | String | optional |  `"class"`  |
 | <a id="kt_kotlinc_options-x_skip_prerelease_check"></a>x_skip_prerelease_check |  Suppress errors thrown when using pre-release classes.   | Boolean | optional |  `False`  |
 | <a id="kt_kotlinc_options-x_suppress_version_warnings"></a>x_suppress_version_warnings |  Suppress warnings about outdated, inconsistent, or experimental language or API versions.   | Boolean | optional |  `False`  |
+| <a id="kt_kotlinc_options-x_suppress_warning"></a>x_suppress_warning |  Suppress specific warnings globally   | List of strings | optional |  `[]`  |
 | <a id="kt_kotlinc_options-x_type_enhancement_improvements_strict_mode"></a>x_type_enhancement_improvements_strict_mode |  Enables strict mode for type enhancement improvements, enforcing stricter type checking and enhancements.   | Boolean | optional |  `False`  |
 | <a id="kt_kotlinc_options-x_use_fir_lt"></a>x_use_fir_lt |  Compile using LightTree parser with Front-end IR. Warning: this feature is far from being production-ready   | Boolean | optional |  `False`  |
 | <a id="kt_kotlinc_options-x_use_k2"></a>x_use_k2 |  Compile using experimental K2. K2 is a new compiler pipeline, no compatibility guarantees are yet provided   | Boolean | optional |  `False`  |

--- a/src/main/starlark/core/options/opts.javac.bzl
+++ b/src/main/starlark/core/options/opts.javac.bzl
@@ -90,7 +90,7 @@ _JOPTS = {
     "add_exports": struct(
         args = dict(
             default = [],
-            doc = "Export internal jdk apis ",
+            doc = "Export internal jdk apis",
         ),
         type = attr.string_list,
         value_to_flag = {

--- a/src/main/starlark/core/options/opts.kotlinc.bzl
+++ b/src/main/starlark/core/options/opts.kotlinc.bzl
@@ -14,6 +14,7 @@
 
 load("@com_github_jetbrains_kotlin//:capabilities.bzl", _KOTLIN_OPTS = "KOTLIN_OPTS")
 load("//src/main/starlark/core/options:convert.bzl", "convert")
+load("//src/main/starlark/core/options:derive.bzl", "derive")
 
 def _map_optin_class_to_flag(values):
     return ["-opt-in=%s" % v for v in values]
@@ -428,6 +429,16 @@ _KOPTS_ALL = {
         type = attr.string,
         value_to_flag = None,
         map_value_to_flag = _map_jdk_release_to_flag,
+    ),
+    "x_suppress_warning": struct(
+        args = dict(
+            default = [],
+            doc = "Suppress specific warnings globally",
+        ),
+        type = attr.string_list,
+        value_to_flag = {
+            derive.info: derive.repeated_values_for("-Xsuppress-warning="),
+        },
     ),
 }
 


### PR DESCRIPTION
In [Kotlin 2.1](https://youtrack.jetbrains.com/issue/KT-8087/Make-it-possible-to-suppress-warnings-globally-in-compiler-via-command-line-option) they added the [SuppressWarning option](https://kotlinlang.org/docs/compiler-reference.html#xsuppress-warning) that allows you to globally suppress specific Kotlin warning with a Kotlin compiler option.

Once Kotlin 2.2 is supported we can change this to [-Xwarning-level](https://youtrack.jetbrains.com/issue/KT-73606/Provide-a-unified-interface-for-managing-the-reporting-of-compiler-warnings#focus=Comments-27-11596919.0-0) instead 