### PR TITLE
Per-class tracking to achieve higher level of compilation avoidance

### DIFF
--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -528,6 +528,7 @@ define_kt_toolchain(<a href="#define_kt_toolchain-name">name</a>, <a href="#defi
                     <a href="#define_kt_toolchain-experimental_remove_private_classes_in_abi_jars">experimental_remove_private_classes_in_abi_jars</a>,
                     <a href="#define_kt_toolchain-experimental_remove_debug_info_in_abi_jars">experimental_remove_debug_info_in_abi_jars</a>, <a href="#define_kt_toolchain-experimental_strict_kotlin_deps">experimental_strict_kotlin_deps</a>,
                     <a href="#define_kt_toolchain-experimental_report_unused_deps">experimental_report_unused_deps</a>, <a href="#define_kt_toolchain-experimental_reduce_classpath_mode">experimental_reduce_classpath_mode</a>,
+                    <a href="#define_kt_toolchain-experimental_track_class_usage">experimental_track_class_usage</a>, <a href="#define_kt_toolchain-experimental_track_resource_usage">experimental_track_resource_usage</a>,
                     <a href="#define_kt_toolchain-experimental_multiplex_workers">experimental_multiplex_workers</a>, <a href="#define_kt_toolchain-experimental_build_tools_api">experimental_build_tools_api</a>, <a href="#define_kt_toolchain-javac_options">javac_options</a>,
                     <a href="#define_kt_toolchain-kotlinc_options">kotlinc_options</a>, <a href="#define_kt_toolchain-jvm_stdlibs">jvm_stdlibs</a>, <a href="#define_kt_toolchain-jvm_runtime">jvm_runtime</a>, <a href="#define_kt_toolchain-jacocorunner">jacocorunner</a>, <a href="#define_kt_toolchain-exec_compatible_with">exec_compatible_with</a>,
                     <a href="#define_kt_toolchain-target_compatible_with">target_compatible_with</a>, <a href="#define_kt_toolchain-target_settings">target_settings</a>)
@@ -551,6 +552,8 @@ Define the Kotlin toolchain.
 | <a id="define_kt_toolchain-experimental_strict_kotlin_deps"></a>experimental_strict_kotlin_deps |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_report_unused_deps"></a>experimental_report_unused_deps |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_reduce_classpath_mode"></a>experimental_reduce_classpath_mode |  <p align="center"> - </p>   |  `None` |
