### PR TITLE
Allow setting newer language versions in toolchain

### DIFF
--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -144,6 +144,8 @@ _kt_toolchain = rule(
                 "1.9",
                 "2.0",
                 "2.1",
+                "2.2",
+                "2.3",
             ],
         ),
         "api_version": attr.string(
@@ -161,6 +163,8 @@ _kt_toolchain = rule(
                 "1.9",
                 "2.0",
                 "2.1",
+                "2.2",
+                "2.3",
             ],
         ),
         "debug": attr.string_list(

--- a/src/main/starlark/core/options/opts.kotlinc.bzl
+++ b/src/main/starlark/core/options/opts.kotlinc.bzl
@@ -430,7 +430,7 @@ default: 'first-only-warn' in language version 2.2+, 'first-only' in version 2.1
         args = dict(
             default = "",
             doc = "The target version of the generated JVM bytecode",
-            values = ["1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", "17"],
+            values = ["1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", "17", "21"],
         ),
         type = attr.string,
         value_to_flag = None,
@@ -442,7 +442,7 @@ default: 'first-only-warn' in language version 2.2+, 'first-only' in version 2.1
             doc = """Compile against the specified JDK API version, similarly to javac's '-release'. This requires JDK 9 or newer.
                      The supported versions depend on the JDK used; for JDK 17+, the supported versions are 1.8 and 9–21.
                      This also sets the value of '-jvm-target' to be equal to the selected JDK version.""",
-            values = ["1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", "17"],
+            values = ["1.6", "1.8", "9", "10", "11", "12", "13", "15", "16", "17", "21"],
         ),
         type = attr.string,
         value_to_flag = None,


### PR DESCRIPTION
Fixes #1365

This allows setting the Kotlin version to 2.2/2.3 and JVM to 21. Though the Kotlin compiler will complain about the language version being "experimental" it seems to compile just fine.

<img width="1141" height="519" alt="image" src="https://github.com/user-attachments/assets/000c1dc4-55fa-4303-a819-e21138c30639" />
