### PR TITLE
Introduce `kt_jvm_test_suite`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -65,6 +65,7 @@ register_toolchains("//kotlin/internal:default_toolchain")
 # we need to sort out a few cases around how these rules are consumed in various ways.
 
 bazel_dep(name = "rules_jvm_external", version = "7.0")
+bazel_dep(name = "contrib_rules_jvm", version = "0.31.1")
 
 bazel_dep(name = "bazel_ci_rules", version = "2.0.0", dev_dependency = True)
 

--- a/MODULE.release.bazel
+++ b/MODULE.release.bazel
@@ -7,6 +7,7 @@ module(
 
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
+bazel_dep(name = "contrib_rules_jvm", version = "0.31.1")
 bazel_dep(name = "rules_java", version = "8.9.0")
 bazel_dep(name = "rules_license", version = "1.0.0")
 bazel_dep(name = "rules_android", version = "0.7.1")

--- a/docs/kotlin.md
+++ b/docs/kotlin.md
@@ -214,6 +214,48 @@ Setup a simple kotlin_test.
 | <a id="kt_jvm_test-test_class"></a>test_class |  The Java class to be loaded by the test runner.   | String | optional |  `""`  |
 
 
+<a id="kt_jvm_test_suite"></a>
+
+## kt_jvm_test_suite
+
+<pre>
+load("@rules_kotlin//kotlin:jvm.bzl", "kt_jvm_test_suite")
+
+kt_jvm_test_suite(<a href="#kt_jvm_test_suite-name">name</a>, <a href="#kt_jvm_test_suite-srcs">srcs</a>, <a href="#kt_jvm_test_suite-runner">runner</a>, <a href="#kt_jvm_test_suite-test_suffixes">test_suffixes</a>, <a href="#kt_jvm_test_suite-package">package</a>, <a href="#kt_jvm_test_suite-deps">deps</a>, <a href="#kt_jvm_test_suite-runtime_deps">runtime_deps</a>, <a href="#kt_jvm_test_suite-size">size</a>, <a href="#kt_jvm_test_suite-kwargs">**kwargs</a>)
+</pre>
+
+Create a suite of Kotlin tests from `*Test.kt` files.
+
+This rule will create a `kt_jvm_test` for each file which matches
+any of the `test_suffixes` that are passed to this rule as
+`srcs`. If any non-test sources are added these will first be
+compiled into a `kt_jvm_library` which will be added as a
+dependency for each test target, allowing common utility functions
+to be shared between tests.
+
+The generated `kt_jvm_test` targets will be named after the test file:
+`FooTest.kt` will create a `:FooTest` target.
+
+In addition, a `test_suite` will be created, named using the `name`
+attribute to allow all the tests to be run in one go.
+
+
+**PARAMETERS**
+
+
+| Name  | Description | Default Value |
+| :------------- | :------------- | :------------- |
+| <a id="kt_jvm_test_suite-name"></a>name |  A unique name for this rule. Will be used to generate a `test_suite`.   |  none |
+| <a id="kt_jvm_test_suite-srcs"></a>srcs |  Source files to create test rules for.   |  none |
+| <a id="kt_jvm_test_suite-runner"></a>runner |  The test runner to use. Valid values are `junit4` and `junit5`.   |  `"junit4"` |
+| <a id="kt_jvm_test_suite-test_suffixes"></a>test_suffixes |  The file name suffix used to identify if a file contains a test class.   |  `["Test.kt"]` |
+| <a id="kt_jvm_test_suite-package"></a>package |  The package name used by the tests. If not set, this is inferred from the current bazel package name.   |  `None` |
+| <a id="kt_jvm_test_suite-deps"></a>deps |  A list of dependencies.   |  `None` |
+| <a id="kt_jvm_test_suite-runtime_deps"></a>runtime_deps |  A list of dependencies needed at runtime.   |  `None` |
+| <a id="kt_jvm_test_suite-size"></a>size |  The size of the test, passed to `kt_jvm_test`.   |  `None` |
+| <a id="kt_jvm_test_suite-kwargs"></a>kwargs |  <p align="center"> - </p>   |  none |
+
+
 <!-- Generated with Stardoc: http://skydoc.bazel.build -->
 
 

--- a/kotlin/internal/jvm/BUILD
+++ b/kotlin/internal/jvm/BUILD
@@ -33,6 +33,8 @@ bzl_library(
         "//third_party:bzl",
         "@bazel_skylib//lib:sets",
         "@bazel_skylib//rules:common_settings",
+        "@bazel_skylib//rules:run_binary",
+        "@contrib_rules_jvm//java:defs",
         "@rules_java//java:rules",
     ],
 )

--- a/kotlin/internal/jvm/BUILD.release.bazel
+++ b/kotlin/internal/jvm/BUILD.release.bazel
@@ -27,5 +27,7 @@ bzl_library(
         "//third_party:bzl",
         "@bazel_skylib//lib:sets",
         "@bazel_skylib//rules:common_settings",
+        "@bazel_skylib//rules:run_binary",
+        "@contrib_rules_jvm//java:defs",
     ],
 )

