### PR TITLE
Update the Github URL in .github/workflows/release_prep.sh to bazel-contrib

### DIFF
--- a/.github/workflows/release_prep.sh
+++ b/.github/workflows/release_prep.sh
@@ -33,7 +33,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "rules_kotlin",
     sha256 = "${SHA}",
-    url = "https://github.com/bazelbuild/rules_kotlin/releases/download/${TAG}/${ARCHIVE}",
+    url = "https://github.com/bazel-contrib/rules_kotlin/releases/download/${TAG}/${ARCHIVE}",
 )
 
 load("@rules_kotlin//kotlin:repositories.bzl", "kotlin_repositories")


### PR DESCRIPTION
Minor correctness change. This doesn't solve the problem of this release not being distributed to the BCR.