### PR TITLE
Add example analysis_test with configuration

### DIFF
--- a/src/test/starlark/rules/BUILD.bazel
+++ b/src/test/starlark/rules/BUILD.bazel
@@ -1,0 +1,5 @@
+load(":experimental_prune_transitive_deps_tests.bzl", "experimental_prune_transitive_deps_tests")
+
+experimental_prune_transitive_deps_tests(
+    name = "experimental_prune_transitive_deps_tests",
+)

--- a/src/test/starlark/rules/arrangement.bzl
+++ b/src/test/starlark/rules/arrangement.bzl
@@ -1,0 +1,40 @@
+load("//kotlin:jvm.bzl", "kt_jvm_import", "kt_jvm_library")
+
+def arrange(test):
+    dependency_a_trans_dep_jar = test.artifact(
+        name = "dependency_a_trans_dep.abi.jar",
+    )
+
+    dependency_a = test.have(
+        kt_jvm_library,
+        name = "dependency_a",
+        srcs = [
+            test.artifact(
+                name = "dependency_a.kt",
+            ),
+        ],
+        deps = [
+            test.have(
+                kt_jvm_import,
+                name = "dependency_a_dep_jar_import",
+                jars = [
+                    dependency_a_trans_dep_jar,
+                ],
+            ),
+        ],
+    )
+
+    main_target_library = test.got(
+        kt_jvm_library,
+        name = "main_target_library",
+        srcs = [
+            test.artifact(
+                name = "main_target_library.kt",
+            ),
+        ],
+        deps = [
+            dependency_a,
+        ],
+    )
+
+    return (dependency_a_trans_dep_jar, dependency_a, main_target_library)

