### PR TITLE
Bump compatibility_level to 1

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,7 @@
 module(
     name = "rules_kotlin",
     version = "2.2.0",
+    compatibility_level = 1,
     repo_name = "rules_kotlin",
 )
 

--- a/MODULE.release.bazel
+++ b/MODULE.release.bazel
@@ -1,6 +1,7 @@
 module(
     name = "rules_kotlin",
     version = "1.9.0",
+    compatibility_level = 1,
     repo_name = "rules_kotlin",
 )
 


### PR DESCRIPTION
This isn't needed in newer version of Bazel, but since we still support Bazel 7.x we have to have this around. This was dropped recently in master.

```
WARNING: The following rc files are no longer being read, please transfer their contents or import their path into one of the standard rc files:
/etc/bazel.bazelrc
ERROR: protobuf@33.4 depends on rules_kotlin@1.9.6 with compatibility level 1, but <root> depends on rules_kotlin@2.3.21-test-1 with compatibility level 0 which is different
```