### PR TITLE
Fix non-file inclusion into runfiles for data.

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -224,13 +224,13 @@ def kt_jvm_library_impl(ctx):
         )
     return _make_providers(
         ctx,
-        _compile.kt_jvm_produce_jar_actions(ctx, "kt_jvm_library") if ctx.attr.srcs or ctx.attr.resources else _compile.export_only_providers(
+        providers = _compile.kt_jvm_produce_jar_actions(ctx, "kt_jvm_library") if ctx.attr.srcs or ctx.attr.resources else _compile.export_only_providers(
             ctx = ctx,
             actions = ctx.actions,
             outputs = ctx.outputs,
             attr = ctx.attr,
         ),
-        runfiles_targets = ctx.attr.deps + ctx.attr.exports,
+        runfiles_targets = ctx.attr.deps + ctx.attr.exports + ctx.attr.runtime_deps + ctx.attr.data,
     )
 
 def kt_jvm_binary_impl(ctx):
@@ -251,12 +251,12 @@ def kt_jvm_binary_impl(ctx):
     return _make_providers(
         ctx,
         providers,
-        runfiles_targets = ctx.attr.deps,
         transitive_files = depset(
             order = "default",
             transitive = [providers.java.transitive_runtime_jars],
             direct = ctx.files._java_runtime,
         ),
+        runfiles_targets = ctx.attr.deps + ctx.attr.runtime_deps + ctx.attr.data,
     )
 
 _SPLIT_STRINGS = [
@@ -308,7 +308,7 @@ def kt_jvm_junit_test_impl(ctx):
     return _make_providers(
         ctx,
         providers,
-        ctx.attr.deps,
+        ctx.attr.deps + ctx.attr.runtime_deps + ctx.attr.data,
         depset(
             order = "default",
             transitive = [runtime_jars, depset(coverage_runfiles), depset(coverage_metadata)],

--- a/src/main/starlark/core/compile/rules.bzl
+++ b/src/main/starlark/core/compile/rules.bzl
@@ -110,7 +110,7 @@ def _kt_jvm_library_impl(ctx):
                 files = ctx.files.data,
             ).merge_all([
                 d[DefaultInfo].default_runfiles
-                for d in ctx.attr.deps + ctx.attr.exports
+                for d in ctx.attr.deps + ctx.attr.exports + ctx.attr.data + ctx.attr.runtime_deps
                 if DefaultInfo in d
             ]),
         ),
@@ -166,7 +166,7 @@ def _kt_jvm_binary_impl(ctx):
                 transitive_files = launch_runfiles,
             ).merge_all([
                 d[DefaultInfo].default_runfiles
-                for d in ctx.attr.deps
+                for d in ctx.attr.deps + ctx.attr.data + ctx.attr.runtime_deps
                 if DefaultInfo in d
             ]),
             executable = executable,


### PR DESCRIPTION
fixes #1348

Dug up more of the magic behind the deprecated `collect_default` (it really did do fair amount of work...) -- previous code would only pull in files (whoops) and not the `DefaultInfo` for targets in `data`.
* Add `runtime_deps` and `data` as sources for runfiles.
* Add coverage for transitive data runfile