### PR TITLE
Ensure "target" and "source" compiler options are honored by KAPT.

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/CompilationTask.kt
@@ -147,10 +147,17 @@ internal fun JvmCompilationTask.kaptArgs(
   plugins: InternalCompilerPlugins,
   aptMode: String,
 ): CompilationArgs {
+  // KAPT does not run javac's CLI argument parser and feeds options directly to javac.
+  // Javac reads option values via each option flag's canonical primaryName. That primaryName changed from
+  // "-source"/"-target" (JDK <= 11) to "--source"/"--target" (JDK >= 14).
+  // Pass both spelling variants, so that javac reads whichever is canonical on the running JDK and ignores the other.
+  val jvmTarget = info.toolchainInfo.jvm.jvmTarget
   val javacArgs =
     mapOf<String, String>(
-      "-target" to info.toolchainInfo.jvm.jvmTarget,
-      "-source" to info.toolchainInfo.jvm.jvmTarget,
+      "-target" to jvmTarget,
+      "--target" to jvmTarget,
+      "-source" to jvmTarget,
+      "--source" to jvmTarget,
     )
   return CompilationArgs().apply {
     xFlag("plugin", plugins.kapt.jarPath)


### PR DESCRIPTION
Depending on javac version, these flags might have several spellings, either with one dash "-" or two dashes "--". If several spellings for a flag are available, one of them is considered "primary". KAPT passes flags to the compiler directly in an argument map, bypassing the CLI arguments parser, which parses and validates passed arguments. Compiler reads flags from the argument map using only "primary" flag name as a key. If KAPT passes only "-target" flag name in the argument map, but compiler uses "--target" name as a "primary" one, the option is effectively ignored. The fix is to pass "source" and "target" flags using all their possible spellings. This ensures the compiler will honor these options, no matter which flag name spelling is considered "primary" in this compiler version.