### PR TITLE
chore(docs): remove badly outdated Bazel compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@
 
 For more information about release and changelogs please see [Changelog](CHANGELOG.md) or refer to the [Github Releases](https://github.com/bazelbuild/rules_kotlin/releases) page.
 
-# `rules_kotlin` Bazel Compatibility
-- HEAD: `6`, `7`
-- [Release 1.9](https://github.com/bazelbuild/rules_kotlin/releases/tag/v1.9.1): `6`, `7`
-- [Release 1.8](https://github.com/bazelbuild/rules_kotlin/releases/tag/v1.8.1): `5`, `6`
-- [Release 1.7](https://github.com/bazelbuild/rules_kotlin/releases/tag/v1.7.1): `4`, `5`, `6`
-
 # Overview 
 
 **rules_kotlin** supports the basic paradigm of `*_binary`, `*_library`, `*_test` of other Bazel 


### PR DESCRIPTION
Removed Bazel compatibility section for previous releases. This hasn't been updated for the last several rules_kotlin OR Bazel releases. I think no information is preferable to wrong information.