### PR TITLE
Use the jacoco_coverage_runner provided by remote_java_tools

### DIFF
--- a/kotlin/internal/jvm/kt_android_local_test.bzl
+++ b/kotlin/internal/jvm/kt_android_local_test.bzl
@@ -42,7 +42,7 @@ _ATTRS = _utils.add_dicts(_BASE_ATTRS, _attrs.runnable_common_attr, {
         default = "com.google.testing.junit.runner.BazelTestRunner",
     ),
     "jacocorunner": attr.label(
-        default = Label("@bazel_tools//tools/jdk:JacocoCoverage"),
+        default = Label("@remote_java_tools//:jacoco_coverage_runner"),
     ),
     "_lcov_merger": attr.label(
         cfg = "exec",


### PR DESCRIPTION
Updating the kt_android rules to pull `jacoco_coverage_runner` from the `remote_java_tools`.