### PR TITLE
Stop enabling Java Security Manager before Java 24

### DIFF
--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -72,9 +72,10 @@ def _write_launcher_action(ctx, rjars, main_class, jvm_flags):
     java_bin_path = java_runtime.java_executable_runfiles_path
 
     # Following https://github.com/bazelbuild/bazel/blob/6d5b084025a26f2f6d5041f7a9e8d302c590bc80/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary.bzl#L66-L67
-    # Enable the security manager past deprecation.
+    # Enable the security manager past deprecation until permanently disabled: https://openjdk.org/jeps/486
     # On bazel 6, this check isn't possible...
-    if getattr(java_runtime, "version", 0) >= 17:
+    _java_runtime_version = getattr(java_runtime, "version", 0)
+    if _java_runtime_version >= 17 and _java_runtime_version < 24:
         jvm_flags = jvm_flags + " -Djava.security.manager=allow"
 
     if ctx.configuration.coverage_enabled:

--- a/kotlin/internal/jvm/kt_android_local_test_impl.bzl
+++ b/kotlin/internal/jvm/kt_android_local_test_impl.bzl
@@ -176,7 +176,7 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
 
     _java_runtime_version = getattr(java_runtime, "version", 0)
     if _java_runtime_version >= 17 and _java_runtime_version < 24:
-        jvm_flags = jvm_flags + " -Djava.security.manager=allow"
+        jvm_flags.append("-Djava.security.manager=allow")
 
     return _ProviderInfo(
         name = "jvm_ctx",

--- a/kotlin/internal/jvm/kt_android_local_test_impl.bzl
+++ b/kotlin/internal/jvm/kt_android_local_test_impl.bzl
@@ -173,8 +173,10 @@ def _process_jvm(ctx, resources_ctx, **_unused_sub_ctxs):
     # Append the security manager override
     jvm_flags = []
     java_runtime = ctx.toolchains[_JAVA_RUNTIME_TOOLCHAIN_TYPE].java_runtime
-    if java_runtime.version >= 17:
-        jvm_flags.append("-Djava.security.manager=allow")
+
+    _java_runtime_version = getattr(java_runtime, "version", 0)
+    if _java_runtime_version >= 17 and _java_runtime_version < 24:
+        jvm_flags = jvm_flags + " -Djava.security.manager=allow"
 
     return _ProviderInfo(
         name = "jvm_ctx",

--- a/src/main/starlark/core/compile/cli/compile.bzl
+++ b/src/main/starlark/core/compile/cli/compile.bzl
@@ -70,9 +70,10 @@ def write_jvm_launcher(toolchain_info, actions, path_separator, workspace_prefix
     java_bin_path = java_runtime.java_executable_runfiles_path
 
     # Following https://github.com/bazelbuild/bazel/blob/6d5b084025a26f2f6d5041f7a9e8d302c590bc80/src/main/starlark/builtins_bzl/bazel/java/bazel_java_binary.bzl#L66-L67
-    # Enable the security manager past deprecation.
+    # Enable the security manager past deprecation until permanently disabled: https://openjdk.org/jeps/486
     # On bazel 6, this check isn't possible...
-    if getattr(java_runtime, "version", 0) >= 17:
+    _java_runtime_version = getattr(java_runtime, "version", 0)
+    if _java_runtime_version >= 17 and _java_runtime_version < 24:
         jvm_flags = jvm_flags + " -Djava.security.manager=allow"
 
     classpath = path_separator.join(


### PR DESCRIPTION
Picking this change back up as well as fixing the Android side https://github.com/bazelbuild/rules_kotlin/pull/1346/