### PR TITLE
Drop KSP 2.0 success message from the build

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2Task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2Task.kt
@@ -242,8 +242,6 @@ class Ksp2Task
           outputPath = generatedClassesOutput,
           directories = listOf(classOutputDir, resourceOutputDir),
         )
-
-        taskContext.info { "KSP2 completed successfully" }
         return 0
       } catch (e: Exception) {
         taskContext.error(e) { "KSP2 execution failed" }


### PR DESCRIPTION
This is causing a bunch of console noise when building since every KSP 2.0 action logs a message that the worker propagates up.