### PR TITLE
Export core/plugin bzl_library from release archive

### DIFF
--- a/src/main/starlark/core/BUILD.release.bazel
+++ b/src/main/starlark/core/BUILD.release.bazel
@@ -21,6 +21,7 @@ bzl_library(
     deps = [
         "//src/main/starlark/core/compile",
         "//src/main/starlark/core/options",
+        "//src/main/starlark/core/plugin",
         "//src/main/starlark/core/repositories",
     ],
 )

--- a/src/main/starlark/core/plugin/BUILD.release.bazel
+++ b/src/main/starlark/core/plugin/BUILD.release.bazel
@@ -3,5 +3,5 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 bzl_library(
     name = "plugin",
     srcs = glob(["*.bzl"]),
-    visibility = ["//:__subpackages__"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Make the `//src/main/starlark/core/plugin:plugin` `bzl_library` publicly visible in the released archive and reachable transitively through the public `core` target, so external rulesets can depend on it.