--- a/kotlin/internal/jvm/kt_jvm_test_suite.bzl
+++ b/kotlin/internal/jvm/kt_jvm_test_suite.bzl
@@ -1,0 +1,101 @@
+load("@contrib_rules_jvm//java:defs.bzl", "create_jvm_test_suite", "java_junit5_test")
+load("//kotlin/internal/jvm:jvm.bzl", "kt_jvm_library", "kt_jvm_test")
+
+_DEFAULT_TEST_SUFFIXES = ["Test.kt"]
+
+def _define_junit4_test(name, **kwargs):
+    kt_jvm_test(
+        name = name,
+        **kwargs
+    )
+    return name
+
+def _define_junit5_test(name, **kwargs):
+    library_target = "%s-compile" % name
+
+    libargs = {} | kwargs
+    libargs.pop("size", [])
+    libargs.pop("test_class", [])
+
+    kt_jvm_library(
+        name = library_target,
+        testonly = True,
+        **libargs
+    )
+
+    testargs = {} | kwargs
+    runtime_deps = testargs.pop("deps", []) + testargs.pop("runtime_deps", []) + [":%s" % library_target]
+    testargs.pop("srcs", [])
+
+    java_junit5_test(
+        name = name,
+        runtime_deps = runtime_deps,
+        **testargs
+    )
+
+    return name
+
+_RUNNERS = {
+    "junit4": _define_junit4_test,
+    "junit5": _define_junit5_test,
+}
+
+def kt_jvm_test_suite(
+        name,
+        srcs,
+        runner = "junit4",
+        test_suffixes = _DEFAULT_TEST_SUFFIXES,
+        package = None,
+        deps = None,
+        runtime_deps = None,
+        size = None,
+        **kwargs):
+    """Create a suite of Kotlin tests from `*Test.kt` files.
+
+    This rule will create a `kt_jvm_test` for each file which matches
+    any of the `test_suffixes` that are passed to this rule as
+    `srcs`. If any non-test sources are added these will first be
+    compiled into a `kt_jvm_library` which will be added as a
+    dependency for each test target, allowing common utility functions
+    to be shared between tests.
+
+    The generated `kt_jvm_test` targets will be named after the test file:
+    `FooTest.kt` will create a `:FooTest` target.
+
+    In addition, a `test_suite` will be created, named using the `name`
+    attribute to allow all the tests to be run in one go.
+
+    Args:
+      name: A unique name for this rule. Will be used to generate a `test_suite`.
+      srcs: Source files to create test rules for.
+      runner: The test runner to use. Valid values are `junit4` and `junit5`.
+      package: The package name used by the tests. If not set, this is
+        inferred from the current bazel package name.
+      deps: A list of dependencies.
+      runtime_deps: A list of dependencies needed at runtime.
+      size: The size of the test, passed to `kt_jvm_test`.
+      test_suffixes: The file name suffix used to identify if a file
+        contains a test class.
+    """
+    if runner not in _RUNNERS:
+        fail("Unsupported kt_jvm_test_suite runner '%s'. Valid runners are: %s" % (
+            runner,
+            ", ".join(sorted(_RUNNERS.keys())),
+        ))
+
+    if deps != None:
+        kwargs["deps"] = deps
+    if runtime_deps != None:
+        kwargs["runtime_deps"] = runtime_deps
+    if size != None:
+        kwargs["size"] = size
+
+    create_jvm_test_suite(
+        name,
+        srcs = srcs,
+        test_suffixes = test_suffixes,
+        package = package,
+        define_library = kt_jvm_library,
+        define_test = _RUNNERS[runner],
+        **kwargs
+    )

--- a/kotlin/jvm.bzl
+++ b/kotlin/jvm.bzl
@@ -9,9 +9,14 @@ load(
     _kt_jvm_library = "kt_jvm_library",
     _kt_jvm_test = "kt_jvm_test",
 )
+load(
+    "//kotlin/internal/jvm:kt_jvm_test_suite.bzl",
+    _kt_jvm_test_suite = "kt_jvm_test_suite",
+)
 
 kt_javac_options = _kt_javac_options
 kt_jvm_binary = _kt_jvm_binary
 kt_jvm_import = _kt_jvm_import
 kt_jvm_library = _kt_jvm_library
 kt_jvm_test = _kt_jvm_test
+kt_jvm_test_suite = _kt_jvm_test_suite

--- a/src/test/data/jvm/basic/BUILD
+++ b/src/test/data/jvm/basic/BUILD
@@ -1,5 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
-load("//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library")
+load("//kotlin:jvm.bzl", "kt_jvm_binary", "kt_jvm_library", "kt_jvm_test_suite")
 
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
@@ -109,6 +109,12 @@ kt_jvm_library(
     name = "test_associates_library",
     srcs = ["test_friends/Service.kt"],
     visibility = ["//src/test/kotlin:__subpackages__"],
+)
+
+kt_jvm_test_suite(
+    name = "kt_jvm_test_suite_tests",
+    srcs = glob(["test_suite/*.kt"]),
+    deps = ["@kotlin_rules_maven//:junit_junit"],
 )
 
 filegroup(

--- a/src/test/data/jvm/basic/test_suite/FirstTest.kt
+++ b/src/test/data/jvm/basic/test_suite/FirstTest.kt
@@ -1,0 +1,11 @@
+package test_suite
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FirstTest {
+  @Test
+  fun usesSharedHelper() {
+    assertEquals("first:shared", sharedMessage("first"))
+  }
+}

--- a/src/test/data/jvm/basic/test_suite/SecondTest.kt
+++ b/src/test/data/jvm/basic/test_suite/SecondTest.kt
@@ -1,0 +1,11 @@
+package test_suite
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class SecondTest {
+  @Test
+  fun alsoUsesSharedHelper() {
+    assertEquals("second:shared", sharedMessage("second"))
+  }
+}

--- a/src/test/data/jvm/basic/test_suite/Shared.kt
+++ b/src/test/data/jvm/basic/test_suite/Shared.kt
@@ -1,0 +1,3 @@
+package test_suite
+
+fun sharedMessage(prefix: String): String = "$prefix:shared"


### PR DESCRIPTION
Provides a macro that allows Kotlin test targets to be created from a simple glob.