### PR TITLE
Declare associate jars as direct dependencies

### DIFF
--- a/examples/associates/BUILD
+++ b/examples/associates/BUILD
@@ -1,0 +1,12 @@
+load("@rules_kotlin//kotlin:core.bzl", "define_kt_toolchain")
+
+# Associates have to keep working with abi jars that had their private (and internal) classes
+# stripped, together with strict deps. An associate cannot be listed in deps, so anything it
+# contributes to the classpath has to be declared as a direct dependency by the rules themselves.
+define_kt_toolchain(
+    name = "kotlin_toolchain",
+    experimental_remove_private_classes_in_abi_jars = True,
+    experimental_report_unused_deps = "error",
+    experimental_strict_kotlin_deps = "error",
+    experimental_use_abi_jars = True,
+)

--- a/examples/associates/MODULE.bazel
+++ b/examples/associates/MODULE.bazel
@@ -8,6 +8,8 @@ local_path_override(
     path = "../..",
 )
 
+register_toolchains("//:kotlin_toolchain")
+
 bazel_dep(name = "rules_jvm_external", version = "6.10")
 
 maven = use_extension("@rules_jvm_external//:extensions.bzl", "maven")

--- a/kotlin/internal/jvm/compile.bzl
+++ b/kotlin/internal/jvm/compile.bzl
@@ -357,7 +357,7 @@ def _build_resourcejar_action(ctx, extra_resources = {}):
     )
     return resources_jar_output
 
-def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps):
+def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps, associate_jars = depset()):
     """Creates a Jdeps merger action invocation."""
     args = ctx.actions.args()
     args.set_param_file_format("multiline")
@@ -379,8 +379,14 @@ def _run_merge_jdeps_action(ctx, toolchains, jdeps, outputs, deps):
 
     inputs = depset(jdeps)
     if not toolchains.kt.experimental_report_unused_deps == "off":
