### PR TITLE
Add data attr to kt_plugin_cfg and kt_compiler_plugin

### DIFF
--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -297,7 +297,8 @@ Lint Kotlin files, and fail if the linter raises errors.
 <pre>
 load("@rules_kotlin//kotlin:core.bzl", "kt_compiler_plugin")
 
-kt_compiler_plugin(<a href="#kt_compiler_plugin-name">name</a>, <a href="#kt_compiler_plugin-deps">deps</a>, <a href="#kt_compiler_plugin-compile_phase">compile_phase</a>, <a href="#kt_compiler_plugin-id">id</a>, <a href="#kt_compiler_plugin-options">options</a>, <a href="#kt_compiler_plugin-stubs_phase">stubs_phase</a>, <a href="#kt_compiler_plugin-target_embedded_compiler">target_embedded_compiler</a>)
+kt_compiler_plugin(<a href="#kt_compiler_plugin-name">name</a>, <a href="#kt_compiler_plugin-deps">deps</a>, <a href="#kt_compiler_plugin-data">data</a>, <a href="#kt_compiler_plugin-compile_phase">compile_phase</a>, <a href="#kt_compiler_plugin-id">id</a>, <a href="#kt_compiler_plugin-options">options</a>, <a href="#kt_compiler_plugin-stubs_phase">stubs_phase</a>,
+                   <a href="#kt_compiler_plugin-target_embedded_compiler">target_embedded_compiler</a>)
 </pre>
 
 Define a plugin for the Kotlin compiler to run. The plugin can then be referenced in the `plugins` attribute