+| <a id="define_kt_toolchain-experimental_track_class_usage"></a>experimental_track_class_usage |  <p align="center"> - </p>   |  `None` |
+| <a id="define_kt_toolchain-experimental_track_resource_usage"></a>experimental_track_resource_usage |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_multiplex_workers"></a>experimental_multiplex_workers |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-experimental_build_tools_api"></a>experimental_build_tools_api |  <p align="center"> - </p>   |  `None` |
 | <a id="define_kt_toolchain-javac_options"></a>javac_options |  <p align="center"> - </p>   |  `Label("@rules_kotlin//kotlin/internal:default_javac_options")` |

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -577,6 +577,8 @@ def _run_kt_builder_action(
     args.add("--strict_kotlin_deps", toolchains.kt.experimental_strict_kotlin_deps)
     args.add_all("--classpath", compile_deps.compile_jars)
     args.add("--reduced_classpath_mode", toolchains.kt.experimental_reduce_classpath_mode)
+    args.add("--track_class_usage", toolchains.kt.experimental_track_class_usage)
+    args.add("--track_resource_usage", toolchains.kt.experimental_track_resource_usage)
     args.add("--build_tools_api", toolchains.kt.experimental_build_tools_api)
     args.add_all("--sources", srcs.all_srcs, omit_if_empty = True)
     args.add_all("--source_jars", srcs.src_jars + generated_src_jars, omit_if_empty = True)

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -90,6 +90,8 @@ def _kotlin_toolchain_impl(ctx):
         experimental_strict_kotlin_deps = ctx.attr.experimental_strict_kotlin_deps,
         experimental_report_unused_deps = ctx.attr.experimental_report_unused_deps,
         experimental_reduce_classpath_mode = ctx.attr.experimental_reduce_classpath_mode,
+        experimental_track_class_usage = ctx.attr.experimental_track_class_usage,
+        experimental_track_resource_usage = ctx.attr.experimental_track_resource_usage,
         experimental_build_tools_api = ctx.attr.experimental_build_tools_api,
         javac_options = ctx.attr.javac_options[JavacOptions] if ctx.attr.javac_options else None,
         kotlinc_options = ctx.attr.kotlinc_options[KotlincOptions] if ctx.attr.kotlinc_options else None,
@@ -180,6 +182,27 @@ _kt_toolchain = rule(
                 "off",
                 "warn",
                 "error",
+            ],
+        ),
+        "experimental_track_class_usage": attr.string(
+            doc = """Enable per-class compilation avoidance. Records which specific classes
+            from each dependency are used during compilation, along with SHA-256 hashes
+            of their bytecode. Build systems can use this data to skip recompilation when
+            a dependency changes but the used classes remain unchanged.""",
+            default = "off",
+            values = [
+                "off",
+                "on",
+            ],
+        ),
+        "experimental_track_resource_usage": attr.string(
+            doc = """Enable Android R class resource tracking. Records which R class fields
+            (e.g., R.string.app_name) are referenced during compilation. Used for
+            compilation avoidance with Android resources.""",
+            default = "off",
+            values = [
+                "off",
+                "on",
             ],
         ),
         "experimental_treat_internal_as_private_in_abi_jars": attr.bool(
@@ -353,6 +376,8 @@ def define_kt_toolchain(
         experimental_strict_kotlin_deps = None,
         experimental_report_unused_deps = None,
         experimental_reduce_classpath_mode = None,
+        experimental_track_class_usage = None,
+        experimental_track_resource_usage = None,
         experimental_multiplex_workers = None,
         experimental_build_tools_api = None,
         javac_options = Label("//kotlin/internal:default_javac_options"),
@@ -384,6 +409,8 @@ def define_kt_toolchain(
         experimental_strict_kotlin_deps = experimental_strict_kotlin_deps,
         experimental_report_unused_deps = experimental_report_unused_deps,
         experimental_reduce_classpath_mode = experimental_reduce_classpath_mode,
+        experimental_track_class_usage = experimental_track_class_usage,
+        experimental_track_resource_usage = experimental_track_resource_usage,
         experimental_build_tools_api = experimental_build_tools_api,
         javac_options = javac_options,
         kotlinc_options = kotlinc_options,

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/KotlinBuilder.kt
@@ -83,6 +83,8 @@ class KotlinBuilder(
       REDUCED_CLASSPATH_MODE("--reduced_classpath_mode"),
       INSTRUMENT_COVERAGE("--instrument_coverage"),
       BUILD_TOOLS_API("--build_tools_api"),
+      TRACK_CLASS_USAGE("--track_class_usage"),
+      TRACK_RESOURCE_USAGE("--track_resource_usage"),
     }
   }
 
@@ -157,6 +159,8 @@ class KotlinBuilder(
         argMap.mandatorySingle(KotlinBuilderFlags.LANGUAGE_VERSION)
       strictKotlinDeps = argMap.mandatorySingle(KotlinBuilderFlags.STRICT_KOTLIN_DEPS)
       reducedClasspathMode = argMap.mandatorySingle(KotlinBuilderFlags.REDUCED_CLASSPATH_MODE)
+      trackClassUsage = argMap.mandatorySingle(KotlinBuilderFlags.TRACK_CLASS_USAGE)
+      trackResourceUsage = argMap.mandatorySingle(KotlinBuilderFlags.TRACK_RESOURCE_USAGE)
       argMap.optionalSingle(KotlinBuilderFlags.ABI_JAR_INTERNAL_AS_PRIVATE)?.let {
         treatInternalAsPrivateInAbiJar = it == "true"
       }

--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinJvmTaskExecutor.kt
@@ -79,6 +79,8 @@ class KotlinJvmTaskExecutor(
                             flag("full_classpath", it)
                           }
                           flag("strict_kotlin_deps", info.strictKotlinDeps)
+                          flag("track_class_usage", info.trackClassUsage)
+                          flag("track_resource_usage", info.trackResourceUsage)
                         }
                       }.given(outputs.jar)
                       .notEmpty {

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/BaseJdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/BaseJdepsGenExtension.kt
@@ -1,11 +1,14 @@
 package io.bazel.kotlin.plugin.jdeps
 
 import com.google.devtools.build.lib.view.proto.Deps
+import com.google.protobuf.ByteString
 import io.bazel.kotlin.builder.utils.jars.JarOwner
 import org.jetbrains.kotlin.config.CompilerConfiguration
 import java.io.BufferedOutputStream
 import java.io.File
 import java.nio.file.Paths
+import java.security.MessageDigest
+import java.util.jar.JarFile
 
 abstract class BaseJdepsGenExtension(
   protected val configuration: CompilerConfiguration,
@@ -13,6 +16,7 @@ abstract class BaseJdepsGenExtension(
   protected fun onAnalysisCompleted(
     explicitClassesCanonicalPaths: Set<String>,
     implicitClassesCanonicalPaths: Set<String>,
+    usedResources: Set<String> = emptySet(),
   ) {
     val directDeps = configuration.getList(JdepsGenConfigurationKeys.DIRECT_DEPENDENCIES)
     val targetLabel = configuration.getNotNull(JdepsGenConfigurationKeys.TARGET_LABEL)
@@ -29,9 +33,24 @@ abstract class BaseJdepsGenExtension(
       explicitDeps,
       implicitClassesCanonicalPaths,
       canonicalToClasspath,
+      usedResources,
     )
 
     doStrictDeps(configuration, targetLabel, directDeps, explicitDeps)
+  }
+
+  /**
+   * Compute SHA-256 hash of a class file entry within a JAR.
+   */
+  protected fun getHashFromJarEntry(
+    jarPath: String,
+    internalPath: String,
+  ): ByteArray {
+    JarFile(jarPath).use { jarFile ->
+      val entry = jarFile.getEntry(internalPath)
+      val bytes = jarFile.getInputStream(entry).readAllBytes()
+      return MessageDigest.getInstance("SHA-256").digest(bytes)
+    }
   }
 
   /**
@@ -104,7 +123,11 @@ abstract class BaseJdepsGenExtension(
     explicitDeps: Map<String, List<String>>,
     implicitClassesCanonicalPaths: Set<String>,
     canonicalToClasspath: Map<String, String>,
+    usedResources: Set<String>,
   ) {
+    val trackClassUsage = configuration.get(JdepsGenConfigurationKeys.TRACK_CLASS_USAGE) == "on"
+    val trackResourceUsage =
+      configuration.get(JdepsGenConfigurationKeys.TRACK_RESOURCE_USAGE) == "on"
     val implicitDeps = createDepsMap(implicitClassesCanonicalPaths, canonicalToClasspath)
 
     // Build and write out deps.proto
@@ -122,10 +145,29 @@ abstract class BaseJdepsGenExtension(
       rootBuilder.addDependency(dependency)
     }
 
-    explicitDeps.forEach { (jarPath, _) ->
+    explicitDeps.toSortedMap().forEach { (jarPath, usedClasses) ->
       val dependency = Deps.Dependency.newBuilder()
       dependency.kind = Deps.Dependency.Kind.EXPLICIT
       dependency.path = jarPath
+
+      if (trackClassUsage) {
+        // Add tracked classes and their (compile time) hash into final output,
+        // as needed for per-class compilation avoidance.
+        usedClasses.sorted().forEach { classInternalPath ->
+          val name = classInternalPath.replace(".class", "").replace("/", ".")
+          val hash =
+            ByteString.copyFrom(getHashFromJarEntry(jarPath, classInternalPath))
+          val usedClass =
+            Deps.UsedClass
+              .newBuilder()
+              .setFullyQualifiedName(name)
+              .setInternalPath(classInternalPath)
+              .setHash(hash)
+              .build()
+          dependency.addUsedClasses(usedClass)
+        }
+      }
+
       rootBuilder.addDependency(dependency)
     }
 
@@ -134,6 +176,12 @@ abstract class BaseJdepsGenExtension(
       dependency.kind = Deps.Dependency.Kind.IMPLICIT
       dependency.path = it
       rootBuilder.addDependency(dependency)
+    }
+
+    if (trackResourceUsage) {
+      usedResources.sorted().forEach { resource ->
+        rootBuilder.addUsedResources(resource)
+      }
     }
 
     BufferedOutputStream(File(jdepsOutput).outputStream()).use {

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenCommandLineProcessor.kt
@@ -34,6 +34,15 @@ class JdepsGenCommandLineProcessor : CommandLineProcessor {
       )
     val STRICT_KOTLIN_DEPS_OPTION: CliOption =
       CliOption("strict_kotlin_deps", "<String>", "Report strict deps violations", required = true)
+    val TRACK_CLASS_USAGE_OPTION: CliOption =
+      CliOption("track_class_usage", "<String>", "Whether to track class usage", required = true)
+    val TRACK_RESOURCE_USAGE_OPTION: CliOption =
+      CliOption(
+        "track_resource_usage",
+        "<String>",
+        "Whether to track resource usage",
+        required = true,
+      )
   }
 
   override val pluginId: String
@@ -46,6 +55,8 @@ class JdepsGenCommandLineProcessor : CommandLineProcessor {
         DIRECT_DEPENDENCIES_OPTION,
         FULL_CLASSPATH_OPTION,
         STRICT_KOTLIN_DEPS_OPTION,
+        TRACK_CLASS_USAGE_OPTION,
+        TRACK_RESOURCE_USAGE_OPTION,
       )
 
   override fun processOption(
@@ -69,6 +80,16 @@ class JdepsGenCommandLineProcessor : CommandLineProcessor {
       STRICT_KOTLIN_DEPS_OPTION ->
         configuration.put(
           JdepsGenConfigurationKeys.STRICT_KOTLIN_DEPS,
+          value,
+        )
+      TRACK_CLASS_USAGE_OPTION ->
+        configuration.put(
+          JdepsGenConfigurationKeys.TRACK_CLASS_USAGE,
+          value,
+        )
+      TRACK_RESOURCE_USAGE_OPTION ->
+        configuration.put(
+          JdepsGenConfigurationKeys.TRACK_RESOURCE_USAGE,
           value,
         )
       else -> throw CliOptionProcessingException("Unknown option: ${option.optionName}")

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenConfigurationKeys.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenConfigurationKeys.kt
@@ -41,4 +41,20 @@ object JdepsGenConfigurationKeys {
     CompilerConfigurationKey.create(
       JdepsGenCommandLineProcessor.FULL_CLASSPATH_OPTION.description,
     )
+
+  /**
+   * Whether used class tracking is enabled or not ("on" or "off").
+   */
+  val TRACK_CLASS_USAGE: CompilerConfigurationKey<String> =
+    CompilerConfigurationKey.create(
+      JdepsGenCommandLineProcessor.TRACK_CLASS_USAGE_OPTION.description,
+    )
+
+  /**
+   * Whether used resource tracking is enabled or not ("on" or "off").
+   */
+  val TRACK_RESOURCE_USAGE: CompilerConfigurationKey<String> =
+    CompilerConfigurationKey.create(
+      JdepsGenCommandLineProcessor.TRACK_RESOURCE_USAGE_OPTION.description,
+    )
 }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/JdepsGenExtension.kt
@@ -18,6 +18,7 @@ import org.jetbrains.kotlin.descriptors.ValueDescriptor
 import org.jetbrains.kotlin.descriptors.impl.LocalVariableDescriptor
 import org.jetbrains.kotlin.extensions.StorageComponentContainerContributor
 import org.jetbrains.kotlin.load.java.descriptors.JavaClassConstructorDescriptor
+import org.jetbrains.kotlin.load.java.lazy.descriptors.LazyJavaClassDescriptor
 import org.jetbrains.kotlin.load.java.sources.JavaSourceElement
 import org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaClass
 import org.jetbrains.kotlin.load.java.structure.impl.classFiles.BinaryJavaField
@@ -128,10 +129,26 @@ class JdepsGenExtension(
           it,
         )
       }
+
+    /**
+     * Extracts Android R class resource name from a descriptor if it references an R class field.
+     * Returns the fully qualified resource name (e.g., "com.example.R.string.app_name").
+     */
+    fun getResourceName(descriptor: DeclarationDescriptorWithSource): String? {
+      val containingDeclaration = descriptor.containingDeclaration
+      if (containingDeclaration is LazyJavaClassDescriptor) {
+        val fqName = containingDeclaration.jClass.fqName?.asString()
+        if (fqName != null && (fqName.contains(".R.") || fqName.startsWith("R."))) {
+          return "$fqName.${descriptor.name.asString()}"
+        }
+      }
+      return null
+    }
   }
 
   private val explicitClassesCanonicalPaths = mutableSetOf<String>()
   private val implicitClassesCanonicalPaths = mutableSetOf<String>()
+  private val usedResources = mutableSetOf<String>()
 
   override fun registerModuleComponents(
     container: StorageComponentContainer,
@@ -139,13 +156,18 @@ class JdepsGenExtension(
     moduleDescriptor: ModuleDescriptor,
   ) {
     container.useInstance(
-      ClasspathCollectingChecker(explicitClassesCanonicalPaths, implicitClassesCanonicalPaths),
+      ClasspathCollectingChecker(
+        explicitClassesCanonicalPaths,
+        implicitClassesCanonicalPaths,
+        usedResources,
+      ),
     )
   }
 
   class ClasspathCollectingChecker(
     private val explicitClassesCanonicalPaths: MutableSet<String>,
     private val implicitClassesCanonicalPaths: MutableSet<String>,
+    private val usedResources: MutableSet<String>,
   ) : CallChecker,
     DeclarationChecker {
     override fun check(
@@ -200,6 +222,11 @@ class JdepsGenExtension(
 
       if (resultingDescriptor is ValueDescriptor) {
         collectTypeReferences(resultingDescriptor.type, isExplicit = false)
+        // Track Android R class resource references
+        // ValueDescriptor extends DeclarationDescriptorWithSource, so we can cast directly
+        getResourceName(resultingDescriptor as DeclarationDescriptorWithSource)?.let {
+          usedResources.add(it)
+        }
       }
     }
 
@@ -346,7 +373,7 @@ class JdepsGenExtension(
     bindingTrace: BindingTrace,
     files: Collection<KtFile>,
   ): AnalysisResult? {
-    onAnalysisCompleted(explicitClassesCanonicalPaths, implicitClassesCanonicalPaths)
+    onAnalysisCompleted(explicitClassesCanonicalPaths, implicitClassesCanonicalPaths, usedResources)
 
     return super.analysisCompleted(project, module, bindingTrace, files)
   }

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/README.md
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/README.md
@@ -1,0 +1,138 @@
+# Per-Class Compilation Avoidance
+
+This feature enables fine-grained dependency tracking for Kotlin compilation, recording exactly which classes from each dependency JAR are used during compilation along with their bytecode hashes.
+
+## Overview
+
+Traditional compilation avoidance works at the JAR level: if any file in a dependency JAR changes, all dependents must recompile. Per-class compilation avoidance improves on this by tracking:
+
+1. **Which classes** from each dependency are actually used
+2. **Bytecode hashes** (SHA-256) of those specific classes
+
+If a dependency JAR changes but the specific classes your target uses remain unchanged (same hashes), recompilation can be skipped.
+
+## Configuration
+
+Enable via the Kotlin toolchain:
+
+```starlark
+load("@rules_kotlin//kotlin:toolchains.bzl", "define_kt_toolchain")
+
+define_kt_toolchain(
+    name = "my_toolchain",
+    experimental_track_class_usage = "on",    # Track class usage with hashes
+    experimental_track_resource_usage = "on", # Track Android R class references
+)
+```
+
+### Options
+
+| Option | Values | Description |
+|--------|--------|-------------|
+| `experimental_track_class_usage` | `"off"` (default), `"on"` | Enable per-class tracking with bytecode hashes |
+| `experimental_track_resource_usage` | `"off"` (default), `"on"` | Track Android R class field references |
+
+## How It Works
+
+### Class Usage Tracking
+
+During Kotlin compilation, the JDeps compiler plugin hooks into the analysis phase:
+
+1. **K1 (classic compiler)**: Uses `CallChecker` and `DeclarationChecker` interfaces
+2. **K2 (FIR compiler)**: Uses FIR checker extensions
+
+For each class reference, the plugin records:
+- Direct type references (class declarations, return types)
+- Supertypes (parent classes, implemented interfaces)
+- Type arguments (generics)
+- Annotations
+
+When writing the jdeps proto, each used class entry includes:
+- `fullyQualifiedName`: e.g., `com.example.MyClass`
+- `internalPath`: e.g., `com/example/MyClass.class`
+- `hash`: SHA-256 hash of the `.class` bytecode
+
+### Resource Usage Tracking
+
+For Android projects, the plugin also tracks R class field references:
+- Detects access to fields in classes matching the pattern `*.R.*` or `R.*`
+- Records the full resource reference (e.g., `com.example.R.string.app_name`)
+
+## Output Format
+
+The jdeps proto (`deps.proto`) includes:
+
+```protobuf
+message Dependency {
+  required string path = 1;
+  required Kind kind = 2;
+  repeated UsedClass usedClasses = 4;  // Added by this feature
+}
+
+message UsedClass {
+  required string fullyQualifiedName = 1;
+  required string internalPath = 2;
+  required bytes hash = 3;  // SHA-256
+}
+
+message Dependencies {
+  repeated string usedResources = 6;  // Added by this feature
+}
+```
+
+## Build System Integration
+
+To use this feature for compilation avoidance, your build system must:
+
+1. Parse the jdeps proto output
+2. Store the `UsedClass` entries and their hashes
+3. On dependency change, compare hashes of used classes
+4. Skip recompilation if all used class hashes match
+
+## Performance Considerations
+
+**Build-time overhead**:
+- Hash computation adds latency (reading and SHA-256 hashing each used class)
+- Larger jdeps files (each used class adds ~60-80 bytes)
+
+**Build avoidance benefit**:
+- Significant time savings when dependencies change frequently
+- Most effective for large monorepos with many transitive dependencies
+
+## Limitations
+
+1. **Kotlin only**: Only tracks class usage during Kotlin compilation. Mixed Java/Kotlin projects may miss Java-only class references.
+
+2. **No method-level tracking**: Tracks whole classes, not individual methods/fields. A change to any method in a used class will trigger recompilation.
+
+3. **Constant inlining**: Compile-time constants from dependencies are inlined into bytecode. If a constant's value changes, the using class won't see the dependency.
+
+4. **Reflection**: Classes accessed via reflection at runtime are not tracked.
+
+5. **Annotation processors**: Dependencies introduced by annotation processors may need separate tracking.
+
+## Example
+
+Given a target that uses `com.lib.Parser` from a dependency:
+
+```kotlin
+import com.lib.Parser
+
+fun process(input: String) = Parser.parse(input)
+```
+
+The jdeps output will include:
+
+```
+dependency {
+  path: "bazel-out/.../libparser.jar"
+  kind: EXPLICIT
+  usedClasses {
+    fullyQualifiedName: "com.lib.Parser"
+    internalPath: "com/lib/Parser.class"
+    hash: <32 bytes SHA-256>
+  }
+}
+```
+
+If `libparser.jar` is rebuilt but `Parser.class` has the same hash, recompilation can be skipped.

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/ClassUsageRecorder.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/ClassUsageRecorder.kt
@@ -20,6 +20,7 @@ private const val ANONYMOUS = "<anonymous>"
 class ClassUsageRecorder(
   internal val explicitClassesCanonicalPaths: MutableSet<String> = mutableSetOf(),
   internal val implicitClassesCanonicalPaths: MutableSet<String> = mutableSetOf(),
+  internal val usedResources: MutableSet<String> = mutableSetOf(),
   private val seen: MutableSet<ClassId> = mutableSetOf(),
   private val results: MutableMap<String, SortedSet<String>> = sortedMapOf(),
   private val rootPath: String = Paths.get("").toAbsolutePath().toString() + "/",

--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/JdepsGenExtension2.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/JdepsGenExtension2.kt
@@ -14,6 +14,7 @@ internal class JdepsGenExtension2(
     onAnalysisCompleted(
       classUsageRecorder.explicitClassesCanonicalPaths,
       classUsageRecorder.implicitClassesCanonicalPaths,
+      classUsageRecorder.usedResources,
     )
   }
 }

--- a/src/main/protobuf/deps.proto
+++ b/src/main/protobuf/deps.proto
@@ -48,6 +48,22 @@ message Dependency {
 
   // Source file locations: compilers can pinpoint the uses of a dependency.
   repeated SourceLocation location = 3;
+
+  // List of used classes from this dependency (for per-class compilation avoidance).
+  repeated UsedClass usedClasses = 4;
+}
+
+// Represents a class used from a dependency, with its bytecode hash for
+// per-class compilation avoidance.
+message UsedClass {
+  // Class fully qualified name (e.g., "com.example.MyClass")
+  required string fullyQualifiedName = 1;
+
+  // Path within jar to .class file (e.g., "com/example/MyClass.class")
+  required string internalPath = 2;
+
+  // SHA-256 hash of the corresponding .class bytecode.
+  required bytes hash = 3;
 }
 
 // Top-level message found in .deps artifacts
@@ -68,4 +84,7 @@ message Dependencies {
   // occurred suggesting that it should be rerun with the full classpath, this
   // will be true.
   optional bool requires_reduced_classpath_fallback = 5;
+
+  // List of used android resources (e.g., R.string.app_name).
+  repeated string usedResources = 6;
 }

--- a/src/main/protobuf/deps.proto
+++ b/src/main/protobuf/deps.proto
@@ -50,7 +50,7 @@ message Dependency {
   repeated SourceLocation location = 3;
 
   // List of used classes from this dependency (for per-class compilation avoidance).
-  repeated UsedClass usedClasses = 4;
+  repeated UsedClass usedClasses = 1000;
 }
 
 // Represents a class used from a dependency, with its bytecode hash for
@@ -86,5 +86,5 @@ message Dependencies {
   optional bool requires_reduced_classpath_fallback = 5;
 
   // List of used android resources (e.g., R.string.app_name).
-  repeated string usedResources = 6;
+  repeated string usedResources = 1000;
 }

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -90,6 +90,10 @@ message CompilationTaskInfo {
     bool build_tools_api = 14;
     // Debug info is stripped in abi.jar generation
     bool remove_debug_info = 15;
+    // Whether to track used classes in .jdeps (for per-class compilation avoidance)
+    string track_class_usage = 16;
+    // Whether to track used android resources in .jdeps
+    string track_resource_usage = 17;
 }
 
 // Nested messages not marked with stable could be refactored.

--- a/src/main/protobuf/kotlin_model.proto
+++ b/src/main/protobuf/kotlin_model.proto
@@ -91,9 +91,9 @@ message CompilationTaskInfo {
     // Debug info is stripped in abi.jar generation
     bool remove_debug_info = 15;
     // Whether to track used classes in .jdeps (for per-class compilation avoidance)
-    string track_class_usage = 16;
+    string track_class_usage = 1000;
     // Whether to track used android resources in .jdeps
-    string track_resource_usage = 17;
+    string track_resource_usage = 1001;
 }
 
 // Nested messages not marked with stable could be refactored.

--- a/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
+++ b/src/test/kotlin/io/bazel/kotlin/builder/KotlinJvmTestBuilder.java
@@ -232,6 +232,16 @@ public final class KotlinJvmTestBuilder extends KotlinAbstractTestBuilder<JvmCom
             return this;
         }
 
+        public TaskBuilder trackClassUsage(String level) {
+            taskBuilder.getInfoBuilder().setTrackClassUsage(level);
+            return this;
+        }
+
+        public TaskBuilder trackResourceUsage(String level) {
+            taskBuilder.getInfoBuilder().setTrackResourceUsage(level);
+            return this;
+        }
+
         public TaskBuilder outputAbiJar() {
             taskBuilder.getOutputsBuilder()
                     .setAbijar(instanceRoot().resolve("abi.jar").toAbsolutePath().toString());

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/BUILD.bazel
@@ -60,6 +60,15 @@ kt_rules_test(
 )
 
 kt_rules_test(
+    name = "KotlinBuilderJvmClassTrackingTest",
+    size = "large",
+    srcs = ["jvm/KotlinBuilderJvmClassTrackingTest.kt"],
+    data = [
+        ":JdepsParserTestFixtures",
+    ],
+)
+
+kt_rules_test(
     name = "KotlinBuilderJvmStrictDepsTest",
     size = "large",
     srcs = ["jvm/KotlinBuilderJvmStrictDepsTest.kt"],
@@ -127,6 +136,7 @@ test_suite(
         ":JdepsParserTest",
         ":KotlinBuilderJvmAbiTest",
         ":KotlinBuilderJvmBasicTest",
+        ":KotlinBuilderJvmClassTrackingTest",
         ":KotlinBuilderJvmCoverageTest",
         ":KotlinBuilderJvmJdepsTest",
         ":KotlinBuilderJvmKaptTest",

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmClassTrackingTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmClassTrackingTest.kt
@@ -1,0 +1,274 @@
+/*
+ * Copyright 2020 The Bazel Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package io.bazel.kotlin.builder.tasks.jvm
+
+import com.google.common.truth.Truth.assertThat
+import com.google.devtools.build.lib.view.proto.Deps
+import io.bazel.kotlin.builder.Deps.Dep
+import io.bazel.kotlin.builder.KotlinJvmTestBuilder
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import java.io.BufferedInputStream
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.function.Consumer
+
+/**
+ * Tests for per-class compilation avoidance feature (class usage tracking).
+ */
+@RunWith(Parameterized::class)
+class KotlinBuilderJvmClassTrackingTest(private val enableK2Compiler: Boolean) {
+
+  companion object {
+    @JvmStatic
+    @Parameterized.Parameters(name = "enableK2Compiler={0}")
+    fun data(): Collection<Array<Any>> {
+      return listOf(
+        arrayOf(true),
+        arrayOf(false),
+      )
+    }
+  }
+
+  val ctx = KotlinJvmTestBuilder()
+
+  val TEST_FIXTURES_DEP = Dep.fromLabel(":JdepsParserTestFixtures")
+
+  @Test
+  fun `class tracking disabled by default`() {
+    val deps = runJdepsCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//deps")
+      c.addSource(
+        "AClass.kt",
+        """
+          package something
+
+          val result = JavaClass.staticMethod()
+        """,
+      )
+      c.addDirectDependencies(TEST_FIXTURES_DEP)
+    }
+
+    val jdeps = depsProto(deps)
+
+    // Verify jdeps has explicit dependency
+    assertThat(jdeps.dependencyCount).isGreaterThan(0)
+
+    // Verify no UsedClass entries when tracking is off
+    val explicitDep = jdeps.dependencyList.find { it.kind == Deps.Dependency.Kind.EXPLICIT }
+    assertThat(explicitDep).isNotNull()
+    assertThat(explicitDep!!.usedClassesCount).isEqualTo(0)
+  }
+
+  @Test
+  fun `class tracking records used classes with hashes when enabled`() {
+    val deps = runJdepsCompileTaskWithClassTracking { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//deps")
+      c.addSource(
+        "AClass.kt",
+        """
+          package something
+
+          val result = JavaClass.staticMethod()
+        """,
+      )
+      c.addDirectDependencies(TEST_FIXTURES_DEP)
+    }
+
+    val jdeps = depsProto(deps)
+
+    // Verify jdeps has explicit dependency
+    assertThat(jdeps.dependencyCount).isGreaterThan(0)
+
+    // Verify UsedClass entries exist when tracking is on
+    val explicitDep = jdeps.dependencyList.find { it.kind == Deps.Dependency.Kind.EXPLICIT }
+    assertThat(explicitDep).isNotNull()
+    assertThat(explicitDep!!.usedClassesCount).isGreaterThan(0)
+
+    // Verify UsedClass has required fields
+    val usedClass = explicitDep.usedClassesList.first()
+    assertThat(usedClass.fullyQualifiedName).isNotEmpty()
+    assertThat(usedClass.internalPath).endsWith(".class")
+    assertThat(usedClass.hash.size()).isEqualTo(32) // SHA-256 = 32 bytes
+  }
+
+  @Test
+  fun `class tracking records multiple used classes`() {
+    val deps = runJdepsCompileTaskWithClassTracking { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//deps")
+      c.addSource(
+        "MultipleClasses.kt",
+        """
+          package something
+
+          val result1 = JavaClass.staticMethod()
+          val result2 = Constants.HELLO_CONSTANT
+        """,
+      )
+      c.addDirectDependencies(TEST_FIXTURES_DEP)
+    }
+
+    val jdeps = depsProto(deps)
+
+    // Verify UsedClass entries for multiple classes
+    val explicitDep = jdeps.dependencyList.find { it.kind == Deps.Dependency.Kind.EXPLICIT }
+    assertThat(explicitDep).isNotNull()
+
+    // Should have tracked multiple classes
+    val usedClassNames = explicitDep!!.usedClassesList.map { it.fullyQualifiedName }.toSet()
+    assertThat(usedClassNames).contains("something.JavaClass")
+    assertThat(usedClassNames).contains("something.Constants")
+  }
+
+  @Test
+  fun `class tracking includes supertype dependencies`() {
+    val baseClass = runCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//:base")
+      c.addSource(
+        "Base.kt",
+        """
+          package something
+
+          open class Base
+        """,
+      )
+    }
+
+    val derivedClass = runCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//:derived")
+      c.addSource(
+        "Derived.kt",
+        """
+          package something
+
+          class Derived : Base()
+        """,
+      )
+      c.addDirectDependencies(baseClass)
+    }
+
+    val deps = runJdepsCompileTaskWithClassTracking { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//deps")
+      c.addSource(
+        "UsesDerived.kt",
+        """
+          package something
+
+          val instance = Derived()
+        """,
+      )
+      c.addDirectDependencies(derivedClass)
+      c.addTransitiveDependencies(baseClass)
+    }
+
+    val jdeps = depsProto(deps)
+
+    // The explicit dep should have Derived class tracked
+    val explicitDep = jdeps.dependencyList.find {
+      it.kind == Deps.Dependency.Kind.EXPLICIT && it.usedClassesCount > 0
+    }
+    assertThat(explicitDep).isNotNull()
+
+    val usedClassNames = explicitDep!!.usedClassesList.map { it.fullyQualifiedName }
+    assertThat(usedClassNames).contains("something.Derived")
+  }
+
+  @Test
+  fun `class hashes are deterministic`() {
+    // Run the same compilation twice and verify hashes match
+    val deps1 = runJdepsCompileTaskWithClassTracking { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//deps1")
+      c.addSource(
+        "AClass.kt",
+        """
+          package something
+
+          val result = JavaClass.staticMethod()
+        """,
+      )
+      c.addDirectDependencies(TEST_FIXTURES_DEP)
+    }
+
+    val deps2 = runJdepsCompileTaskWithClassTracking { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//deps2")
+      c.addSource(
+        "BClass.kt",
+        """
+          package something
+
+          val result = JavaClass.staticMethod()
+        """,
+      )
+      c.addDirectDependencies(TEST_FIXTURES_DEP)
+    }
+
+    val jdeps1 = depsProto(deps1)
+    val jdeps2 = depsProto(deps2)
+
+    // Find JavaClass in both jdeps
+    val javaClassHash1 = jdeps1.dependencyList
+      .flatMap { it.usedClassesList }
+      .find { it.fullyQualifiedName == "something.JavaClass" }
+      ?.hash
+
+    val javaClassHash2 = jdeps2.dependencyList
+      .flatMap { it.usedClassesList }
+      .find { it.fullyQualifiedName == "something.JavaClass" }
+      ?.hash
+
+    assertThat(javaClassHash1).isNotNull()
+    assertThat(javaClassHash2).isNotNull()
+    assertThat(javaClassHash1).isEqualTo(javaClassHash2)
+  }
+
+  private fun depsProto(jdeps: Dep) =
+    Deps.Dependencies.parseFrom(BufferedInputStream(Files.newInputStream(Paths.get(jdeps.jdeps()!!))))
+
+  private fun runCompileTask(block: (c: KotlinJvmTestBuilder.TaskBuilder) -> Unit): Dep {
+    return ctx.runCompileTask(
+      Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+        if (enableK2Compiler) {
+          c.useK2()
+        }
+        block(c.outputJar().compileKotlin())
+      },
+    )
+  }
+
+  private fun runJdepsCompileTask(block: (c: KotlinJvmTestBuilder.TaskBuilder) -> Unit): Dep {
+    return ctx.runCompileTask(
+      Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+        if (enableK2Compiler) {
+          c.useK2()
+        }
+        block(c.outputJar().outputJdeps().compileKotlin())
+      },
+    )
+  }
+
+  private fun runJdepsCompileTaskWithClassTracking(block: (c: KotlinJvmTestBuilder.TaskBuilder) -> Unit): Dep {
+    return ctx.runCompileTask(
+      Consumer { c: KotlinJvmTestBuilder.TaskBuilder ->
+        if (enableK2Compiler) {
+          c.useK2()
+        }
+        block(c.outputJar().outputJdeps().trackClassUsage("on").compileKotlin())
+      },
+    )
+  }
+}


### PR DESCRIPTION
This change adds support for per-class compilation avoidance, enabling fine-grained dependency tracking during Kotlin compilation. When enabled, the jdeps output records exactly
   which classes from each dependency JAR are used, along with SHA-256 hashes of their bytecode.

  Motivation

  Traditional compilation avoidance works at the JAR level—if any file in a dependency JAR changes, all dependents must recompile. Per-class tracking improves this by allowing
  build systems to skip recompilation when a dependency JAR changes but the specific classes actually used remain unchanged (same hashes).

  Configuration

  Two new toolchain attributes:

  define_kt_toolchain(
      name = "my_toolchain",
      experimental_track_class_usage = "on",    # Track class usage with hashes
      experimental_track_resource_usage = "on", # Track Android R class references
  )

  Changes

  Proto definitions:
  - deps.proto: Added UsedClass message with fullyQualifiedName, internalPath, and hash fields; added usedResources field to Dependencies
  - kotlin_model.proto: Added track_class_usage and track_resource_usage fields

  JDeps plugin:
  - Added configuration keys and CLI options for the new tracking flags
  - BaseJdepsGenExtension: Added getHashFromJarEntry() to compute SHA-256 hashes; updated doWriteJdeps() to write UsedClass entries when tracking is enabled
  - JdepsGenExtension (K1): Added resource tracking for Android R class references
  - K2 extensions: Added usedResources support

  Builder:
  - Added TRACK_CLASS_USAGE and TRACK_RESOURCE_USAGE flags to KotlinBuilder
  - Pass tracking flags to jdeps plugin in KotlinJvmTaskExecutor

  Starlark rules:
  - toolchains.bzl: Added experimental_track_class_usage and experimental_track_resource_usage attributes
  - compile.bzl: Pass tracking flags to builder

  Output Format

  When enabled, jdeps includes per-class entries:

  dependency {
    path: "bazel-out/.../libparser.jar" kind: EXPLICIT usedClasses { fullyQualifiedName: "com.lib.Parser" internalPath: "com/lib/Parser.class"
      hash: <32 bytes SHA-256>
    } }

  Testing

  Added KotlinBuilderJvmClassTrackingTest with tests verifying:
  - Tracking is disabled by default (no UsedClass entries)
  - Tracking records classes with hashes when enabled
  - Multiple classes are tracked correctly
  - Supertype dependencies are included
  - Hashes are deterministic across compilations