-        # For sandboxing to work, and for this action to be deterministic, the compile jars need to be passed as inputs
-        inputs = depset(jdeps, transitive = [depset([], transitive = [dep.transitive_compile_time_jars for dep in deps])])
+        # For sandboxing to work, and for this action to be deterministic, the compile jars need to be passed as inputs.
+        # The associate jars are included as well because the merger reads the owning label out of the manifest of every
+        # jar mentioned in the jdeps, and the jar the associate contributed to the classpath is not necessarily its
+        # compile jar, see associates.bzl.
+        inputs = depset(
+            jdeps,
+            transitive = [dep.transitive_compile_time_jars for dep in deps] + [associate_jars],
+        )
 
     ctx.actions.run(
         mnemonic = mnemonic,
@@ -609,7 +615,18 @@ def _run_kt_builder_action(
     # Unwrap kotlinc_options/javac_options options or default to the ones being provided by the toolchain
     args.add_all("--kotlin_passthrough_flags", kotlinc_options_to_flags(kotlinc_options))
     args.add_all("--javacopts", javac_options_to_flags(javac_options))
-    args.add_all("--direct_dependencies", _java_infos_to_compile_jars(compile_deps.deps))
+
+    # Associates contribute their own jars to the classpath, and which flavor (compile jar or class
+    # jar) depends on the toolchain, see associates.bzl. Declare exactly the jars that ended up on
+    # the classpath, otherwise strict deps reports the associate as an undeclared direct dependency
+    # and it cannot be fixed by the user: an associate is not allowed to also be in deps.
+    args.add_all(
+        "--direct_dependencies",
+        depset(transitive = [
+            _java_infos_to_compile_jars(compile_deps.deps),
+            compile_deps.associate_jars,
+        ]),
+    )
     args.add("--strict_kotlin_deps", toolchains.kt.experimental_strict_kotlin_deps)
     args.add_all("--classpath", compile_deps.compile_jars)
     args.add("--reduced_classpath_mode", toolchains.kt.experimental_reduce_classpath_mode)
@@ -1092,6 +1109,7 @@ def _run_kt_java_builder_actions(
                 toolchains = toolchains,
                 jdeps = jdeps,
                 deps = compile_deps.deps,
+                associate_jars = compile_deps.associate_jars,
                 outputs = {"output": output_jdeps},
             )
         else:

--- a/src/test/starlark/rules/BUILD.bazel
+++ b/src/test/starlark/rules/BUILD.bazel
@@ -1,5 +1,20 @@
+load("//kotlin:core.bzl", "define_kt_toolchain")
+load(":associates_tests.bzl", "associates_tests")
 load(":experimental_prune_transitive_deps_tests.bzl", "experimental_prune_transitive_deps_tests")
 
 experimental_prune_transitive_deps_tests(
     name = "experimental_prune_transitive_deps_tests",
+)
+
+associates_tests(
+    name = "associates_tests",
+)
+
+# Only used by associates_tests, which pulls it in with --extra_toolchains.
+define_kt_toolchain(
+    name = "remove_private_classes_toolchain",
+    experimental_remove_private_classes_in_abi_jars = True,
+    experimental_report_unused_deps = "error",
+    experimental_strict_kotlin_deps = "error",
+    experimental_use_abi_jars = True,
 )

--- a/src/test/starlark/rules/associates_tests.bzl
+++ b/src/test/starlark/rules/associates_tests.bzl
@@ -76,11 +76,15 @@ def _associate_class_jar_is_direct_dependency_(env, target):
         map_each = basename_of,
     ).contains_none_of(["%s_associate.abi.jar" % env.ctx.attr.namespace])
 
-    # The merger reads the owning label from the manifest of every jar the jdeps mention, so the
-    # class jar of the associate has to be available to the action.
+    # The merger reads the owning label from the manifest of every jar the jdeps mention, whatever
+    # the kind of the entry is. Both flavors of the associate jar have to be available to the
+    # action: the class jar because it is the one on the classpath, and so the one the used entries
+    # point at, and the compile jar because it stays in --direct_dependencies and therefore shows up
+    # as an unused entry.
     jdeps_merge = env.expect.that_target(target).action_named("JdepsMerge")
     jdeps_merge.inputs().contains_at_least_predicates([
         matching.file_basename_equals("%s_associate.jar" % env.ctx.attr.namespace),
+        matching.file_basename_equals("%s_associate.abi.jar" % env.ctx.attr.namespace),
     ])
 
 def _test_associate_class_jar_is_direct_dependency_with_remove_private_classes(test):

--- a/src/test/starlark/rules/associates_tests.bzl
+++ b/src/test/starlark/rules/associates_tests.bzl
@@ -1,0 +1,107 @@
+"""Tests for the way associates are declared to the kotlin builder."""
+
+load("@rules_testing//lib:analysis_test.bzl", "analysis_test")
+load("@rules_testing//lib:truth.bzl", "matching")
+load("//kotlin:jvm.bzl", "kt_jvm_library")
+load("//src/test/starlark:case.bzl", "suite")
+load(":util.bzl", "basename_of", "values_for_flag_of")
+
+# A toolchain with experimental_remove_private_classes_in_abi_jars enabled, which makes associates
+# contribute their class jar - rather than their compile jar - to the classpath.
+_REMOVE_PRIVATE_CLASSES_TOOLCHAIN = Label("//src/test/starlark/rules:remove_private_classes_toolchain")
+
+def _arrange(test):
+    associate = test.have(
+        kt_jvm_library,
+        name = "associate",
+        srcs = [
+            test.artifact(name = "associate.kt"),
+        ],
+    )
+
+    main_target_library = test.got(
+        kt_jvm_library,
+        name = "main_target_library",
+        srcs = [
+            test.artifact(name = "main_target_library.kt"),
+        ],
+        associates = [
+            associate,
+        ],
+    )
+
+    return main_target_library
+
+def _associate_jars_are_direct_dependencies_(env, target):
+    """Every jar an associate puts on the classpath has to be a declared direct dependency.
+
+    Associates cannot be listed in deps as well, so anything the associate contributes that is not
+    declared here is reported by strict deps as a violation the user has no way of fixing.
+    """
+    action = env.expect.that_target(target).action_named("KotlinCompile")
+
+    friend_paths = values_for_flag_of(action, "--kotlin_friend_paths").actual
+    env.expect.that_collection(friend_paths).has_size(1)
+
+    values_for_flag_of(action, "--direct_dependencies").contains_at_least(friend_paths)
+    values_for_flag_of(action, "--classpath").contains_at_least(friend_paths)
+
+def _test_associate_jars_are_direct_dependencies(test):
+    analysis_test(
+        name = test.name,
+        impl = _associate_jars_are_direct_dependencies_,
+        target = _arrange(test),
+    )
+
+def _associate_class_jar_is_direct_dependency_(env, target):
+    """With private class removal on, the class jar of the associate is the one that has to be declared.
+
+    Its compile jar no longer carries the internal symbols an associate is allowed to see, so
+    associates.bzl swaps in the class jar. Declaring the compile jar instead leaves the class jar
+    undeclared on the classpath.
+    """
+    _associate_jars_are_direct_dependencies_(env, target)
+
+    action = env.expect.that_target(target).action_named("KotlinCompile")
+    direct_dependencies = values_for_flag_of(action, "--direct_dependencies").transform(
+        desc = "basenames",
+        map_each = basename_of,
+    )
+    direct_dependencies.contains("%s_associate.jar" % env.ctx.attr.namespace)
+
+    # The compile jar of the associate is the one that is missing the internal symbols, it is
+    # replaced on the classpath by the class jar asserted above.
+    values_for_flag_of(action, "--classpath").transform(
+        desc = "basenames",
+        map_each = basename_of,
+    ).contains_none_of(["%s_associate.abi.jar" % env.ctx.attr.namespace])
+
+    # The merger reads the owning label from the manifest of every jar the jdeps mention, so the
+    # class jar of the associate has to be available to the action.
+    jdeps_merge = env.expect.that_target(target).action_named("JdepsMerge")
+    jdeps_merge.inputs().contains_at_least_predicates([
+        matching.file_basename_equals("%s_associate.jar" % env.ctx.attr.namespace),
+    ])
+
+def _test_associate_class_jar_is_direct_dependency_with_remove_private_classes(test):
+    analysis_test(
+        name = test.name,
+        impl = _associate_class_jar_is_direct_dependency_,
+        target = _arrange(test),
+        config_settings = {
+            "//command_line_option:extra_toolchains": [str(_REMOVE_PRIVATE_CLASSES_TOOLCHAIN)],
+        },
+        attr_values = {
+            "namespace": test.name,
+        },
+        attrs = {
+            "namespace": attr.string(),
+        },
+    )
+
+def associates_tests(name):
+    suite(
+        name,
+        direct_dependencies = _test_associate_jars_are_direct_dependencies,
+        remove_private_classes = _test_associate_class_jar_is_direct_dependency_with_remove_private_classes,
+    )


### PR DESCRIPTION
## Problem

With `experimental_remove_private_classes_in_abi_jars = True` on the toolchain, any target that uses `associates` and has strict deps enabled fails to build:

```
error: [strict] Unexpected source or dependency
  ** Please add the following dependencies: //src/main/kotlin/foo:bar to //src/test/kotlin/foo:bar_test
```

Adding the dependency is not possible: `_fail_if_invalid_associate_deps` rejects a target that appears in both `associates` and `deps`.

## Root cause

`associates.bzl` intentionally swaps in the associate's **class** jar when private-class stripping is on, because the compile jar no longer carries the internal symbols an associate is allowed to see:

```starlark
jars_depset = depset(direct = [a.class_jar for a in associate[JavaInfo].java_outputs])
```

The classpath therefore contains the class jar, but `--direct_dependencies` was still derived from the associate's *compile* jar:

```starlark
args.add_all("--direct_dependencies", _java_infos_to_compile_jars(compile_deps.deps))
```

The Kotlin builder sees a classpath entry it was never told about and reports it as an undeclared direct dependency.

## Fix

Declare the associate jars alongside the compile jars. `compile_deps.associate_jars` already resolves to whichever jar flavor is actually on the classpath, so this is a no-op when private-class stripping is disabled.

The resulting `.jdeps` then reference the associate class jar, so `JdepsMerge` also needs it as an action input — otherwise it fails reading the jar owner manifest:

```
java.io.UncheckedIOException: java.nio.file.NoSuchFileException: bazel-out/k8-fastbuild/bin/.../client.jar
    at io.bazel.kotlin.builder.tasks.jvm.JdepsMerger$Companion.readJarOwnerFromManifest(JdepsMerger.kt:56)
```

`_run_merge_jdeps_action` gains an optional `associate_jars` parameter that is added to the action inputs when unused-deps reporting is on (the only case in which the merger opens those jars).

## Alternative considered

Tagging every affected target with `kt_remove_private_classes_in_abi_plugin_incompatible` works, but it opts those targets (and the libraries they associate with) out of ABI stripping entirely, which defeats the point of the flag for exactly the targets that use Kotlin modules.

## Tests

- `//src/test/starlark/rules:associates_tests` — analysis tests asserting that every jar an associate puts on the classpath is also declared in `--direct_dependencies`, both with the default toolchain and with one that enables `experimental_remove_private_classes_in_abi_jars` (pulled in through `--extra_toolchains`), plus that the associate class jar is an input of the `JdepsMerge` action. The second test fails on `master`.
- `examples/associates` now registers a toolchain with `experimental_remove_private_classes_in_abi_jars`, `experimental_use_abi_jars`, `experimental_strict_kotlin_deps = "error"` and `experimental_report_unused_deps = "error"`. Without this change the example fails to build with `Strict Deps Violations - please fix`; with it, it builds and its tests pass.

## Validation

Also applied against rules_kotlin 2.4.0 in a Kotlin monorepo with strict deps enabled repo-wide. Before the fix, enabling `experimental_remove_private_classes_in_abi_jars` broke every `associates` target (7 test suites / 8 libraries in the packages exercised); after the fix all of them build and their tests pass with no per-target opt-out tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)