### PR TITLE
Inherit module_name from associates for export-only targets

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -37,6 +37,10 @@ load(
     "kotlinc_options_to_flags",
 )
 load(
+    "//kotlin/internal/jvm:associates.bzl",
+    _associate_utils = "associate_utils",
+)
+load(
     "//kotlin/internal/jvm:jvm_deps.bzl",
     _jvm_deps_utils = "jvm_deps_utils",
 )
@@ -1160,7 +1164,13 @@ def _export_only_providers(ctx, actions, attr, outputs):
     return struct(
         java = java,
         kt = _KtJvmInfo(
-            module_name = _utils.derive_module_name(ctx),
+            # Inherit module_name from associates, so an srcs-less target with `associates` shares their module
+            # instead of label-deriving a different name. Falls back to the label-derived name when there are no associates.
+            module_name = _associate_utils.get_associates(
+                ctx,
+                toolchains = toolchains,
+                associates = getattr(attr, "associates", []),
+            ).module_name,
             module_jars = [],
             language_version = toolchains.kt.api_version,
             exported_compiler_plugins = _collect_plugins_for_export(

--- a/src/test/starlark/internal/jvm/BUILD.bazel
+++ b/src/test/starlark/internal/jvm/BUILD.bazel
@@ -1,5 +1,8 @@
+load(":export_only_module_name_test.bzl", "export_only_module_name_test_suite")
 load(":jvm_deps_tests.bzl", "jvm_deps_test_suite")
 load(":kt_jvm_binary_env_test.bzl", "kt_jvm_binary_env_test_suite")
+
+export_only_module_name_test_suite(name = "export_only_module_name_tests")
 
 jvm_deps_test_suite(name = "jvm_tests")
 

--- a/src/test/starlark/internal/jvm/export_only_module_name_test.bzl
+++ b/src/test/starlark/internal/jvm/export_only_module_name_test.bzl
@@ -1,0 +1,49 @@
+"""Tests that the export-only (srcs-less) kt_jvm_library path inherits module_name from associates."""
+
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
+load("@rules_testing//lib:test_suite.bzl", "test_suite")
+load("@rules_testing//lib:util.bzl", "util")
+load("//kotlin:jvm.bzl", "kt_jvm_library")
+load("//kotlin/internal:defs.bzl", "KtJvmInfo")
+
+_ASSOCIATE_MODULE = "test.export_only.associated_module"
+
+def _export_only_inherits_associate_module_name_test_impl(env, target):
+    """A srcs-less kt_jvm_library inherits its module_name from its associates.
+
+    The compiled path resolves module_name from the associates (jvm_deps.bzl); the export-only
+    path must do the same, otherwise an associate of an srcs-less shim would see a different
+    module than the rest of its module and lose `internal` visibility.
+    """
+    env.expect.that_target(target).has_provider(KtJvmInfo)
+    env.expect.that_str(target[KtJvmInfo].module_name).equals(_ASSOCIATE_MODULE)
+
+def _export_only_inherits_associate_module_name_test(name):
+    kt_jvm_library(
+        name = name + "_associate",
+        srcs = [util.empty_file(name + "_Associated.kt")],
+        module_name = _ASSOCIATE_MODULE,
+        tags = ["manual"],
+    )
+
+    # No srcs and no resources -> the export-only providers path (see kt_jvm_library_impl).
+    kt_jvm_library(
+        name = name + "_subject",
+        associates = [":" + name + "_associate"],
+        tags = ["manual"],
+    )
+
+    analysis_test(
+        name = name,
+        impl = _export_only_inherits_associate_module_name_test_impl,
+        target = name + "_subject",
+    )
+
+def export_only_module_name_test_suite(name):
+    """Test suite for export-only module_name inheritance."""
+    test_suite(
+        name = name,
+        tests = [
+            _export_only_inherits_associate_module_name_test,
+        ],
+    )


### PR DESCRIPTION
For targets without sources derive module name from the declared associates/exports, if any. This way the derived module name stays consistent across all associated parts.