### PR TITLE
Add back ktlint_fix_all command

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,4 +1,5 @@
 load("@buildifier_prebuilt//:rules.bzl", "buildifier")
+load("@rules_multirun//:defs.bzl", "multirun")
 load("//kotlin:lint.bzl", "ktlint_config")
 
 # Copyright 2018 The Bazel Authors. All rights reserved.
@@ -76,6 +77,25 @@ filegroup(
         ":rules_kotlin_release",
     ],
     visibility = ["//:__subpackages__"],
+)
+
+multirun(
+    name = "ktlint_fix_all",
+    commands = [
+        "//src/main/kotlin/io/bazel/kotlin/builder/cmd:build_lib_ktlint_fix",
+        "//src/main/kotlin/io/bazel/kotlin/builder/cmd:ksp2_lib_ktlint_fix",
+        "//src/main/kotlin/io/bazel/kotlin/builder/cmd:merge_jdeps_lib_ktlint_fix",
+        "//src/main/kotlin/io/bazel/kotlin/builder/tasks:tasks_ktlint_fix",
+        "//src/main/kotlin/io/bazel/kotlin/builder/toolchain:toolchain_ktlint_fix",
+        "//src/main/kotlin/io/bazel/kotlin/builder/utils:utils_ktlint_fix",
+        "//src/main/kotlin/io/bazel/kotlin/builder/utils/jars:jars_ktlint_fix",
+        "//src/main/kotlin/io/bazel/kotlin/compiler:compiler_ktlint_fix",
+        "//src/main/kotlin/io/bazel/kotlin/ksp2:ksp2_ktlint_fix",
+        "//src/main/kotlin/io/bazel/kotlin/plugin:skip-code-gen-lib_ktlint_fix",
+        "//src/main/kotlin/io/bazel/kotlin/plugin/jdeps:jdeps-gen-lib_ktlint_fix",
+        "//src/main/kotlin/io/bazel/worker:worker_ktlint_fix",
+    ],
+    jobs = 0,
 )
 
 # TODO[https://github.com/bazelbuild/rules_kotlin/issues/1395]: Must be run with `--config=deprecated`

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,6 +37,7 @@ bazel_dep(name = "bazel_worker_api", version = "0.0.10")
 bazel_dep(name = "bazel_worker_java", version = "0.0.10")
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1", dev_dependency = True)
+bazel_dep(name = "rules_multirun", version = "0.13.0", dev_dependency = True)
 
 rules_java_toolchains = use_extension("@rules_java//java:extensions.bzl", "toolchains")
 use_repo(rules_java_toolchains, "remote_java_tools")

--- a/src/main/kotlin/bootstrap.bzl
+++ b/src/main/kotlin/bootstrap.bzl
@@ -50,7 +50,7 @@ def kt_bootstrap_library(name, deps = [], neverlink_deps = [], srcs = [], visibi
     _ktlint_fix(
         name = "%s_ktlint_fix" % name,
         srcs = srcs,
-        visibility = ["//visibility:private"],
+        visibility = ["//visibility:public"],
         config = "//:ktlint_editorconfig",
         tags = ["no-ide", "ktlint"],
         **kwargs


### PR DESCRIPTION
Adding back a multirun command for formatting all of our Kotlin sources.