### PR TITLE
Only pass KSP-generated srcjars to javac when the processor generates Java

### DIFF
--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -1041,7 +1041,7 @@ def _run_kt_java_builder_actions(
         java_info = java_common.compile(
             ctx,
             source_files = srcs.java,
-            source_jars = generated_kapt_src_jars + srcs.src_jars + generated_ksp_src_jars,
+            source_jars = generated_kapt_src_jars + srcs.src_jars + (generated_ksp_src_jars if ksp_generated_java_src_jars else []),
             output = ctx.actions.declare_file(ctx.label.name + "-java.jar"),
             deps = compile_deps.deps + kt_stubs_for_java + [p[JavaInfo] for p in ctx.attr.plugins if JavaInfo in p],
             java_toolchain = toolchains.java,

--- a/src/test/starlark/ksp/BUILD.bazel
+++ b/src/test/starlark/ksp/BUILD.bazel
@@ -14,7 +14,7 @@
 
 load("//kotlin:core.bzl", "kt_ksp_plugin")
 load("//kotlin:jvm.bzl", "kt_jvm_library")
-load(":ksp_test.bzl", "ksp_action_test", "ksp_conflicting_options_test", "ksp_options_action_test", "ksp_outputs_test", "ksp_plugin_empty_options_provider_test", "ksp_plugin_options_provider_test", "ksp_single_action_test")
+load(":ksp_test.bzl", "ksp_action_test", "ksp_conflicting_options_test", "ksp_javac_excludes_srcjars_test", "ksp_javac_includes_srcjars_test", "ksp_options_action_test", "ksp_outputs_test", "ksp_plugin_empty_options_provider_test", "ksp_plugin_options_provider_test", "ksp_single_action_test")
 
 # Simple KSP plugin for testing (uses moshi which generates Kotlin code)
 kt_ksp_plugin(
@@ -146,11 +146,65 @@ ksp_conflicting_options_test(
     target_under_test = ":ksp_test_lib_with_conflicting_options",
 )
 
+# KSP plugin with generates_java=True for testing javac srcjar inclusion
+kt_ksp_plugin(
+    name = "moshi_plugin_generates_java",
+    generates_java = True,
+    processor_class = "com.squareup.moshi.kotlin.codegen.ksp.JsonClassSymbolProcessorProvider",
+    deps = [
+        "@kotlin_rules_maven//:com_squareup_moshi_moshi",
+        "@kotlin_rules_maven//:com_squareup_moshi_moshi_kotlin",
+        "@kotlin_rules_maven//:com_squareup_moshi_moshi_kotlin_codegen",
+    ],
+)
+
+# Mixed Java+Kotlin with KSP (generates_java=False) — KSP srcjars must NOT go to javac
+kt_jvm_library(
+    name = "ksp_mixed_no_java_gen",
+    srcs = [
+        "TestHelper.java",
+        "TestModel.kt",
+    ],
+    plugins = [":moshi_plugin"],
+    deps = [
+        "@kotlin_rules_maven//:com_squareup_moshi_moshi",
+        "@kotlin_rules_maven//:com_squareup_moshi_moshi_kotlin",
+    ],
+)
+
+# Mixed Java+Kotlin with KSP (generates_java=True) — KSP srcjars must go to javac
+kt_jvm_library(
+    name = "ksp_mixed_with_java_gen",
+    srcs = [
+        "TestHelper.java",
+        "TestModel.kt",
+    ],
+    plugins = [":moshi_plugin_generates_java"],
+    deps = [
+        "@kotlin_rules_maven//:com_squareup_moshi_moshi",
+        "@kotlin_rules_maven//:com_squareup_moshi_moshi_kotlin",
+    ],
+)
+
+# Test that KSP srcjars are excluded from javac when generates_java=False
+ksp_javac_excludes_srcjars_test(
+    name = "ksp_javac_excludes_srcjars_test",
+    target_under_test = ":ksp_mixed_no_java_gen",
+)
+
+# Test that KSP srcjars are included in javac when generates_java=True
+ksp_javac_includes_srcjars_test(
+    name = "ksp_javac_includes_srcjars_test",
+    target_under_test = ":ksp_mixed_with_java_gen",
+)
+
 test_suite(
     name = "ksp_tests",
     tests = [
         ":ksp_action_test",
         ":ksp_conflicting_options_test",
+        ":ksp_javac_excludes_srcjars_test",
+        ":ksp_javac_includes_srcjars_test",
         ":ksp_options_action_test",
         ":ksp_outputs_test",
         ":ksp_plugin_empty_options_provider_test",

--- a/src/test/starlark/ksp/TestHelper.java
+++ b/src/test/starlark/ksp/TestHelper.java
@@ -1,0 +1,8 @@
+package io.bazel.kotlin.test.ksp;
+
+/** Simple Java class to trigger javac in mixed-language builds. */
+public class TestHelper {
+    public static String greet(String name) {
+        return "Hello, " + name;
+    }
+}

--- a/src/test/starlark/ksp/ksp_test.bzl
+++ b/src/test/starlark/ksp/ksp_test.bzl
@@ -189,6 +189,73 @@ ksp_conflicting_options_test = analysistest.make(
     expect_failure = True,
 )
 
+def _find_javac_action(actions):
+    """Find the java_common.compile action by its -java.jar output."""
+    for a in actions:
+        for o in a.outputs.to_list():
+            if o.path.endswith("-java.jar"):
+                return a
+    return None
+
+def _has_ksp_srcjar_input(action):
+    """Check whether any input to an action is a KSP-generated srcjar."""
+    for i in action.inputs.to_list():
+        if i.path.endswith("-ksp-gensrc.jar"):
+            return True
+    return False
+
+def _ksp_javac_excludes_srcjars_when_not_generating_java_test_impl(ctx):
+    """When generates_java=False and Java sources exist, javac must not receive KSP srcjars."""
+    env = analysistest.begin(ctx)
+
+    actions = analysistest.target_actions(env)
+    javac_action = _find_javac_action(actions)
+
+    asserts.true(
+        env,
+        javac_action != None,
+        "Javac action should exist because target has Java sources",
+    )
+
+    if javac_action:
+        asserts.false(
+            env,
+            _has_ksp_srcjar_input(javac_action),
+            "Javac action should NOT have KSP srcjars when generates_java=False",
+        )
+
+    return analysistest.end(env)
+
+ksp_javac_excludes_srcjars_test = analysistest.make(
+    _ksp_javac_excludes_srcjars_when_not_generating_java_test_impl,
+)
+
+def _ksp_javac_includes_srcjars_when_generating_java_test_impl(ctx):
+    """When generates_java=True, javac must receive KSP srcjars."""
+    env = analysistest.begin(ctx)
+
+    actions = analysistest.target_actions(env)
+    javac_action = _find_javac_action(actions)
+
+    asserts.true(
+        env,
+        javac_action != None,
+        "Javac action should exist because KSP generates Java",
+    )
+
+    if javac_action:
+        asserts.true(
+            env,
+            _has_ksp_srcjar_input(javac_action),
+            "Javac action should have KSP srcjars when generates_java=True",
+        )
+
+    return analysistest.end(env)
+
+ksp_javac_includes_srcjars_test = analysistest.make(
+    _ksp_javac_includes_srcjars_when_generating_java_test_impl,
+)
+
 def ksp_test_suite(name):
     """Create test suite for KSP2 integration tests.
 
@@ -207,5 +274,7 @@ def ksp_test_suite(name):
             ":ksp_plugin_options_provider_test",
             ":ksp_plugin_empty_options_provider_test",
             ":ksp_options_action_test",
+            ":ksp_javac_excludes_srcjars_test",
+            ":ksp_javac_includes_srcjars_test",
         ],
     )


### PR DESCRIPTION
Previously, KSP-generated source jars were always passed to javac for compilation. For KSP2 processors that only generate Kotlin, this is unnecessary since those sources are already compiled via kotlinc and the compiled classes are included in the KSP classes jar. This change conditionally includes KSP srcjars in the javac source_jars only when `generates_java = True` is set on the KSP plugin, avoiding redundant compilation.