### PR TITLE
Fingerprint KSP2 classloader cache by jar content, not just path

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2Task.kt
+++ b/src/main/kotlin/io/bazel/kotlin/builder/tasks/jvm/Ksp2Task.kt
@@ -30,6 +30,8 @@ import java.nio.charset.StandardCharsets
 import java.nio.file.FileSystems
 import java.nio.file.Files
 import java.nio.file.Path
+import java.security.DigestInputStream
+import java.security.MessageDigest
 import java.util.GregorianCalendar
 import java.util.concurrent.ConcurrentHashMap
 import java.util.jar.JarEntry
@@ -53,10 +55,15 @@ class Ksp2Task : Work {
   companion object {
     private val FLAGFILE_RE = Pattern.compile("""^--flagfile=((.*)-(\d+).params)$""").toRegex()
 
+    private data class CacheEntry(
+      val classLoader: URLClassLoader,
+      val fingerprint: String,
+    )
+
     // Work around https://github.com/google/ksp/issues/2959: KSP2 creates a large
     // processor classloader, and persistent multiplex workers otherwise retain one
     // per work request until the worker JVM exits. Cache one loader per processor classpath.
-    private val kspClassLoaderCache = ConcurrentHashMap<String, URLClassLoader>()
+    private val classLoaderCache = ConcurrentHashMap<String, CacheEntry>()
 
     enum class Ksp2Flags(
       override val flag: String,
@@ -84,16 +91,41 @@ class Ksp2Task : Work {
 
     fun getKspClassLoader(processorClasspath: List<String>): URLClassLoader {
       val cacheKey = processorClasspath.sorted().joinToString(File.pathSeparator)
-      return kspClassLoaderCache.computeIfAbsent(cacheKey) {
-        URLClassLoader(
-          processorClasspath.map { File(it).toURI().toURL() }.toTypedArray(),
-          ClassLoader.getSystemClassLoader(),
-        )
-      }
+      val fingerprint = fingerprintOf(processorClasspath)
+      return classLoaderCache
+        .compute(cacheKey) { _, existing ->
+          if (existing != null && existing.fingerprint == fingerprint) {
+            return@compute existing
+          }
+          if (existing != null) {
+            runCatching { existing.classLoader.close() }
+          }
+          CacheEntry(
+            URLClassLoader(
+              processorClasspath.map { File(it).toURI().toURL() }.toTypedArray(),
+              ClassLoader.getSystemClassLoader(),
+            ),
+            fingerprint,
+          )
+        }!!
+        .classLoader
     }
 
     fun clearKspClassLoaderCacheForTesting() {
-      kspClassLoaderCache.clear()
+      classLoaderCache.values.forEach { runCatching { it.classLoader.close() } }
+      classLoaderCache.clear()
+    }
+
+    fun fingerprintOf(classpath: List<String>): String {
+      val sortedPaths = classpath.sorted()
+      val digest = MessageDigest.getInstance("SHA-256")
+      for (path in sortedPaths) {
+        val file = File(path)
+        digest.update(path.toByteArray(StandardCharsets.UTF_8))
+        digest.update(file.length().toString().toByteArray(StandardCharsets.UTF_8))
+        DigestInputStream(Files.newInputStream(file.toPath()), digest).use { it.readAllBytes() }
+      }
+      return digest.digest().joinToString("") { "%02x".format(it) }
     }
 
     // Fixed epoch (1980-01-01 00:00:00 UTC) for reproducible jar timestamps.

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/Ksp2TaskTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/Ksp2TaskTest.kt
@@ -19,11 +19,14 @@ package io.bazel.kotlin.builder.tasks
 import com.google.common.truth.Truth.assertThat
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.Ksp2Flags
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.clearKspClassLoaderCacheForTesting
+import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.fingerprintOf
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.getKspClassLoader
 import io.bazel.kotlin.builder.tasks.jvm.Ksp2Task.Companion.parseKspOptions
 import io.bazel.kotlin.builder.utils.ArgMap
 import org.junit.After
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
 
@@ -32,6 +35,9 @@ import org.junit.runners.JUnit4
  */
 @RunWith(JUnit4::class)
 class Ksp2TaskTest {
+  @get:Rule
+  val tmp = TemporaryFolder()
+
   @After
   fun tearDown() {
     clearKspClassLoaderCacheForTesting()
@@ -197,7 +203,9 @@ class Ksp2TaskTest {
 
   @Test
   fun testKspClassLoaderCacheReusesLoaderForSameProcessorClasspath() {
-    val processorClasspath = listOf("processor.jar", "ksp-api.jar")
+    val jar1 = tmp.newFile("processor.jar").apply { writeBytes(byteArrayOf(1)) }
+    val jar2 = tmp.newFile("ksp-api.jar").apply { writeBytes(byteArrayOf(2)) }
+    val processorClasspath = listOf(jar1.absolutePath, jar2.absolutePath)
 
     val firstClassLoader = getKspClassLoader(processorClasspath)
     val secondClassLoader = getKspClassLoader(processorClasspath)
@@ -207,17 +215,71 @@ class Ksp2TaskTest {
 
   @Test
   fun testKspClassLoaderCacheKeyIsProcessorClasspathOrderInsensitive() {
-    val firstClassLoader = getKspClassLoader(listOf("processor.jar", "ksp-api.jar"))
-    val secondClassLoader = getKspClassLoader(listOf("ksp-api.jar", "processor.jar"))
+    val jar1 = tmp.newFile("processor.jar").apply { writeBytes(byteArrayOf(1)) }
+    val jar2 = tmp.newFile("ksp-api.jar").apply { writeBytes(byteArrayOf(2)) }
+
+    val firstClassLoader = getKspClassLoader(listOf(jar1.absolutePath, jar2.absolutePath))
+    val secondClassLoader = getKspClassLoader(listOf(jar2.absolutePath, jar1.absolutePath))
 
     assertThat(secondClassLoader).isSameInstanceAs(firstClassLoader)
   }
 
   @Test
   fun testKspClassLoaderCacheSeparatesDifferentProcessorClasspaths() {
-    val firstClassLoader = getKspClassLoader(listOf("processor.jar", "ksp-api.jar"))
-    val secondClassLoader = getKspClassLoader(listOf("other-processor.jar", "ksp-api.jar"))
+    val jar1 = tmp.newFile("processor.jar").apply { writeBytes(byteArrayOf(1)) }
+    val jar2 = tmp.newFile("ksp-api.jar").apply { writeBytes(byteArrayOf(2)) }
+    val jar3 = tmp.newFile("other-processor.jar").apply { writeBytes(byteArrayOf(3)) }
+
+    val firstClassLoader = getKspClassLoader(listOf(jar1.absolutePath, jar2.absolutePath))
+    val secondClassLoader = getKspClassLoader(listOf(jar3.absolutePath, jar2.absolutePath))
 
     assertThat(secondClassLoader).isNotSameInstanceAs(firstClassLoader)
+  }
+
+  @Test
+  fun testKspClassLoaderCacheInvalidatesOnContentChange() {
+    val jar = tmp.newFile("processor.jar").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+    val classpath = listOf(jar.absolutePath)
+
+    val firstClassLoader = getKspClassLoader(classpath)
+    jar.writeBytes(byteArrayOf(4, 5, 6, 7))
+    val secondClassLoader = getKspClassLoader(classpath)
+
+    assertThat(secondClassLoader).isNotSameInstanceAs(firstClassLoader)
+  }
+
+  @Test
+  fun testFingerprintIsDeterministic() {
+    val jar = tmp.newFile("a.jar").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+    val classpath = listOf(jar.absolutePath)
+    assertThat(fingerprintOf(classpath)).isEqualTo(fingerprintOf(classpath))
+  }
+
+  @Test
+  fun testFingerprintChangesWhenContentChanges() {
+    val jar = tmp.newFile("a.jar").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+    val classpath = listOf(jar.absolutePath)
+    val before = fingerprintOf(classpath)
+
+    jar.writeBytes(byteArrayOf(4, 5, 6, 7))
+    val after = fingerprintOf(classpath)
+
+    assertThat(after).isNotEqualTo(before)
+  }
+
+  @Test
+  fun testFingerprintDiffersForDifferentPaths() {
+    val jar1 = tmp.newFile("a.jar").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+    val jar2 = tmp.newFile("b.jar").apply { writeBytes(byteArrayOf(1, 2, 3)) }
+    assertThat(fingerprintOf(listOf(jar1.absolutePath)))
+      .isNotEqualTo(fingerprintOf(listOf(jar2.absolutePath)))
+  }
+
+  @Test
+  fun testFingerprintIsHexEncoded() {
+    val jar = tmp.newFile("a.jar").apply { writeBytes(byteArrayOf(1)) }
+    val fp = fingerprintOf(listOf(jar.absolutePath))
+    assertThat(fp).hasLength(64)
+    assertThat(fp).matches("[0-9a-f]{64}")
   }
 }


### PR DESCRIPTION
Bazel keeps the same output path across incremental rebuilds of a KSP processor, so the path-only cache key can't tell a recompiled jar from an unchanged one. This causes the worker to reuse a stale classloader after a processor is edited and rebuilt.

Replace `computeIfAbsent` with `compute` and pair each cached classloader with a SHA-256 content fingerprint (path + size + bytes). When the fingerprint changes for a cached classpath, the stale classloader is closed and replaced. This keeps at most one entry per distinct classpath, so it can't regress the metaspace OOM the cache was originally added to fix.