@@ -339,6 +340,7 @@ kt_jvm_library(
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="kt_compiler_plugin-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="kt_compiler_plugin-deps"></a>deps |  The list of libraries to be added to the compiler's plugin classpath   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="kt_compiler_plugin-data"></a>data |  The list of data files to be used by compiler's plugin   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="kt_compiler_plugin-compile_phase"></a>compile_phase |  Runs the compiler plugin during kotlin compilation. Known examples: `allopen`, `sam_with_reciever`   | Boolean | optional |  `True`  |
 | <a id="kt_compiler_plugin-id"></a>id |  The ID of the plugin   | String | required |  |
 | <a id="kt_compiler_plugin-options"></a>options |  Dictionary of options to be passed to the plugin. Supports the following template values:<br><br>- `{generatedClasses}`: directory for generated class output - `{temp}`: temporary directory, discarded between invocations - `{generatedSources}`:  directory for generated source output - `{classpath}` : replaced with a list of jars separated by the filesystem appropriate separator.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
@@ -488,7 +490,7 @@ kt_jvm_library(
 <pre>
 load("@rules_kotlin//kotlin:core.bzl", "kt_plugin_cfg")
 
-kt_plugin_cfg(<a href="#kt_plugin_cfg-name">name</a>, <a href="#kt_plugin_cfg-deps">deps</a>, <a href="#kt_plugin_cfg-options">options</a>, <a href="#kt_plugin_cfg-plugin">plugin</a>)
+kt_plugin_cfg(<a href="#kt_plugin_cfg-name">name</a>, <a href="#kt_plugin_cfg-deps">deps</a>, <a href="#kt_plugin_cfg-data">data</a>, <a href="#kt_plugin_cfg-options">options</a>, <a href="#kt_plugin_cfg-plugin">plugin</a>)
 </pre>
 
 Configurations for kt_compiler_plugin, ksp_plugin, and java_plugin.
@@ -502,6 +504,7 @@ This allows setting options and dependencies independently from the initial plug
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="kt_plugin_cfg-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="kt_plugin_cfg-deps"></a>deps |  Dependencies for this configuration.   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="kt_plugin_cfg-data"></a>data |  The list of data files to be used by compiler's plugin   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="kt_plugin_cfg-options"></a>options |  A dictionary of flag to values to be used as plugin configuration options.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> List of strings</a> | optional |  `{}`  |
 | <a id="kt_plugin_cfg-plugin"></a>plugin |  The plugin to associate with this configuration   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 

--- a/examples/jetpack_compose/BUILD
+++ b/examples/jetpack_compose/BUILD
@@ -18,15 +18,22 @@ define_kt_toolchain(
 
 kt_compiler_plugin(
     name = "jetpack_compose_compiler_plugin",
+    data = [":stability_config"],
     id = "androidx.compose.compiler.plugins.kotlin",
     options = {
         "sourceInformation": "true",  # Required for AS Layout Inspector, disable for release builds
+        "stabilityConfigurationPath": "$(locations :stability_config)",
     },
     target_embedded_compiler = True,
     visibility = ["//visibility:public"],
     deps = [
         "@maven_rules_kotlin_example//:org_jetbrains_kotlin_kotlin_compose_compiler_plugin_embeddable",
     ],
+)
+
+filegroup(
+    name = "stability_config",
+    srcs = ["stability.conf"],
 )
 
 platform(

--- a/examples/jetpack_compose/WORKSPACE
+++ b/examples/jetpack_compose/WORKSPACE
@@ -1,5 +1,6 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+# TODO (rbeazleyspot) Update release url when #1364 is released
 http_archive(
     name = "rules_kotlin",
     sha256 = "34e8c0351764b71d78f76c8746e98063979ce08dcf1a91666f3f3bc2949a533d",

--- a/examples/jetpack_compose/stability.conf
+++ b/examples/jetpack_compose/stability.conf
@@ -1,0 +1,1 @@
+android.net.Uri

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -392,6 +392,9 @@ def _reshade_embedded_kotlinc_jars(target, ctx, jars, deps):
         ],
     )
 
+def _expand_location_with_data_deps(ctx):
+    return lambda targets: ctx.expand_location(targets, ctx.attr.data)
+
 def kt_compiler_plugin_impl(ctx):
     plugin_id = ctx.attr.id
 
@@ -413,7 +416,7 @@ def kt_compiler_plugin_impl(ctx):
     classpath = depset(info.runtime_output_jars, transitive = [info.transitive_runtime_jars])
 
     # TODO(1035): Migrate kt_compiler_plugin.options to string_list_dict
-    options = plugin_common.resolve_plugin_options(plugin_id, {k: [v] for (k, v) in ctx.attr.options.items()}, ctx.expand_location)
+    options = plugin_common.resolve_plugin_options(plugin_id, {k: [v] for (k, v) in ctx.attr.options.items()}, _expand_location_with_data_deps(ctx))
 
     return [
         DefaultInfo(files = classpath),
@@ -432,7 +435,7 @@ def kt_plugin_cfg_impl(ctx):
     plugin = ctx.attr.plugin[_KtCompilerPluginInfo]
     return [
         plugin,
-    ] + plugin.resolve_cfg(plugin, ctx.attr.options, ctx.attr.deps, ctx.expand_location)
+    ] + plugin.resolve_cfg(plugin, ctx.attr.options, ctx.attr.deps, _expand_location_with_data_deps(ctx))
 
 def kt_ksp_plugin_impl(ctx):
     deps = ctx.attr.deps

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -535,6 +535,11 @@ kt_jvm_library(
 ```
 """,
     attrs = {
+        "data": attr.label_list(
+            doc = "The list of data files to be used by compiler's plugin",
+            providers = [DefaultInfo],
+            cfg = "exec",
+        ),
         "deps": attr.label_list(
             doc = "The list of libraries to be added to the compiler's plugin classpath",
             providers = [JavaInfo],
@@ -661,6 +666,11 @@ kt_plugin_cfg = rule(
                 [JavaInfo],
                 [JavaPluginInfo],
             ],
+            cfg = "exec",
+        ),
+        "data": attr.label_list(
+            doc = "The list of data files to be used by compiler's plugin",
+            providers = [DefaultInfo],
             cfg = "exec",
         ),
     },


### PR DESCRIPTION
Alternative for #1363 using data attribute

This adds a data attribute to kt_plugin_cfg and kt_compiler_plugin

ctx.expand_location is curried with the targets listed in data

tested [here](https://github.com/rbeazleyspot/rules_kotlin/commit/43aa72413044cdb298f18a86a961348811ac6119) using bazelisk build //app:compose_example_app