### PR TITLE
Add env and env_inherit support to kt_jvm_binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ Also, `kt_jvm_*` rules support the following standard `java_*` rules attributes:
   * `resources`
   * `resources_strip_prefix`
   * `exports`
-  
+
+Additionally, `kt_jvm_binary` and `kt_jvm_test` support environment variable configuration:
+  * `env` - Dictionary of environment variables to set when the target is executed with `bazel run` or `bazel test`
+  * `env_inherit` - List of environment variable names to inherit from the shell environment
+
 Android rules also support custom_package for `R.java` generation, `manifest=`, `resource_files`, etc.
 
 Other features:

--- a/examples/env_demo/BUILD.bazel
+++ b/examples/env_demo/BUILD.bazel
@@ -1,0 +1,15 @@
+load("//kotlin:jvm.bzl", "kt_jvm_binary")
+
+# Example demonstrating env and env_inherit support in kt_jvm_binary
+kt_jvm_binary(
+    name = "env_demo",
+    srcs = ["Main.kt"],
+    main_class = "com.example.MainKt",
+    # Set custom environment variables
+    env = {
+        "GREETING": "Hello from Bazel!",
+        "MESSAGE": "Environment variables are working!",
+    },
+    # Inherit environment variables from the shell
+    env_inherit = ["HOME"],
+)

--- a/examples/env_demo/Main.kt
+++ b/examples/env_demo/Main.kt
@@ -1,0 +1,8 @@
+package com.example
+
+fun main() {
+    println("Environment variable demo:")
+    println("GREETING = ${System.getenv("GREETING") ?: "not set"}")
+    println("MESSAGE = ${System.getenv("MESSAGE") ?: "not set"}")
+    println("HOME = ${System.getenv("HOME") ?: "not set"}")
+}

--- a/kotlin/internal/jvm/impl.bzl
+++ b/kotlin/internal/jvm/impl.bzl
@@ -251,12 +251,16 @@ def kt_jvm_binary_impl(ctx):
     return _make_providers(
         ctx,
         providers,
-        transitive_files = depset(
+        ctx.attr.deps + ctx.attr.runtime_deps + ctx.attr.data,
+        depset(
             order = "default",
             transitive = [providers.java.transitive_runtime_jars],
             direct = ctx.files._java_runtime,
         ),
-        runfiles_targets = ctx.attr.deps + ctx.attr.runtime_deps + ctx.attr.data,
+        RunEnvironmentInfo(
+            environment = ctx.attr.env,
+            inherited_environment = ctx.attr.env_inherit,
+        ),
     )
 
 _SPLIT_STRINGS = [

--- a/kotlin/internal/jvm/jvm.bzl
+++ b/kotlin/internal/jvm/jvm.bzl
@@ -297,6 +297,15 @@ _runnable_common_attr = utils.add_dicts(_common_attr, _runnable_implicit_deps, {
         support make variable substitution.""",
         default = [],
     ),
+    "env": attr.string_dict(
+        doc = """Environment variables to set when this binary is executed with `bazel run`.
+Note: for Starlark rules, values are used as-is (no automatic $(location) / make variable expansion).""",
+        default = {},
+    ),
+    "env_inherit": attr.string_list(
+        doc = """Names of environment variables to inherit from the shell when executed with `bazel run`.""",
+        default = [],
+    ),
 })
 
 _common_outputs = dict(

--- a/src/test/starlark/internal/jvm/BUILD.bazel
+++ b/src/test/starlark/internal/jvm/BUILD.bazel
@@ -1,3 +1,6 @@
 load(":jvm_deps_tests.bzl", "jvm_deps_test_suite")
+load(":kt_jvm_binary_env_test.bzl", "kt_jvm_binary_env_test_suite")
 
 jvm_deps_test_suite(name = "jvm_tests")
+
+kt_jvm_binary_env_test_suite(name = "kt_jvm_binary_env_tests")

--- a/src/test/starlark/internal/jvm/kt_jvm_binary_env_test.bzl
+++ b/src/test/starlark/internal/jvm/kt_jvm_binary_env_test.bzl
@@ -1,0 +1,85 @@
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
+load("@rules_testing//lib:test_suite.bzl", "test_suite")
+load("@rules_testing//lib:util.bzl", "util")
+load("//kotlin:jvm.bzl", "kt_jvm_binary")
+
+def _kt_jvm_binary_env_test_impl(env, target):
+    """Test that kt_jvm_binary sets RunEnvironmentInfo correctly."""
+
+    # Check that RunEnvironmentInfo is present
+    env.expect.that_target(target).has_provider(RunEnvironmentInfo)
+
+    # Get the RunEnvironmentInfo provider
+    run_env_info = target[RunEnvironmentInfo]
+
+    # Verify the environment variables
+    env.expect.that_dict(run_env_info.environment).contains_exactly({
+        "FOO": "bar",
+        "BAZ": "qux",
+    })
+
+    # Verify the inherited environment variables
+    env.expect.that_collection(run_env_info.inherited_environment).contains_exactly([
+        "HOME",
+        "PATH",
+    ])
+
+def _kt_jvm_binary_env_test(name):
+    """Creates a test that verifies env and env_inherit attributes work."""
+    kt_jvm_binary(
+        name = name + "_subject",
+        srcs = [util.empty_file(name + "_Main.kt")],
+        main_class = "test.Main",
+        env = {
+            "FOO": "bar",
+            "BAZ": "qux",
+        },
+        env_inherit = ["HOME", "PATH"],
+        tags = ["manual"],
+    )
+
+    analysis_test(
+        name = name,
+        impl = _kt_jvm_binary_env_test_impl,
+        target = name + "_subject",
+    )
+
+def _kt_jvm_binary_empty_env_test_impl(env, target):
+    """Test that kt_jvm_binary works with no env attributes."""
+
+    # Check that RunEnvironmentInfo is present
+    env.expect.that_target(target).has_provider(RunEnvironmentInfo)
+
+    # Get the RunEnvironmentInfo provider
+    run_env_info = target[RunEnvironmentInfo]
+
+    # Verify the environment is empty
+    env.expect.that_dict(run_env_info.environment).contains_exactly({})
+
+    # Verify no inherited environment variables
+    env.expect.that_collection(run_env_info.inherited_environment).contains_exactly([])
+
+def _kt_jvm_binary_empty_env_test(name):
+    """Creates a test that verifies default env behavior."""
+    kt_jvm_binary(
+        name = name + "_subject",
+        srcs = [util.empty_file(name + "_Main.kt")],
+        main_class = "test.Main",
+        tags = ["manual"],
+    )
+
+    analysis_test(
+        name = name,
+        impl = _kt_jvm_binary_empty_env_test_impl,
+        target = name + "_subject",
+    )
+
+def kt_jvm_binary_env_test_suite(name):
+    """Test suite for kt_jvm_binary env support."""
+    test_suite(
+        name = name,
+        tests = [
+            _kt_jvm_binary_env_test,
+            _kt_jvm_binary_empty_env_test,
+        ],
+    )


### PR DESCRIPTION
This adds parity with java_binary and kt_jvm_test by allowing kt_jvm_binary to specify environment variables when executed with bazel run.

Two new attributes are added:
- env: Dictionary of environment variables to set
- env_inherit: List of environment variable names to inherit from the shell environment

The implementation uses RunEnvironmentInfo provider, following the same pattern as the existing kt_jvm_test support (PR #837).

Fixes #1359