### PR TITLE
Build third_party/empty.jar with copy_file instead of a cp genrule

### DIFF
--- a/third_party/BUILD
+++ b/third_party/BUILD
@@ -1,3 +1,4 @@
+load("@bazel_lib//lib:copy_file.bzl", "copy_file")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@rules_java//java:defs.bzl", "java_binary", "java_library", "java_plugin")
 load("//src/main/starlark/release:packager.bzl", "release_archive")
@@ -22,15 +23,10 @@ exports_files([
     "java_stub_template.txt",
 ])
 
-genrule(
+copy_file(
     name = "empty",
-    srcs = [
-        "empty-definately-not-binary-jar.txt",
-    ],
-    outs = [
-        "empty.jar",
-    ],
-    cmd = "cp $(location empty-definately-not-binary-jar.txt) $@",
+    src = "empty-definately-not-binary-jar.txt",
+    out = "empty.jar",
 )
 
 java_plugin(


### PR DESCRIPTION
The empty.jar placeholder was produced by a genrule running `cp`, which is not available on a standard Windows toolchain, so this step is not cross-platform.

Use @bazel_lib's copy_file (bazel_lib is already a module dependency) to copy the placeholder. The output //third_party:empty.jar is unchanged, so every consumer (the toolchain's empty compile/runtime jar) is unaffected.