### PR TITLE
Update BCR pre-submit to run 9.x tests

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -1,6 +1,6 @@
 matrix:
   platform: ["macos_arm64", "ubuntu2004"]
-  bazel: ["7.x", "8.x"]
+  bazel: ["7.x", "8.x", "9.x"]
 tasks:
   verify_targets:
     name: "Verify build targets"


### PR DESCRIPTION
Adding Bazel 9 integration tests on the BCR side since this project already supports Bazel 9.