### PR TITLE
Update README to point to bazel-contrib

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 # Bazel Kotlin Rules
 
 [![Build Status](https://badge.buildkite.com/a8860e94a7378491ce8f50480e3605b49eb2558cfa851bbf9b.svg)](https://buildkite.com/bazel/kotlin-postsubmit)
-<a href="https://github.com/bazelbuild/rules_kotlin/tree/master"><img src="https://img.shields.io/badge/Main%20Branch-master-blue.svg"/></a>
+<a href="https://github.com/bazel-contrib/rules_kotlin/tree/master"><img src="https://img.shields.io/badge/Main%20Branch-master-blue.svg"/></a>
 ###  Releases
 
-<a href="https://github.com/bazelbuild/rules_kotlin/releases/latest"><img src="https://img.shields.io/github/v/release/bazelbuild/rules_kotlin?display_name=tag&label=Latest%20Stable%20Release"/></a>
+<a href="https://github.com/bazel-contrib/rules_kotlin/releases/latest"><img src="https://img.shields.io/github/v/release/bazel-contrib/rules_kotlin?display_name=tag&label=Latest%20Stable%20Release"/></a>
 <br/>
-<a href="https://github.com/bazelbuild/rules_kotlin/releases/"><img src="https://img.shields.io/github/v/release/bazelbuild/rules_kotlin?display_name=tag&include_prereleases&label=Latest%20Release%20Candidate"/></a>
+<a href="https://github.com/bazel-contrib/rules_kotlin/releases/"><img src="https://img.shields.io/github/v/release/bazel-contrib/rules_kotlin?display_name=tag&include_prereleases&label=Latest%20Release%20Candidate"/></a>
 
-For more information about release and changelogs please see [Changelog](CHANGELOG.md) or refer to the [Github Releases](https://github.com/bazelbuild/rules_kotlin/releases) page.
+For more information about release and changelogs please see [Changelog](CHANGELOG.md) or refer to the [Github Releases](https://github.com/bazel-contrib/rules_kotlin/releases) page.
 
 # Overview 
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Javascript is reported to work, but is not as well maintained (at present)
 # Documentation
 
 Generated API documentation is available at
-[https://bazelbuild.github.io/rules_kotlin/kotlin](https://bazelbuild.github.io/rules_kotlin/kotlin).
+[https://bazel-contrib.github.io/rules_kotlin/kotlin](https://bazel-contrib.github.io/rules_kotlin/kotlin).
 
 # Quick Guide
 


### PR DESCRIPTION
Updating the README to go from `bazelbuild` -> `bazel-contrib`.