### PR TITLE
jdeps: record type arguments of a called function's return type

### DIFF
--- a/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/checker/expression/QualifiedAccessChecker.kt
+++ b/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/checker/expression/QualifiedAccessChecker.kt
@@ -32,7 +32,7 @@ internal class QualifiedAccessChecker(
         it,
         context,
         isExplicit = false,
-        collectTypeArguments = false,
+        collectTypeArguments = true,
       )
     }
 

--- a/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
+++ b/src/test/kotlin/io/bazel/kotlin/builder/tasks/jvm/KotlinBuilderJvmJdepsTest.kt
@@ -929,6 +929,59 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
   }
 
   @Test
+  fun `type argument of a called function's return type`() {
+    val returnedTypeArgumentTarget = runJdepsCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource(
+        "ReturnedClass.kt",
+        """
+            package something
+
+            class ReturnedClass
+            """,
+      )
+    }
+
+    val serviceTarget = runJdepsCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.addSource(
+        "Service.kt",
+        """
+            package something
+
+            class Service {
+              fun returnsList(): List<ReturnedClass> = listOf()
+            }
+            """,
+      )
+      c.addDirectDependencies(returnedTypeArgumentTarget)
+    }
+
+    val dependingTarget = runJdepsCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
+      c.setLabel("//:dependingTarget")
+      c.addSource(
+        "CallsService.kt",
+        """
+            package something
+
+            fun callsService(service: Service) {
+              service.returnsList()
+            }
+          """,
+      )
+      c.addDirectDependencies(serviceTarget)
+      c.addTransitiveDependencies(returnedTypeArgumentTarget)
+    }
+    val jdeps = depsProto(dependingTarget)
+    val expected = Deps.Dependencies.newBuilder()
+      .setRuleLabel("//:dependingTarget")
+      .setSuccess(true)
+      .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
+      .addExplicitDep(serviceTarget.singleCompileJar())
+      .addImplicitDep(returnedTypeArgumentTarget.singleCompileJar())
+      .buildSorted()
+    assertThat(jdeps).isEqualTo(expected)
+  }
+
+  @Test
   fun `inline reified test`() {
     val objectMapperTarget = runJdepsCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
       c.addSource(
@@ -1797,7 +1850,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
   }
 
   @Test
-  fun `function call return type type parameter should not be a dependency`() {
+  fun `function call return type type parameter should be an implicit dependency`() {
     val depWithTypeParameter = runCompileTask { c: KotlinJvmTestBuilder.TaskBuilder ->
       c.addSource(
         "SomeType.kt",
@@ -1845,6 +1898,7 @@ class KotlinBuilderJvmJdepsTest(private val enableK2Compiler: Boolean) {
       .setSuccess(true)
       .addExplicitDep(depWithFunction.singleCompileJar())
       .addExplicitDep(KOTLIN_STDLIB_DEP.singleCompileJar())
+      .addImplicitDep(depWithTypeParameter.singleCompileJar())
       .buildSorted()
     assertThat(jdeps).isEqualTo(expected)
   }


### PR DESCRIPTION
## Summary

jdeps reports a dep as `UNUSED` even though kotlinc requires it: type arguments of a called function's return type are never recorded.

`QualifiedAccessChecker` records the resolved return type of a call, but explicitly disables collection of its type arguments:

https://github.com/bazelbuild/rules_kotlin/blob/b211d1027e4892e138406cd1e0a0009ded90ac37/src/main/kotlin/io/bazel/kotlin/plugin/jdeps/k2/checker/expression/QualifiedAccessChecker.kt#L29-L37

So for a call to `fun returnsList(): List<ReturnedClass>`, `kotlin.collections.List` is recorded and `ReturnedClass` is not. The value-parameter path a few lines below uses the default (`collectTypeArguments = true`), so parameter type arguments *are* recorded — only the return type opts out.

With `experimental_prune_transitive_deps` enabled this is not merely under-reporting: kotlinc **requires** the type argument's jar on the compile classpath, so the jar must be a direct dep, yet `report_unused_deps` tells you to remove it. Compiling without the dep fails; declaring it fails the unused-deps check. The only escape is an allowlist entry.

## Repro

```python
# BUILD.bazel  (experimental_prune_transitive_deps enabled)
kt_jvm_library(name = "kotlin_type", srcs = ["KotlinType.kt"])   # class KotlinType
java_library(name = "java_type", srcs = ["JavaType.java"])       # public class JavaType

kt_jvm_library(
    name = "service",                                            # class Service {
    srcs = ["Service.kt"],                                       #   fun returnsKotlinList(): List<KotlinType> = listOf()
    deps = [":kotlin_type", ":java_type"],                       #   fun returnsJavaList(): List<JavaType> = listOf()
)                                                                # }

kt_jvm_library(
    name = "caller_kotlin",                                      # fun callKotlin(service: Service) {
    srcs = ["CallerKotlin.kt"],                                  #   service.returnsKotlinList()   // result discarded
    deps = [":service"],                                         # }
)
```

The caller never names `KotlinType` — it only calls a method whose return type mentions it, and discards the result.

**1. Without the type-argument dep, compilation fails:**

```
CallerKotlin.kt:6:13: error: cannot access class 'scratch.jdeps.KotlinType'.
Check your module classpath for missing or conflicting dependencies.
```

(identical error for the Java case: `cannot access class 'scratch.jdeps.JavaType'`)

**2. Add `:kotlin_type` / `:java_type` to `deps` so it compiles, and `report_unused_deps` now demands you remove it:**

```
** Please remove the following dependencies: //:kotlin_type from //:caller_kotlin
** You can use the following buildozer command: buildozer 'remove deps //:kotlin_type' //:caller_kotlin
```

`.jdeps` contents:

```
UNUSED    kotlin_type.abi.jar
EXPLICIT  service.abi.jar
```

So the two checks contradict each other for the same dep.

## Fix

One line — record the return type's type arguments, same as value parameters:

```diff
-        collectTypeArguments = false,
+        collectTypeArguments = true,
```

`isExplicit = false` is kept, so these land as `IMPLICIT`, which is what `Kind.IMPLICIT` is for: needed at compile time, not directly named in source. It does **not** make strict-deps demand a new direct dep, so it can't turn a currently-green build red. After the change, the repro above produces:

```
IMPLICIT  kotlin_type.abi.jar
EXPLICIT  service.abi.jar
```

and both checks agree.

## Note on the existing test

`KotlinBuilderJvmJdepsTest.function call return type type parameter should not be a dependency` asserts the current behavior, and this change flips it (renamed to `... should be an implicit dependency`, with the type-parameter jar now expected as an implicit dep). I believe that assertion encodes an assumption that only holds on an unpruned classpath: in that test the type-argument class stays reachable as a transitive dep, so nothing forces it to be direct and omitting it from jdeps is harmless. With `experimental_prune_transitive_deps` the same shape is a build-breaking false positive, as above.

`collectTypeArguments = false` was introduced for the K1 implementation in #1118 (in a spot where `isExplicit` defaults to `true`, where suppressing type arguments makes sense to avoid over-reporting *explicit* deps) and was carried over verbatim to K2 in #1166; there's no comment or discussion covering the call-expression case, so it may have been inherited rather than intended.

## Testing

- New test: `type argument of a called function's return type` — asserts the type-argument jar is reported as `IMPLICIT` while the direct dep stays `EXPLICIT`.
- Updated the existing test as described above.
- The full `KotlinBuilderJvmJdepsTest` and `KotlinBuilderJvmStrictDepsTest` suites pass with both `enableK2Compiler=true` and `false`.

## Impact

We hit this in a Kotlin monorepo (~200k targets' worth of Kotlin, `experimental_prune_transitive_deps` on) where generated protobuf message types flow through service signatures. Every handler that calls a method returning `List<SomeProtoMessage>` and ignores the result needs an unused-deps allowlist entry. With this patch, several of our allowlist entries became unnecessary and a full `//src/main/... //src/test/...` build stays green with no new strict-deps findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
