### PR TITLE
Add Publish to BCR workflow to replace deprecated GitHub App

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,45 @@
+# Publishes a release to the Bazel Central Registry (BCR).
+#
+# This replaces the legacy "Publish to BCR" GitHub App, which is deprecated and
+# is being discontinued after 2026-06-30. It opens a pull request against
+# https://github.com/bazelbuild/bazel-central-registry using the templates in
+# the .bcr/ folder.
+#
+# Trigger: fires when a release is promoted to a full (non-prerelease) release.
+# Our release.yml cuts releases as prereleases first; the `released` activity
+# type fires both when a release is published as a full release and when a
+# prerelease is changed to a release, which matches the behavior the GitHub App
+# previously had. It can also be run manually via workflow_dispatch for a tag.
+#
+# Requirements (must be configured by a repo admin):
+#   - A registry fork the workflow can push to: bazel-contrib/bazel-central-registry.
+#   - A classic Personal Access Token with `repo` scope stored as the
+#     BCR_PUBLISH_TOKEN repository secret. Fine-grained PATs cannot open pull
+#     requests against public repos, so a classic PAT is required.
+name: Publish to BCR
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: The release tag to publish to the BCR, e.g. v2.4.0
+        required: true
+        type: string
+
+jobs:
+  publish:
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.4.1
+    permissions:
+      contents: write # Upload release files / read the release
+      id-token: write # Attest provenance
+      attestations: write # Attest provenance
+    with:
+      tag_name: ${{ github.event.release.tag_name || inputs.tag_name }}
+      registry_fork: bazel-contrib/bazel-central-registry
+      # release.yml does not produce attestations (it uses
+      # softprops/action-gh-release, not the bazel-contrib reusable release
+      # workflow), so skip attestation upload.
+      attest: false
+    secrets:
+      publish_token: ${{ secrets.BCR_PUBLISH_TOKEN }}


### PR DESCRIPTION
## Why

Automated publishing to the Bazel Central Registry has been broken since March 2026. The legacy **Publish to BCR GitHub App** last opened a registry PR for `rules_kotlin@2.3.10` (2026-03-08). Every release since then — `2.3.20`, `2.3.21` — had to be pushed to the BCR **manually** by community members (and the 2.3.21 PR was even closed over a CLA check). The app is deprecated and is being **discontinued after 2026-06-30**.

## What

Migrates to the supported reusable workflow [`bazel-contrib/publish-to-bcr`](https://github.com/bazel-contrib/publish-to-bcr) (pinned to `v1.4.1`):

- Adds `.github/workflows/publish.yaml`.
- Triggers on `release: [released]` — fires when a release is published as / promoted to a full (non-prerelease) release, matching the GitHub App's previous behavior with our `release.yml` (which cuts prereleases first). Also runnable via `workflow_dispatch` for a given tag.
- Opens the registry PR using the existing `.bcr/` templates and pushes the entry branch via the existing `bazel-contrib/bazel-central-registry` fork.
- `attest: false` because `release.yml` uses `softprops/action-gh-release` and does not produce attestations.

## Required follow-up (repo admin)

This won't function until a secret is added:

- Create a **classic** Personal Access Token with `repo` scope.
- Store it as the **`BCR_PUBLISH_TOKEN`** repository secret.

A fine-grained PAT will not work — it can't open PRs against public repos.

## Notes

- `.bcr/config.yml` (`fixedReleaser`) and the other `.bcr/` templates are unchanged; the reusable workflow reads them as-is.
- The release flow is otherwise unchanged: cut the release, promote it from prerelease to full, and the BCR PR opens automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)