### PR TITLE
Apply equivalent of changes from 4e3b18e to release build file

### DIFF
--- a/src/main/kotlin/BUILD.release.bazel
+++ b/src/main/kotlin/BUILD.release.bazel
@@ -76,6 +76,14 @@ java_binary(
 
 java_binary(
     name = "jdeps_merger",
+	data = [
+	  "@com_github_jetbrains_kotlin//:annotations",
+	  "@com_github_jetbrains_kotlin//:kotlin-stdlib",
+	  "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk7",
+	  "@com_github_jetbrains_kotlin//:kotlin-stdlib-jdk8",
+	  "@com_github_jetbrains_kotlin//:kotlinx-coroutines-core-jvm",
+	  "@com_github_jetbrains_kotlin//:trove4j",
+	],
     jvm_flags = [
         "-XX:-MaxFDLimit",
     ],


### PR DESCRIPTION
Add the equivalent to the changes to the development BUILD files in https://github.com/ahumesky/rules_kotlin/commit/4e3b18e552a62eca2f727b7fe6950ee3a3a506a2 to the release BUILD file for jdeps_merger. Fixes for https://github.com/bazel-contrib/rules_jvm_external/pull/1297