### PR TITLE
Fix typo in kt_android_library_impl

### DIFF
--- a/kotlin/internal/jvm/kt_android_library_impl.bzl
+++ b/kotlin/internal/jvm/kt_android_library_impl.bzl
@@ -147,7 +147,7 @@ def _kt_android_produce_jar_actions(
         compile_deps = compile_deps,
         outputs = outputs,
         extra_resources = extra_resources,
-    ) if ctx.attr.srcs else _compile.compile.export_only_providers(
+    ) if ctx.attr.srcs else _compile.export_only_providers(
         ctx = ctx,
         actions = ctx.actions,
         outputs = outputs,


### PR DESCRIPTION
Quick fix that didn't make it into the prior pull request https://github.com/bazelbuild/rules_kotlin/pull/1333