--- a/src/test/starlark/rules/experimental_prune_transitive_deps_tests.bzl
+++ b/src/test/starlark/rules/experimental_prune_transitive_deps_tests.bzl
@@ -1,0 +1,89 @@
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
+load("//src/test/starlark:case.bzl", "suite")
+load(":arrangement.bzl", "arrange")
+load(":util.bzl", "abi_jar_of", "values_for_flag_of")
+
+def _classpath_assertions_(env, target):
+    action = env.expect.that_target(target).action_named(env.ctx.attr.on_action_mnemonic)
+    action.inputs().contains_at_least([abi_jar_of(f.short_path) for f in env.ctx.files.want_inputs if not f.short_path.endswith("jdeps")])
+
+    values_for_flag_of(action, "--classpath").contains_at_least([abi_jar_of(f.path) for f in env.ctx.files.want_classpath if not f.short_path.endswith("jdeps")])
+    values_for_flag_of(action, "--classpath").contains_none_of([f.path for f in env.ctx.files.not_want_classpath])
+
+def _test_classpath_experimental_prune_transitive_deps_False(test):
+    (dependency_a_trans_dep_jar, dependency_a, main_target_library) = arrange(test)
+
+    analysis_test(
+        name = test.name,
+        impl = _classpath_assertions_,
+        target = main_target_library,
+        config_settings = {
+            str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps")): False,
+            str(Label("@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies")): False,
+        },
+        attr_values = {
+            "on_action_mnemonic": "KotlinCompile",
+            "want_inputs": [
+                dependency_a,
+                dependency_a_trans_dep_jar,
+            ],
+            "want_direct_dependencies": [
+                dependency_a,
+                dependency_a_trans_dep_jar,
+            ],
+            "want_classpath": [
+                dependency_a,
+                dependency_a_trans_dep_jar,
+            ],
+            "not_want_classpath": [],
+        },
+        attrs = {
+            "on_action_mnemonic": attr.string(),
+            "want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_direct_dependencies": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "not_want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+        },
+    )
+
+def _test_classpath_experimental_prune_transitive_deps_True(test):
+    (dependency_a_trans_dep_jar, dependency_a, main_target_library) = arrange(test)
+
+    analysis_test(
+        name = test.name,
+        impl = _classpath_assertions_,
+        target = main_target_library,
+        config_settings = {
+            str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps")): True,
+            str(Label("@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies")): False,
+        },
+        attr_values = {
+            "on_action_mnemonic": "KotlinCompile",
+            "want_inputs": [
+                dependency_a,
+            ],
+            "want_direct_dependencies": [
+                dependency_a,
+            ],
+            "want_classpath": [
+                dependency_a,
+            ],
+            "not_want_classpath": [
+                dependency_a_trans_dep_jar,
+            ],
+        },
+        attrs = {
+            "on_action_mnemonic": attr.string(),
+            "want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_direct_dependencies": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "not_want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+        },
+    )
+
+def experimental_prune_transitive_deps_tests(name):
+    suite(
+        name,
+        enabled = _test_classpath_experimental_prune_transitive_deps_True,
+        disabled = _test_classpath_experimental_prune_transitive_deps_False,
+    )

--- a/src/test/starlark/rules/util.bzl
+++ b/src/test/starlark/rules/util.bzl
@@ -1,0 +1,41 @@
+def values_for_flag_of(action_subject, flag):
+    return action_subject.argv().transform(desc = "parsed()", loop = _curry_denormalise_flags_with(flag))
+
+def _curry_denormalise_flags_with(flag):
+    def _denormalise_flags(argv):
+        parsed_flags = []
+
+        # argv might be none for e.g. builtin actions
+        if argv == None:
+            return parsed_flags
+        last_flag = None
+        for arg in argv:
+            value = None
+            if arg == "--":
+                # skip the rest of the arguments, this is standard end of the flags.
+                break
+            if arg.startswith("-"):
+                if "=" in arg:
+                    last_flag, value = arg.split("=", 1)
+                else:
+                    last_flag = arg
+            elif last_flag:
+                # have a flag, therefore this is probably an associated argument
+                value = arg
+            else:
+                # skip non-flag arguments
+                continue
+
+            # only set the value if it exists
+            if value:
+                if last_flag == flag:
+                    parsed_flags.append(value)
+        return parsed_flags
+
+    return _denormalise_flags
+
+def abi_jar_of(jar):
+    if jar.endswith(".abi.jar"):
+        return jar
+    else:
+        return jar.replace(".jar", ".abi.jar")


### PR DESCRIPTION
**WIP**

exploring analysis tests with different configuration properties set

**arrange.bzl** produces a small set of targets 

[main_target_library] --dep--> [dependency_a] --dep--> [dependency_a_trans_dep_jar]

**experimental_prune_transitive_deps_tests.bzl**

has two tests, one test enables experimental_prune_transitive_deps the other dosnt.

basic assertions around the KotlinCompile action to check --classpath, --direct_dependencies and inputs

[dependency_a_trans_dep_jar] should be dropped when the experimental flag is enabled

for these tests to work I think all flags need to be public, ie not the ones in the internal/kotlin/kt_configure_toolchains function

These tests dont run perfectly yet but i thought i would share what i have so far, i have an issue with checking absolute paths atm

```1 expected elements missing from argv:
  0: bazel-out/darwin_arm64-fastbuild/bin/src/test/starlark/rules/enabled_dependency_a.abi.jar
actual argv:
  0: external/+rules_kotlin_extensions+com_github_jetbrains_kotlin_git/lib/annotations-13.0.jar
  1: external/+rules_kotlin_extensions+com_github_jetbrains_kotlin_git/lib/kotlin-stdlib.jar
  2: external/+rules_kotlin_extensions+com_github_jetbrains_kotlin_git/lib/kotlin-stdlib-jdk7.jar
  3: external/+rules_kotlin_extensions+com_github_jetbrains_kotlin_git/lib/kotlin-stdlib-jdk8.jar
  4: bazel-out/darwin_arm64-fastbuild-ST-d9dfb3145612/bin/src/test/starlark/rules/enabled_dependency_a.abi.jar
```
  
  im guessing darwin_arm64-fastbuild-ST-d9dfb3145612 is something to do with the "reconfiguration" when the analysis test runs with the new flags