### PR TITLE
Remove compatibility level from MODULE.bazel

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,7 +1,6 @@
 module(
     name = "rules_kotlin",
     version = "2.2.0",
-    compatibility_level = 1,
     repo_name = "rules_kotlin",
 )
 

--- a/MODULE.release.bazel
+++ b/MODULE.release.bazel
@@ -1,7 +1,6 @@
 module(
     name = "rules_kotlin",
     version = "1.9.0",
-    compatibility_level = 1,
     repo_name = "rules_kotlin",
 )
 


### PR DESCRIPTION
This will get rid of this warning `WARNING: /home/agluszak/code/bazel/rules_kotlin/MODULE.bazel:1:7: The attribute 'compatibility_level' in module() is a no-op and will be removed in a future Bazel release. Please remove it from your MODULE.bazel file.`