### PR TITLE
Add support for experimental `removeDebugInfo`  flag

### DIFF
--- a/CompileAvoidance.md
+++ b/CompileAvoidance.md
@@ -54,6 +54,19 @@ define_kt_toolchain(
 )
 ```
 
+To completely remove debug information from the ABI jar, the `experimental_remove_debug_info_in_abi_jars` flag can be used along with `experimental_use_abi_jars`
+
+```python
+load("//kotlin:core.bzl", "define_kt_toolchain")
+
+
+define_kt_toolchain(
+    name = "kotlin_toolchain",
+    experimental_use_abi_jars = True,
+    experimental_remove_debug_info_in_abi_jars = True,
+)
+```
+
 If you encounter bugs in older compiler versions such as [KT-71525](https://youtrack.jetbrains.com/issue/KT-71525) then ABI generation with only public symbols can be disabled on a per target basis by setting the following tags
 
 ```python
@@ -61,6 +74,10 @@ load("//kotlin:jvm.bzl", "kt_jvm_library")
 
 kt_jvm_library(
     name = "framework",
-    tags = ["kt_treat_internal_as_private_in_abi_plugin_incompatible", "kt_remove_private_classes_in_abi_plugin_incompatible"],
+    tags = [
+        "kt_treat_internal_as_private_in_abi_plugin_incompatible", 
+        "kt_remove_private_classes_in_abi_plugin_incompatible", 
+        "kt_remove_debug_info_in_abi_plugin_incompatible"
+    ],
 )
 ```

--- a/CompileAvoidance.md
+++ b/CompileAvoidance.md
@@ -54,7 +54,7 @@ define_kt_toolchain(
 )
 ```
 
