### PR TITLE
Fix #1330 : Include associates transitive compile jars in classpath

### DIFF
--- a/kotlin/internal/jvm/jvm_deps.bzl
+++ b/kotlin/internal/jvm/jvm_deps.bzl
@@ -41,6 +41,9 @@ def _jvm_deps(ctx, toolchains, associate_deps, deps, exports = [], runtime_deps 
         ] + [
             d.transitive_compile_time_jars
             for d in dep_infos
+        ] + [
+            d.transitive_compile_time_jars
+            for d in associates.dep_infos
         ]
 
     compile_depset_list = depset(transitive = transitive + [associates.jars]).to_list()


### PR DESCRIPTION
This PR fixes #1330

Previously the dep infos iterated over here
```
[
    d.transitive_compile_time_jars
     for d in dep_infos
  ]
```
        
included the associate dep infos thus all their transitive deps were available on the classpath.

This PR adds this back whilst still keeping any ABI jars of associates out of the classpath

I have written a test and seen it fail before applying the fix.

The scenario is as follows

```
    target A associates with target B
    target B has a dependency to target C
    target A uses C
```
    
what this means is the associates transitive_compile_time_jars has something a bit like this

```
  <generated file B.jar>,
  <generated file C.jar>,
  <source file various-sdk-libs.jar>
```


