### PR TITLE
Enable multiplex workers by default

### DIFF
--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -140,7 +140,7 @@ _kt_toolchain = rule(
         ),
         "experimental_multiplex_workers": attr.bool(
             doc = """Run workers in multiplex mode.""",
-            default = False,
+            default = True,
         ),
         "experimental_reduce_classpath_mode": attr.string(
             doc = "Removes unneeded dependencies from the classpath",


### PR DESCRIPTION
We've kept this as optional because of this issue https://github.com/bazelbuild/rules_kotlin/issues/652