### PR TITLE
Support for conditional classpath reduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,26 @@ Or add it to your `.bazelrc` file:
 build --@rules_kotlin//kotlin/settings:experimental_build_tools_api=false
 ```
 
+# Pruning transitive dependencies
+
+The experimental transitive dependency pruning mode normally removes every transitive dependency from the Kotlin
+compile classpath:
+
+```
+build --@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps=True
+```
+
+Some Maven dependency graphs need to remain transitive. Their canonical repository names can be allow-listed globally
+with a comma-separated build setting:
+
+```
+build --@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories=maven,rules_jvm_external++maven+maven
+```
+
+Repository names omit the leading `@`. For Bzlmod extensions, use the canonical name (for example,
+`rules_jvm_external++maven+maven`); for `WORKSPACE` repositories, use the repository name (for example, `maven`).
+The allow-list is empty by default and has no effect unless transitive dependency pruning is enabled.
+
 # Workers
 
 Persistent workers and multiplex workers are enabled by default for Kotlin compilation actions. This significantly improves build performance by reusing compiler processes across builds.

--- a/kotlin/internal/jvm/jvm_deps.bzl
+++ b/kotlin/internal/jvm/jvm_deps.bzl
@@ -38,11 +38,27 @@ def _jvm_deps(ctx, toolchains, associate_deps, deps = [], deps_java_infos = [], 
     # Reduced classpath, exclude transitive deps from compilation
     if (toolchains.kt.experimental_prune_transitive_deps and
         not "kt_experimental_prune_transitive_deps_incompatible" in ctx.attr.tags):
+        transitive_jars = []
+        repositories_to_keep = toolchains.kt.experimental_prune_transitive_deps_keep_transitive_repositories
+        if repositories_to_keep:
+            repository_set = {repository: None for repository in repositories_to_keep}
+            transitive_compile_time_jars = depset(
+                transitive = [
+                    dep_info.transitive_compile_time_jars
+                    for dep_info in dep_infos
+                ],
+            )
+            transitive_jars = [
+                jar
+                for jar in transitive_compile_time_jars.to_list()
+                if jar.owner != None and jar.owner.repo_name in repository_set
+            ]
         transitive = [
             d.compile_jars
             for d in dep_infos
         ]
     else:
+        transitive_jars = []
         transitive = [
             d.compile_jars
             for d in dep_infos
@@ -51,7 +67,10 @@ def _jvm_deps(ctx, toolchains, associate_deps, deps = [], deps_java_infos = [], 
             for d in dep_infos
         ]
 
-    compile_depset_list = depset(transitive = transitive + [associates.jars]).to_list()
+    compile_depset_list = depset(
+        direct = transitive_jars,
+        transitive = transitive + [associates.jars],
+    ).to_list()
     compile_depset_list_filtered = [jar for jar in compile_depset_list if not _sets.contains(associates.abi_jar_set, jar)]
 
     return struct(

--- a/kotlin/internal/toolchains.bzl
+++ b/kotlin/internal/toolchains.bzl
@@ -101,6 +101,7 @@ def _kotlin_toolchain_impl(ctx):
         empty_jdeps = ctx.file._empty_jdeps,
         jacocorunner = ctx.attr.jacocorunner,
         experimental_prune_transitive_deps = ctx.attr._experimental_prune_transitive_deps[BuildSettingInfo].value,
+        experimental_prune_transitive_deps_keep_transitive_repositories = ctx.attr._experimental_prune_transitive_deps_keep_transitive_repositories[BuildSettingInfo].value,
         experimental_strict_associate_dependencies = ctx.attr._experimental_strict_associate_dependencies[BuildSettingInfo].value,
         experimental_ksp2_psi_resolution = ctx.attr._experimental_ksp2_psi_resolution[BuildSettingInfo].value,
     )
@@ -341,6 +342,11 @@ _kt_toolchain = rule(
             Transitive deps required for compilation must be explicitly added. Using
             kt_experimental_prune_transitive_deps_incompatible tag allows to exclude specific targets""",
             default = Label("//kotlin/settings:experimental_prune_transitive_deps"),
+        ),
+        "_experimental_prune_transitive_deps_keep_transitive_repositories": attr.label(
+            doc = """Canonical repository names whose transitive compile jars remain on the classpath when
+            experimental_prune_transitive_deps is enabled.""",
+            default = Label("//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories"),
         ),
         "_experimental_strict_associate_dependencies": attr.label(
             doc = """

--- a/kotlin/settings/BUILD.bazel
+++ b/kotlin/settings/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_list_flag")
 
 # Copyright 2020 The Bazel Authors. All rights reserved.
 #
@@ -33,6 +33,15 @@ bool_flag(
 bool_flag(
     name = "experimental_prune_transitive_deps",
     build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+# Comma-separated canonical repository names whose transitive compile jars should
+# remain on the classpath when experimental_prune_transitive_deps is enabled.
+# --@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories=repo_a,repo_b
+string_list_flag(
+    name = "experimental_prune_transitive_deps_keep_transitive_repositories",
+    build_setting_default = [],
     visibility = ["//visibility:public"],
 )
 

--- a/kotlin/settings/BUILD.release.bazel
+++ b/kotlin/settings/BUILD.release.bazel
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_list_flag")
 
 # Flag that controls the emission of jdeps files during kotlin jvm compilation.
 bool_flag(
@@ -24,6 +24,15 @@ bool_flag(
 bool_flag(
     name = "experimental_prune_transitive_deps",
     build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+# Comma-separated canonical repository names whose transitive compile jars should
+# remain on the classpath when experimental_prune_transitive_deps is enabled.
+# --@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories=repo_a,repo_b
+string_list_flag(
+    name = "experimental_prune_transitive_deps_keep_transitive_repositories",
+    build_setting_default = [],
     visibility = ["//visibility:public"],
 )
 

--- a/src/test/starlark/internal/jvm/jvm_deps_tests.bzl
+++ b/src/test/starlark/internal/jvm/jvm_deps_tests.bzl
@@ -75,6 +75,7 @@ def _strict_abi_test_impl(env, target):
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = True,
             experimental_prune_transitive_deps = True,
+            experimental_prune_transitive_deps_keep_transitive_repositories = [],
             experimental_strict_associate_dependencies = True,
             jvm_stdlibs = JavaInfo(
                 compile_jar = _file(env.ctx.attr.jvm_jar),
@@ -109,6 +110,7 @@ def _fat_abi_test_impl(env, target):
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = False,
             experimental_prune_transitive_deps = False,
+            experimental_prune_transitive_deps_keep_transitive_repositories = [],
             experimental_strict_associate_dependencies = False,
             jvm_stdlibs = JavaInfo(
                 compile_jar = _file(env.ctx.attr.jvm_jar),
@@ -158,6 +160,7 @@ def _transitive_from_exports_test_impl(env, target):
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = True,
             experimental_prune_transitive_deps = True,
+            experimental_prune_transitive_deps_keep_transitive_repositories = [],
             experimental_strict_associate_dependencies = True,
             jvm_stdlibs = JavaInfo(
                 compile_jar = _file(env.ctx.attr.jvm_jar),
@@ -226,6 +229,7 @@ def _transitive_from_associates_test_impl(env, target):
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = False,
             experimental_prune_transitive_deps = False,
+            experimental_prune_transitive_deps_keep_transitive_repositories = [],
             experimental_strict_associate_dependencies = False,
             jvm_stdlibs = JavaInfo(
                 compile_jar = _file(env.ctx.attr.jvm_jar),
@@ -337,6 +341,7 @@ def _dep_infos_ordering_test_impl(env, target):
         kt = struct(
             experimental_remove_private_classes_in_abi_jars = False,
             experimental_prune_transitive_deps = False,
+            experimental_prune_transitive_deps_keep_transitive_repositories = [],
             experimental_strict_associate_dependencies = False,
             jvm_stdlibs = stdlib_java_info,
         ),
@@ -395,6 +400,90 @@ def _dep_infos_ordering_test(name):
         },
     )
 
+def _kept_transitive_repository_deduplication_test_impl(env, target):
+    shared_transitive_jar = _file(env.ctx.attr.shared_transitive_jar)
+    shared_transitive_dep = JavaInfo(
+        compile_jar = shared_transitive_jar,
+        output_jar = shared_transitive_jar,
+    )
+    direct_dep_jar = _file(env.ctx.attr.direct_dep_jar)
+    direct_dep_jar2 = _file(env.ctx.attr.direct_dep_jar2)
+    jvm_jar = _file(env.ctx.attr.jvm_jar)
+    deps_java_infos = [
+        JavaInfo(
+            compile_jar = direct_dep_jar,
+            output_jar = direct_dep_jar,
+            deps = [shared_transitive_dep],
+        ),
+        JavaInfo(
+            compile_jar = direct_dep_jar2,
+            output_jar = direct_dep_jar2,
+            deps = [shared_transitive_dep],
+        ),
+    ]
+    fake_ctx = struct(
+        label = target.label,
+        attr = struct(
+            module_name = "",
+            tags = [],
+        ),
+    )
+    toolchains = struct(
+        kt = struct(
+            experimental_remove_private_classes_in_abi_jars = False,
+            experimental_prune_transitive_deps = True,
+            experimental_prune_transitive_deps_keep_transitive_repositories = [shared_transitive_jar.owner.repo_name],
+            experimental_strict_associate_dependencies = False,
+            jvm_stdlibs = JavaInfo(
+                compile_jar = jvm_jar,
+                output_jar = jvm_jar,
+            ),
+        ),
+    )
+
+    result = _jvm_deps_utils.jvm_deps(
+        ctx = fake_ctx,
+        toolchains = toolchains,
+        associate_deps = [],
+        deps_java_infos = deps_java_infos,
+    )
+
+    classpath = result.compile_jars.to_list()
+    legacy_transitive_jars = []
+    for dep_info in deps_java_infos + [toolchains.kt.jvm_stdlibs]:
+        legacy_transitive_jars.extend(dep_info.transitive_compile_time_jars.to_list())
+    legacy_classpath = depset(
+        direct = legacy_transitive_jars,
+        transitive = [dep_info.compile_jars for dep_info in deps_java_infos + [toolchains.kt.jvm_stdlibs]],
+    ).to_list()
+    shared_transitive_jars = [jar for jar in classpath if jar == shared_transitive_jar]
+    env.expect.that_int(len(shared_transitive_jars)).equals(1)
+    env.expect.that_bool(classpath == legacy_classpath).equals(True)
+
+def _kept_transitive_repository_deduplication_test(name):
+    util.helper_target(
+        native.filegroup,
+        name = name + "_subject",
+        srcs = [],
+    )
+    analysis_test(
+        name = name,
+        impl = _kept_transitive_repository_deduplication_test_impl,
+        target = name + "_subject",
+        attr_values = {
+            "direct_dep_jar": util.empty_file(name + "_direct_dep.jar"),
+            "direct_dep_jar2": util.empty_file(name + "_direct_dep2.jar"),
+            "jvm_jar": util.empty_file(name + "_jvm.jar"),
+            "shared_transitive_jar": util.empty_file(name + "_shared_transitive.jar"),
+        },
+        attrs = {
+            "direct_dep_jar": attr.label(allow_files = True),
+            "direct_dep_jar2": attr.label(allow_files = True),
+            "jvm_jar": attr.label(allow_files = True),
+            "shared_transitive_jar": attr.label(allow_files = True),
+        },
+    )
+
 def _sourceless_dep_propagation_test_impl(env, target):
     """Verify that a sourceless wrapper propagates transitive deps
 
@@ -444,6 +533,7 @@ def jvm_deps_test_suite(name):
             _transitive_from_exports_test,
             _transitive_from_associates_test,
             _dep_infos_ordering_test,
+            _kept_transitive_repository_deduplication_test,
             _sourceless_dep_propagation_test,
         ],
     )

--- a/src/test/starlark/rules/arrangement.bzl
+++ b/src/test/starlark/rules/arrangement.bzl
@@ -1,9 +1,20 @@
 load("//kotlin:jvm.bzl", "kt_jvm_import", "kt_jvm_library")
 
-def arrange(test):
-    dependency_a_trans_dep_jar = test.artifact(
-        name = "dependency_a_trans_dep.abi.jar",
-    )
+def arrange(test, transitive_dep = None):
+    dependency_a_trans_dep_jar = transitive_dep
+    if dependency_a_trans_dep_jar == None:
+        dependency_a_trans_dep_jar = test.artifact(
+            name = "dependency_a_trans_dep.abi.jar",
+        )
+        dependency_a_trans_dep = test.have(
+            kt_jvm_import,
+            name = "dependency_a_dep_jar_import",
+            jars = [
+                dependency_a_trans_dep_jar,
+            ],
+        )
+    else:
+        dependency_a_trans_dep = dependency_a_trans_dep_jar
 
     dependency_a = test.have(
         kt_jvm_library,
@@ -14,13 +25,7 @@ def arrange(test):
             ),
         ],
         deps = [
-            test.have(
-                kt_jvm_import,
-                name = "dependency_a_dep_jar_import",
-                jars = [
-                    dependency_a_trans_dep_jar,
-                ],
-            ),
+            dependency_a_trans_dep,
         ],
     )
 

--- a/src/test/starlark/rules/experimental_prune_transitive_deps_tests.bzl
+++ b/src/test/starlark/rules/experimental_prune_transitive_deps_tests.bzl
@@ -4,6 +4,10 @@ load("//src/test/starlark:case.bzl", "suite")
 load(":arrangement.bzl", "arrange")
 load(":util.bzl", "abi_jar_of", "basename_of", "values_for_flag_of")
 
+_MAVEN_COMPILE_JAR_BASENAME = "header_javax.inject-1.jar"
+_MAVEN_REPOSITORY_NAME = "rules_jvm_external++maven+kotlin_rules_maven"
+_MAVEN_TRANSITIVE_DEP = Label("@kotlin_rules_maven//:javax_inject_javax_inject")
+
 def _classpath_assertions_(env, target):
     action = env.expect.that_target(target).action_named(env.ctx.attr.on_action_mnemonic)
 
@@ -20,10 +24,14 @@ def _classpath_assertions_(env, target):
     action.inputs().contains_at_least_predicates(want_input_matchers)
 
     # For classpath (string paths), use str_endswith matcher to match by basename
-    want_classpath_basenames = [abi_jar_of(f.basename) for f in env.ctx.files.want_classpath if not f.basename.endswith("jdeps")]
+    want_classpath_basenames = [
+        abi_jar_of(f.basename)
+        for f in env.ctx.files.want_classpath
+        if not f.basename.endswith("jdeps")
+    ] + env.ctx.attr.want_classpath_basenames
     values_for_flag_of(action, "--classpath").transform(desc = "basenames", map_each = basename_of).contains_at_least(want_classpath_basenames)
 
-    not_want_basenames = [f.basename for f in env.ctx.files.not_want_classpath]
+    not_want_basenames = [f.basename for f in env.ctx.files.not_want_classpath] + env.ctx.attr.not_want_classpath_basenames
     values_for_flag_of(action, "--classpath").transform(desc = "basenames", map_each = basename_of).contains_none_of(not_want_basenames)
 
 def _test_classpath_experimental_prune_transitive_deps_False(test):
@@ -35,15 +43,18 @@ def _test_classpath_experimental_prune_transitive_deps_False(test):
         target = main_target_library,
         config_settings = {
             str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps")): False,
+            str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories")): [],
             str(Label("@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies")): False,
         },
         attr_values = {
             "not_want_classpath": [],
+            "not_want_classpath_basenames": [],
             "on_action_mnemonic": "KotlinCompile",
             "want_classpath": [
                 dependency_a,
                 dependency_a_trans_dep_jar,
             ],
+            "want_classpath_basenames": [],
             "want_direct_dependencies": [
                 dependency_a,
                 dependency_a_trans_dep_jar,
@@ -55,8 +66,10 @@ def _test_classpath_experimental_prune_transitive_deps_False(test):
         },
         attrs = {
             "not_want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "not_want_classpath_basenames": attr.string_list(),
             "on_action_mnemonic": attr.string(),
             "want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_classpath_basenames": attr.string_list(),
             "want_direct_dependencies": attr.label_list(providers = [DefaultInfo], allow_files = True),
             "want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
         },
@@ -71,15 +84,58 @@ def _test_classpath_experimental_prune_transitive_deps_True(test):
         target = main_target_library,
         config_settings = {
             str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps")): True,
+            str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories")): [],
             str(Label("@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies")): False,
         },
         attr_values = {
             "not_want_classpath": [
                 dependency_a_trans_dep_jar,
             ],
+            "not_want_classpath_basenames": [],
             "on_action_mnemonic": "KotlinCompile",
             "want_classpath": [
                 dependency_a,
+            ],
+            "want_classpath_basenames": [],
+            "want_direct_dependencies": [
+                dependency_a,
+            ],
+            "want_inputs": [
+                dependency_a,
+            ],
+        },
+        attrs = {
+            "not_want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "not_want_classpath_basenames": attr.string_list(),
+            "on_action_mnemonic": attr.string(),
+            "want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_classpath_basenames": attr.string_list(),
+            "want_direct_dependencies": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
+        },
+    )
+
+def _test_classpath_experimental_prune_transitive_deps_keep_maven_repository(test):
+    (_, dependency_a, main_target_library) = arrange(test, transitive_dep = _MAVEN_TRANSITIVE_DEP)
+
+    analysis_test(
+        name = test.name,
+        impl = _classpath_assertions_,
+        target = main_target_library,
+        config_settings = {
+            str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps")): True,
+            str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories")): [_MAVEN_REPOSITORY_NAME],
+            str(Label("@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies")): False,
+        },
+        attr_values = {
+            "not_want_classpath": [],
+            "not_want_classpath_basenames": [],
+            "on_action_mnemonic": "KotlinCompile",
+            "want_classpath": [
+                dependency_a,
+            ],
+            "want_classpath_basenames": [
+                _MAVEN_COMPILE_JAR_BASENAME,
             ],
             "want_direct_dependencies": [
                 dependency_a,
@@ -90,8 +146,50 @@ def _test_classpath_experimental_prune_transitive_deps_True(test):
         },
         attrs = {
             "not_want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "not_want_classpath_basenames": attr.string_list(),
             "on_action_mnemonic": attr.string(),
             "want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_classpath_basenames": attr.string_list(),
+            "want_direct_dependencies": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
+        },
+    )
+
+def _test_classpath_experimental_prune_transitive_deps_prune_unmatched_maven_repository(test):
+    (_, dependency_a, main_target_library) = arrange(test, transitive_dep = _MAVEN_TRANSITIVE_DEP)
+
+    analysis_test(
+        name = test.name,
+        impl = _classpath_assertions_,
+        target = main_target_library,
+        config_settings = {
+            str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps")): True,
+            str(Label("@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories")): ["other_maven_repository"],
+            str(Label("@rules_kotlin//kotlin/settings:experimental_strict_associate_dependencies")): False,
+        },
+        attr_values = {
+            "not_want_classpath": [],
+            "not_want_classpath_basenames": [
+                _MAVEN_COMPILE_JAR_BASENAME,
+            ],
+            "on_action_mnemonic": "KotlinCompile",
+            "want_classpath": [
+                dependency_a,
+            ],
+            "want_classpath_basenames": [],
+            "want_direct_dependencies": [
+                dependency_a,
+            ],
+            "want_inputs": [
+                dependency_a,
+            ],
+        },
+        attrs = {
+            "not_want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "not_want_classpath_basenames": attr.string_list(),
+            "on_action_mnemonic": attr.string(),
+            "want_classpath": attr.label_list(providers = [DefaultInfo], allow_files = True),
+            "want_classpath_basenames": attr.string_list(),
             "want_direct_dependencies": attr.label_list(providers = [DefaultInfo], allow_files = True),
             "want_inputs": attr.label_list(providers = [DefaultInfo], allow_files = True),
         },
@@ -101,5 +199,7 @@ def experimental_prune_transitive_deps_tests(name):
     suite(
         name,
         enabled = _test_classpath_experimental_prune_transitive_deps_True,
+        enabled_keep_maven_repository = _test_classpath_experimental_prune_transitive_deps_keep_maven_repository,
+        enabled_prune_unmatched_maven_repository = _test_classpath_experimental_prune_transitive_deps_prune_unmatched_maven_repository,
         disabled = _test_classpath_experimental_prune_transitive_deps_False,
     )


### PR DESCRIPTION
Adds a globally configurable repository allow-list for `experimental_prune_transitive_deps`.

When transitive pruning is enabled, rules_kotlin normally compiles against direct dependencies only. This change allows those repositories to retain a subset of their transitive jars without disabling pruning for the entire Kotlin target. This is mostly useful if you want to retain subsets of the dependency graph like maven dependencies that are less likely to cause cache invalidation, while stripping out more if the higher-churn jars that live directly in your repository.

Example `.bazelrc` configuration:

```bazelrc
build --@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps=True
build --@rules_kotlin//kotlin/settings:experimental_prune_transitive_deps_keep_transitive_repositories=maven,rules_jvm_external++maven+maven
```

A real world example is when you enable classpath reduction, you are forced to declare every single dependency that you depend on both directly and transitively. If a single type is referenced at compile time or during annotation processing, that dependency needs to be included, even dependencies that 3rd party maven dependencies declare in their pom files. This change helps smooth that out by assuming that things within a certain namespace, like maven dependencies, should just be included and not stripped out saving developers from having to verbosely list out everything down to the entire transitive classpath at the maven level.