### PR TITLE
Cache URLClassLoader in KotlinKsp2 worker actions

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2Task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2Task.kt
@@ -30,6 +30,7 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.concurrent.ConcurrentHashMap
 import java.util.jar.JarEntry
 import java.util.jar.JarOutputStream
 import java.util.jar.Manifest
@@ -50,6 +51,11 @@ import java.util.zip.ZipFile
 class Ksp2Task : Work {
   companion object {
     private val FLAGFILE_RE = Pattern.compile("""^--flagfile=((.*)-(\d+).params)$""").toRegex()
+
+    // Work around https://github.com/google/ksp/issues/2959: KSP2 creates a large
+    // processor classloader, and persistent multiplex workers otherwise retain one
+    // per work request until the worker JVM exits. Cache one loader per processor classpath.
+    private val kspClassLoaderCache = ConcurrentHashMap<String, URLClassLoader>()
 
     enum class Ksp2Flags(
       override val flag: String,
@@ -74,6 +80,20 @@ class Ksp2Task : Work {
         val eqIdx = entry.indexOf('=')
         if (eqIdx >= 0) entry.substring(0, eqIdx) to entry.substring(eqIdx + 1) else entry to ""
       }
+
+    fun getKspClassLoader(processorClasspath: List<String>): URLClassLoader {
+      val cacheKey = processorClasspath.sorted().joinToString(File.pathSeparator)
+      return kspClassLoaderCache.computeIfAbsent(cacheKey) {
+        URLClassLoader(
+          processorClasspath.map { File(it).toURI().toURL() }.toTypedArray(),
+          ClassLoader.getSystemClassLoader(),
+        )
+      }
+    }
+
+    fun clearKspClassLoaderCacheForTesting() {
+      kspClassLoaderCache.clear()
+    }
   }
 
   override fun invoke(
@@ -177,8 +197,7 @@ class Ksp2Task : Work {
 
       // Create classloader with KSP2 jars and processor jars
       val processorClasspath = argMap.optional(Ksp2Flags.PROCESSOR_CLASSPATH) ?: emptyList()
-      val processorUrls = processorClasspath.map { File(it).toURI().toURL() }.toTypedArray()
-      val kspClassLoader = URLClassLoader(processorUrls, ClassLoader.getSystemClassLoader())
+      val kspClassLoader = getKspClassLoader(processorClasspath)
 
       val processorOptions = parseKspOptions(argMap.optional(Ksp2Flags.KSP_OPTIONS) ?: emptyList())
       val experimentalPsiResolution =

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/Ksp2TaskTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/Ksp2TaskTest.kt
@@ -18,8 +18,11 @@ package io.bazel.kotlin.builder.tasks
 
 import com.google.common.truth.Truth.assertThat
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.Ksp2Flags
+import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.clearKspClassLoaderCacheForTesting
+import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.getKspClassLoader
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.parseKspOptions
 import io.bazel.kotlin.builder.utils.ArgMap
+import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -29,6 +32,11 @@ import org.junit.runners.JUnit4
  */
 @RunWith(JUnit4::class)
 class Ksp2TaskTest {
+  @After
+  fun tearDown() {
+    clearKspClassLoaderCacheForTesting()
+  }
+
   @Test
   fun testKsp2ModuleName() {
     val args =
@@ -185,5 +193,31 @@ class Ksp2TaskTest {
   @Test
   fun testParseKspOptionsEmptyList() {
     assertThat(parseKspOptions(emptyList())).isEmpty()
+  }
+
+  @Test
+  fun testKspClassLoaderCacheReusesLoaderForSameProcessorClasspath() {
+    val processorClasspath = listOf("processor.jar", "ksp-api.jar")
+
+    val firstClassLoader = getKspClassLoader(processorClasspath)
+    val secondClassLoader = getKspClassLoader(processorClasspath)
+
+    assertThat(secondClassLoader).isSameInstanceAs(firstClassLoader)
+  }
+
+  @Test
+  fun testKspClassLoaderCacheKeyIsProcessorClasspathOrderInsensitive() {
+    val firstClassLoader = getKspClassLoader(listOf("processor.jar", "ksp-api.jar"))
+    val secondClassLoader = getKspClassLoader(listOf("ksp-api.jar", "processor.jar"))
+
+    assertThat(secondClassLoader).isSameInstanceAs(firstClassLoader)
+  }
+
+  @Test
+  fun testKspClassLoaderCacheSeparatesDifferentProcessorClasspaths() {
+    val firstClassLoader = getKspClassLoader(listOf("processor.jar", "ksp-api.jar"))
+    val secondClassLoader = getKspClassLoader(listOf("other-processor.jar", "ksp-api.jar"))
+
+    assertThat(secondClassLoader).isNotSameInstanceAs(firstClassLoader)
   }
 }


### PR DESCRIPTION
Potential work around for this https://github.com/google/ksp/issues/2959 otherwise KotlinKsp2 actions just eventually OOM when building in a large project.