### PR TITLE
Use `export_files` to export the KSP JAR files

### DIFF
--- a/src/main/starlark/core/repositories/BUILD.com_github_google_ksp.bazel
+++ b/src/main/starlark/core/repositories/BUILD.com_github_google_ksp.bazel
@@ -13,8 +13,16 @@
 # limitations under the License.
 package(default_visibility = ["//visibility:public"])
 
-# KSP filegroup containing everything that might be needed
+# Collect list of all KSP files that might be needed
+_KSP_FILES = glob(["**"])
+
+# KSP filegroup containing all KSP files to export
 filegroup(
     name = "ksp",
-    srcs = glob(["**"]),
+    srcs = _KSP_FILES,
 )
+
+# If the `--incompatible_no_implicit_file_export` option is enabled, then the
+# individual "srcs" from the "ksp" filegroup will not be visible, so also
+# export them with `export_files` to ensure that they are made public.
+exports_files(_KSP_FILES)


### PR DESCRIPTION
This fixes the`target '@@rules_kotlin~~rules_kotlin_extensions~com_github_google_ksp//:symbol-processing-cmdline.jar' is not visible from target '@@rules_kotlin~//kotlin/compiler:symbol-processing-cmdline'` error described in [my comment](https://github.com/bazelbuild/rules_kotlin/issues/1193#issuecomment-2912995135) on bazelbuild/rules_kotlin#1193.

The legacy behavior of Bazel is that input source files are implicitly exported with the `default_visibility` specified in the `BUILD` file.  The `--incompatible_no_implicit_file_export` option disables this legacy behavior, making all input source files private by default, and the Bazel documentation recommends that files should always be exported explicitly if they are needed outside the current package:

> Avoid relying on the legacy behavior. Always write an `exports_files` declaration whenever a source file target needs non-private visibility.

(see https://bazel.build/concepts/visibility#source-file-target-visibility)

I was not able to reproduce the similar `target 'symbol-processing-cmdline.jar' not declared in package  '' defined by D:/bazel_tmp/33apilyc/external/com_github_google_ksp/BUILD.bazel` error that was also mentioned in bazelbuild/rules_kotlin#1193 for `rules_kotlin` version 1.9.6, so I cannot confirm if this fix also addresses that error.