### PR TITLE
Ensure that associates are being included in the source dep_infos list

### DIFF
--- a/kotlin/internal/jvm/jvm_deps.bzl
+++ b/kotlin/internal/jvm/jvm_deps.bzl
@@ -56,7 +56,7 @@ def _jvm_deps(ctx, toolchains, associate_deps, deps = [], deps_java_infos = [], 
 
     return struct(
         module_name = associates.module_name,
-        deps = dep_infos + associates.dep_infos,
+        deps = dep_infos,
         exports = [_java_info(d) for d in exports],
         associate_jars = associates.jars,
         compile_jars = depset(direct = compile_depset_list_filtered),

--- a/kotlin/internal/jvm/jvm_deps.bzl
+++ b/kotlin/internal/jvm/jvm_deps.bzl
@@ -23,9 +23,17 @@ def _java_info(target):
 
 def _jvm_deps(ctx, toolchains, associate_deps, deps = [], deps_java_infos = [], exports = [], runtime_deps = []):
     """Encapsulates jvm dependency metadata."""
-    dep_infos = deps_java_infos + [_java_info(d) for d in deps] + [toolchains.kt.jvm_stdlibs]
-
-    associates = _associate_utils.get_associates(ctx, toolchains = toolchains, associates = associate_deps)
+    associates = _associate_utils.get_associates(
+        ctx,
+        toolchains = toolchains,
+        associates = associate_deps,
+    )
+    dep_infos = (
+        [toolchains.kt.jvm_stdlibs] +
+        associates.dep_infos +
+        deps_java_infos +
+        [_java_info(d) for d in deps]
+    )
 
     # Reduced classpath, exclude transitive deps from compilation
     if (toolchains.kt.experimental_prune_transitive_deps and
@@ -41,9 +49,6 @@ def _jvm_deps(ctx, toolchains, associate_deps, deps = [], deps_java_infos = [], 
         ] + [
             d.transitive_compile_time_jars
             for d in dep_infos
-        ] + [
-            d.transitive_compile_time_jars
-            for d in associates.dep_infos
         ]
 
     compile_depset_list = depset(transitive = transitive + [associates.jars]).to_list()


### PR DESCRIPTION
Ensuring that the top-level dep_infos list contains the complete set of deps collected from both `associates` and `deps`. Without this we have modules in our codebase that fail to compile due to jars missing from the classpath.

I'm only able to encounter this issue with `experimental_prune_transitive_deps` enabled, which makes sense seeing as the non-pruning mode explicitly collects the transitive compile jars from associates.