-To completely remove debug information from the ABI jar, the `experimental_remove_debug_info_in_abi_jars` flag can be used along with `experimental_use_abi_jars`
+In order to completely remove debug information from the ABI jar, the `experimental_remove_debug_info_in_abi_jars` flag can be used along with `experimental_use_abi_jars`
 
 ```python
 load("//kotlin:core.bzl", "define_kt_toolchain")

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -513,7 +513,8 @@ load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
 
 define_kt_toolchain(<a href="#define_kt_toolchain-name">name</a>, <a href="#define_kt_toolchain-language_version">language_version</a>, <a href="#define_kt_toolchain-api_version">api_version</a>, <a href="#define_kt_toolchain-jvm_target">jvm_target</a>, <a href="#define_kt_toolchain-experimental_use_abi_jars">experimental_use_abi_jars</a>,
                     <a href="#define_kt_toolchain-experimental_treat_internal_as_private_in_abi_jars">experimental_treat_internal_as_private_in_abi_jars</a>,
-                    <a href="#define_kt_toolchain-experimental_remove_private_classes_in_abi_jars">experimental_remove_private_classes_in_abi_jars</a>, <a href="#define_kt_toolchain-experimental_strict_kotlin_deps">experimental_strict_kotlin_deps</a>,
+                    <a href="#define_kt_toolchain-experimental_remove_private_classes_in_abi_jars">experimental_remove_private_classes_in_abi_jars</a>,
+                    <a href="#define_kt_toolchain-experimental_remove_debug_info_in_abi_jars">experimental_remove_debug_info_in_abi_jars</a>, <a href="#define_kt_toolchain-experimental_strict_kotlin_deps">experimental_strict_kotlin_deps</a>,
                     <a href="#define_kt_toolchain-experimental_report_unused_deps">experimental_report_unused_deps</a>, <a href="#define_kt_toolchain-experimental_reduce_classpath_mode">experimental_reduce_classpath_mode</a>,
                     <a href="#define_kt_toolchain-experimental_multiplex_workers">experimental_multiplex_workers</a>, <a href="#define_kt_toolchain-experimental_build_tools_api">experimental_build_tools_api</a>, <a href="#define_kt_toolchain-javac_options">javac_options</a>,
                     <a href="#define_kt_toolchain-kotlinc_options">kotlinc_options</a>, <a href="#define_kt_toolchain-jvm_stdlibs">jvm_stdlibs</a>, <a href="#define_kt_toolchain-jvm_runtime">jvm_runtime</a>, <a href="#define_kt_toolchain-jacocorunner">jacocorunner</a>, <a href="#define_kt_toolchain-exec_compatible_with">exec_compatible_with</a>,
@@ -534,6 +535,7 @@ Define the Kotlin toolchain.
 | <a id="define_kt_toolchain-experimental_use_abi_jars"></a>experimental_use_abi_jars |  <p align="center"> - </p>   |  `False` |
 | <a id="define_kt_toolchain-experimental_treat_internal_as_private_in_abi_jars"></a>experimental_treat_internal_as_private_in_abi_jars |  <p align="center"> - </p>   |  `False` |
 | <a id="define_kt_toolchain-experimental_remove_private_classes_in_abi_jars"></a>experimental_remove_private_classes_in_abi_jars |  <p align="center"> - </p>   |  `False` |
+| <a id="define_kt_toolchain-experimental_remove_debug_info_in_abi_jars"></a>experimental_remove_debug_info_in_abi_jars |  <p align="center"> - </p>   |  `False` |
 | <a id="define_kt_toolchain-experimental_strict_kotlin_deps"></a>experimental_strict_kotlin_deps |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_report_unused_deps"></a>experimental_report_unused_deps |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_reduce_classpath_mode"></a>experimental_reduce_classpath_mode |  <p align="center"> - </p>   |  `None` |

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -537,6 +537,9 @@ def _run_kt_builder_action(
                 "\nAdditionally ensure the target does not contain the kt_remove_private_classes_in_abi_plugin_incompatible tag.",
             )
 
+    if not "kt_remove_debug_info_in_abi_plugin_incompatible" in ctx.attr.tags and toolchains.kt.experimental_remove_debug_info_in_abi_jars == True:
+        args.add("--remove_debug_info_in_abi_jar", "true")
+
     args.add("--build_kotlin", build_kotlin)
 
     progress_message = "%s %%{label} { kt: %d, java: %d, srcjars: %d } for %s" % (

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -88,6 +88,7 @@ def _kotlin_toolchain_impl(ctx):
         experimental_use_abi_jars = ctx.attr.experimental_use_abi_jars,
         experimental_treat_internal_as_private_in_abi_jars = ctx.attr.experimental_treat_internal_as_private_in_abi_jars,
         experimental_remove_private_classes_in_abi_jars = ctx.attr.experimental_remove_private_classes_in_abi_jars,
+        experimental_remove_debug_info_in_abi_jars = ctx.attr.experimental_remove_debug_info_in_abi_jars,
         experimental_strict_kotlin_deps = ctx.attr.experimental_strict_kotlin_deps,
         experimental_report_unused_deps = ctx.attr.experimental_report_unused_deps,
         experimental_reduce_classpath_mode = ctx.attr.experimental_reduce_classpath_mode,
@@ -222,6 +223,13 @@ _kt_toolchain = rule(
             `kt_remove_private_classes_in_abi_plugin_incompatible`""",
             default = False,
         ),
+        "experimental_remove_debug_info_in_abi_jars": attr.bool(
+            doc = """This applies the following compiler plugin option:
+              plugin:org.jetbrains.kotlin.jvm.abi:removeDebugInfo=true
+            Can be disabled for an individual target using the tag.
+            `kt_remove_debug_info_in_abi_plugin_incompatible`""",
+            default = False,
+        ),
         "experimental_strict_kotlin_deps": attr.string(
             doc = "Report strict deps violations",
             default = "off",
@@ -322,6 +330,7 @@ def define_kt_toolchain(
         experimental_use_abi_jars = False,
         experimental_treat_internal_as_private_in_abi_jars = False,
         experimental_remove_private_classes_in_abi_jars = False,
+        experimental_remove_debug_info_in_abi_jars = False,
         experimental_strict_kotlin_deps = None,
         experimental_report_unused_deps = None,
         experimental_reduce_classpath_mode = None,
@@ -351,6 +360,7 @@ def define_kt_toolchain(
         }),
         experimental_treat_internal_as_private_in_abi_jars = experimental_treat_internal_as_private_in_abi_jars,
         experimental_remove_private_classes_in_abi_jars = experimental_remove_private_classes_in_abi_jars,
+        experimental_remove_debug_info_in_abi_jars = experimental_remove_debug_info_in_abi_jars,
         experimental_multiplex_workers = experimental_multiplex_workers,
         experimental_strict_kotlin_deps = experimental_strict_kotlin_deps,
         experimental_report_unused_deps = experimental_report_unused_deps,

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -79,6 +79,7 @@ class KotlinBuilder
         ABI_JAR("--abi_jar"),
         ABI_JAR_INTERNAL_AS_PRIVATE("--treat_internal_as_private_in_abi_jar"),
         ABI_JAR_REMOVE_PRIVATE_CLASSES("--remove_private_classes_in_abi_jar"),
+        ABI_JAR_REMOVE_DEBUG_INFO("--remove_debug_info_in_abi_jar"),
         GENERATED_JAVA_SRC_JAR("--generated_java_srcjar"),
         GENERATED_JAVA_STUB_JAR("--kapt_generated_stub_jar"),
         GENERATED_CLASS_JAR("--kapt_generated_class_jar"),
@@ -166,6 +167,9 @@ class KotlinBuilder
         }
         argMap.optionalSingle(KotlinBuilderFlags.ABI_JAR_REMOVE_PRIVATE_CLASSES)?.let {
           removePrivateClassesInAbiJar = it == "true"
+        }
+        argMap.optionalSingle(KotlinBuilderFlags.ABI_JAR_REMOVE_DEBUG_INFO)?.let {
+          removeDebugInfo = it == "true"
         }
         argMap.optionalSingle(KotlinBuilderFlags.BUILD_TOOLS_API)?.let {
           buildToolsApi = it == "true"

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -95,6 +95,9 @@ class KotlinJvmTaskExecutor
                             if (info.removePrivateClassesInAbiJar) {
                               flag("removePrivateClasses", "true")
                             }
+                            if (info.removeDebugInfo) {
+                              flag("removeDebugInfo", "true")
+                            }
                           }
                           given(outputs.jar).empty {
                             plugin(plugins.skipCodeGen)

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -88,6 +88,8 @@ message CompilationTaskInfo {
     bool remove_private_classes_in_abi_jar = 13;
     // New Build Tools API. Required for incremental compilation.
     bool build_tools_api = 14;
+    // Debug info is stripped in abi.jar generation
+    bool remove_debug_info = 15;
 }
 
 // Nested messages not marked with stable could be refactored.


### PR DESCRIPTION
**Background**
https://youtrack.jetbrains.com/issue/KT-33020/Support-stripping-debug-information-in-the-jvm-abi-gen-plugin

Starting from Kotlin 2.0.0-Beta3, the following compiler argument to strip debug info in jvm-abi-gen has been introduced: 
`-P plugin:org.jetbrains.kotlin.jvm.abi:removeDebugInfo=true`

This PR adds support for this experimental flag