### PR TITLE
Drop support for Java 8, stop using kotlin-preloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Announcements and Notable Changes
 
-|  Date&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | News  | 
-| :----------- | -------- |
+| Date&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | News                    |
+|:-----------------------------------------------------------------------------------------------------------------|-------------------------|
+| Mar 6, 2026 | Drop support for Java 8 |
 | May 26, 2022  | Released version [v1.6.0-RC-2](https://github.com/bazelbuild/rules_kotlin/releases/tag/v1.6.0-RC-2). |
 | April 27, 2022  | Released version [1.6.0-RC1](https://github.com/bazelbuild/rules_kotlin/releases/tag/1.6.0-RC-1). |
 | Feb 2, 2022  | Released version [1.5.0](https://github.com/bazelbuild/rules_kotlin/releases/tag/v1.5.0). |

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -24,7 +24,6 @@ kt_bootstrap_library(
     ],
     visibility = ["//src:__subpackages__"],
     deps = [
-        "//kotlin/compiler:kotlin-preloader",
         "//src/main/kotlin/io/bazel/kotlin/builder/toolchain",
         "//src/main/kotlin/io/bazel/kotlin/builder/utils",
         "//src/main/kotlin/io/bazel/kotlin/builder/utils/jars",

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/BUILD.bazel
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/BUILD.bazel
@@ -21,7 +21,6 @@ kt_bootstrap_library(
     neverlink_deps = [
         "//kotlin/compiler:jvm-abi-gen",
         "//kotlin/compiler:kotlin-compiler",
-        "//kotlin/compiler:kotlin-preloader",
     ],
     visibility = ["//src:__subpackages__"],
     deps = [

--- a/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/toolchain/KotlinToolchain.kt
@@ -17,17 +17,11 @@
 package io.bazel.kotlin.builder.toolchain
 
 import io.bazel.kotlin.builder.utils.BazelRunFiles
-import io.bazel.kotlin.builder.utils.resolveVerified
 import io.bazel.kotlin.builder.utils.verified
-import io.bazel.kotlin.builder.utils.verifiedPath
-import org.jetbrains.kotlin.preloading.ClassPreloadingUtils
-import org.jetbrains.kotlin.preloading.Preloader
 import java.io.File
 import java.io.PrintStream
 import java.lang.reflect.Method
-import java.nio.file.FileSystems
-import java.nio.file.Path
-import java.nio.file.Paths
+import java.net.URLClassLoader
 
 class KotlinToolchain private constructor(
   private val baseJars: List<File>,
@@ -107,18 +101,7 @@ class KotlinToolchain private constructor(
         ).toPath()
     }
 
-    private val JAVA_HOME by lazy {
-      FileSystems
-        .getDefault()
-        .getPath(System.getProperty("java.home"))
-        .let { path ->
-          path.takeIf { !it.endsWith(Paths.get("jre")) } ?: path.parent
-        }.verifiedPath()
-    }
-
     internal val NO_ARGS = arrayOf<Any>()
-
-    private val isJdk9OrNewer = !System.getProperty("java.version").startsWith("1.")
 
     @JvmStatic
     fun createToolchain(): KotlinToolchain =
@@ -153,9 +136,6 @@ class KotlinToolchain private constructor(
           kotlinc,
           compiler,
           buildTools,
-          // plugins *must* be preloaded. Not doing so causes class conflicts
-          // (and a NoClassDef err) in the compiler extension interfaces.
-          // This may cause issues in accepting user defined compiler plugins.
           jvmAbiGenFile,
           skipCodeGenFile,
           jdepsGenFile,
@@ -186,31 +166,10 @@ class KotlinToolchain private constructor(
       )
   }
 
-  private fun createClassLoader(
-    javaHome: Path,
-    baseJars: List<File>,
-    classLoader: ClassLoader = ClassLoader.getSystemClassLoader(),
-  ): ClassLoader =
-    runCatching {
-      ClassPreloadingUtils.preloadClasses(
-        mutableListOf<File>().also {
-          it += baseJars
-          if (!isJdk9OrNewer) {
-            it += javaHome.resolveVerified("lib", "tools.jar")
-          }
-        },
-        Preloader.DEFAULT_CLASS_NUMBER_ESTIMATE,
-        classLoader,
-        null,
-      )
-    }.onFailure {
-      throw RuntimeException("$javaHome, $baseJars", it)
-    }.getOrThrow()
-
   val classLoader by lazy {
-    createClassLoader(
-      JAVA_HOME,
-      baseJars,
+    URLClassLoader(
+      baseJars.map { it.toURI().toURL() }.toTypedArray(),
+      ClassLoader.getPlatformClassLoader(),
     )
   }
 

--- a/src/main/starlark/core/repositories/kotlin/artifacts.bzl
+++ b/src/main/starlark/core/repositories/kotlin/artifacts.bzl
@@ -45,7 +45,6 @@ KOTLINC_ARTIFACTS = struct(
     core = struct(
         plugin = {},
         runtime = {
-            "kotlin-preloader": "lib/kotlin-preloader.jar",
             "kotlin-reflect": "lib/kotlin-reflect.jar",
             "kotlin-reflect-sources": "lib/kotlin-reflect-sources.jar",
             "kotlin-script-runtime": "lib/kotlin-script-runtime.jar",


### PR DESCRIPTION
1. kotlin-preloader is not an actual artifact (it cannot be pulled from maven)
2. java 8 is ancient
3. this way of invoking kotlinc is going to be replaced by BTAPI completely