### PR TITLE
Add DefaultInfo provider to kt_compiler_plugin and kt_plugin_cfg deps list

### DIFF
--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -537,7 +537,7 @@ kt_jvm_library(
     attrs = {
         "deps": attr.label_list(
             doc = "The list of libraries to be added to the compiler's plugin classpath",
-            providers = [JavaInfo],
+            providers = [[JavaInfo], [DefaultInfo]],
             cfg = "exec",
             aspects = [_kt_compiler_deps_aspect],
         ),
@@ -660,6 +660,7 @@ kt_plugin_cfg = rule(
                 [_KspPluginInfo],
                 [JavaInfo],
                 [JavaPluginInfo],
+                [DefaultInfo],
             ],
             cfg = "exec",
         ),


### PR DESCRIPTION
This is to enable #1362.

With this change in place you can do something like

```
kt_compiler_plugin(
    name = "jetpack_compose_compiler_plugin",
    id = "androidx.compose.compiler.plugins.kotlin",
    options = {
        "sourceInformation": "true",  # Required for AS Layout Inspector, disable for release builds
        "stabilityConfigurationPath": "$(locations :stability_config)",
    },
    target_embedded_compiler = True,
    visibility = ["//visibility:public"],
    deps = [
        ":stability_config",
        "@maven_rules_kotlin_example//:org_jetbrains_kotlin_kotlin_compose_compiler_plugin_embeddable",
    ],
)

filegroup(
    name = "stability_config",
    srcs = ["stability.conf"],
)
```

I tested this by modifying `examples/jetpack_compose` //app:compose_example_app with a locally built version of the rules (the example code above was lifted from that)