### PR TITLE
kt_jvm_binary: resolve JVM via runfiles path (fixes #1332)

### DIFF
--- a/src/test/integration/runfiles/BUILD.bazel
+++ b/src/test/integration/runfiles/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_binary")
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load(":RunnerRule.bzl", "runner")
+
+# A simple kt_jvm_binary for testing
+kt_jvm_binary(
+    name = "hello",
+    srcs = ["Main.kt"],
+    main_class = "runfiles.test.MainKt",
+)
+
+# Execute the kt_jvm_binary as a tool in another rule's action.
+# This tests that the binary can find its Java runtime when executed
+# as a tool, which was failing before the fix for #1332.
+runner(
+    name = "hello_as_tool",
+    tool_bin = ":hello",
+)
+
+# Test that verifies the above action succeeds
+sh_test(
+    name = "runfiles_test",
+    srcs = ["run_test.sh"],
+    args = ["$(location :hello_as_tool)"],
+    data = [":hello_as_tool"],
+)

--- a/src/test/integration/runfiles/Main.kt
+++ b/src/test/integration/runfiles/Main.kt
@@ -1,0 +1,5 @@
+package runfiles.test
+
+fun main() {
+    println("kt_jvm_binary runfiles test: OK")
+}

--- a/src/test/integration/runfiles/RunnerRule.bzl
+++ b/src/test/integration/runfiles/RunnerRule.bzl
@@ -1,0 +1,29 @@
+"""
+Rule that executes a kt_jvm_binary as a tool in an action.
+This reproduces the scenario from issue #1332 where kt_jvm_binary
+fails to find the Java runtime when executed from another rule.
+"""
+
+def _runner_impl(ctx):
+    # Run the kt binary as a tool in an action (sandboxed).
+    # This is the scenario that was failing before the fix.
+    out = ctx.actions.declare_file(ctx.label.name + ".out")
+    ctx.actions.run_shell(
+        inputs = [],
+        tools = [ctx.executable.tool_bin],  # ensures the tool's runfiles are staged
+        command = "{} > {}".format(ctx.executable.tool_bin.path, out.path),
+        progress_message = "Running kt_jvm_binary as tool",
+        outputs = [out],
+    )
+    return DefaultInfo(files = depset([out]))
+
+runner = rule(
+    implementation = _runner_impl,
+    attrs = {
+        "tool_bin": attr.label(
+            executable = True,
+            cfg = "exec",
+            doc = "The kt_jvm_binary to execute as a tool",
+        ),
+    },
+)

--- a/src/test/integration/runfiles/run_test.sh
+++ b/src/test/integration/runfiles/run_test.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Test that kt_jvm_binary can be executed as a tool in another action.
+# This verifies the fix for issue #1332.
+
+set -euo pipefail
+
+# The test succeeds if the hello_as_tool target was built successfully.
+# The actual execution happened during the build of that target.
+# We just need to verify the output file exists.
+
+if [[ -f "$1" ]]; then
+    echo "Test PASSED: kt_jvm_binary successfully executed as a tool"
+    exit 0
+else
+    echo "Test FAILED: Output file not found at $1"
+    exit 1
+fi


### PR DESCRIPTION
Use JavaRuntimeInfo.java_executable_runfiles_path (already in use)
and normalize it like rules_java does: prepend workspace name for
relative paths, and use ${JAVA_RUNFILES}/ prefix in the stub template.

This makes kt_jvm_binary work when executed as a tool inside another
action and under Bazel 8's default --nolegacy_external_runfiles.

The fix follows the same approach as rules_java:
- Normalize java_bin_path by prepending workspace name for relative paths
- Use ${JAVA_RUNFILES}/ prefix which the template resolves at runtime
- Keep third_party/java_stub_template.txt unchanged

Note: rules_java uses ctx.configuration.runfiles_enabled() to check
whether runfiles are enabled, but this is a private API that third-party
rules cannot access. Our implementation uses ${JAVA_RUNFILES}/ prefix
unconditionally, which works in both runfiles-enabled and manifest-only
modes since the stub template handles both cases.

Add an integration test that runs a kt_jvm_binary from a rule action
to verify the fix works correctly.

Fixes #1332